### PR TITLE
[sycl-jit] Parallelize resource.cpp compile by sharding all #embed files

### DIFF
--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -2,6 +2,15 @@
 
 set(SYCL_JIT_RESOURCE_CPP "${CMAKE_CURRENT_BINARY_DIR}/resource.cpp")
 set(SYCL_JIT_RESOURCE_OBJ "${CMAKE_CURRENT_BINARY_DIR}/resource.cpp.o")
+set(SYCL_JIT_RESOURCE_SHARD_DIR "${CMAKE_CURRENT_BINARY_DIR}/resource-shards")
+set(SYCL_JIT_RESOURCE_NUM_SHARDS 16)
+# `generate.py` packs #embed'd files into fixed resource-shard-N.cpp units for
+# parallel compilation. This count allows path declaration at configure time.
+set(SYCL_JIT_RESOURCE_SHARD_CPPS)
+math(EXPR SYCL_JIT_RESOURCE_LAST_SHARD "${SYCL_JIT_RESOURCE_NUM_SHARDS} - 1")
+foreach(shard_index RANGE 0 ${SYCL_JIT_RESOURCE_LAST_SHARD})
+  list(APPEND SYCL_JIT_RESOURCE_SHARD_CPPS "${SYCL_JIT_RESOURCE_SHARD_DIR}/resource-shard-${shard_index}.cpp")
+endforeach()
 
 if (WIN32)
 set(SYCL_JIT_VIRTUAL_TOOLCHAIN_ROOT "c:/sycl-jit-toolchain/")
@@ -77,12 +86,14 @@ add_custom_target(rtc-prepare-resources
 
 add_custom_command(
   OUTPUT ${SYCL_JIT_RESOURCE_CPP}
-  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/generate.py --toolchain-dir ${SYCL_JIT_RESOURCE_INSTALL_DIR} --output ${SYCL_JIT_RESOURCE_CPP} --prefix ${SYCL_JIT_VIRTUAL_TOOLCHAIN_ROOT}
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/generate.py --toolchain-dir ${SYCL_JIT_RESOURCE_INSTALL_DIR} --output ${SYCL_JIT_RESOURCE_CPP} --prefix ${SYCL_JIT_VIRTUAL_TOOLCHAIN_ROOT} --shard-dir ${SYCL_JIT_RESOURCE_SHARD_DIR} --num-shards ${SYCL_JIT_RESOURCE_NUM_SHARDS}
   DEPENDS
   rtc-prepare-resources
   ${SYCL_JIT_RESOURCE_DEPS}
   ${SYCL_JIT_RESOURCE_FILES}
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/generate.py
+  BYPRODUCTS
+  ${SYCL_JIT_RESOURCE_SHARD_CPPS}
 )
 
 # We use C23/C++26's `#embed` to implement this resource creation, and "current"
@@ -110,6 +121,21 @@ else()
     list(APPEND SYCL_JIT_RESOURCE_CXX_FLAGS -isysroot ${SYCL_JIT_OSX_SYSROOT})
   endif()
 endif()
+
+# Compile each of the fixed set of resource-shard-N.cpp files (declared above).
+set(SYCL_JIT_RESOURCE_SHARD_OBJS)
+foreach(shard_cpp IN LISTS SYCL_JIT_RESOURCE_SHARD_CPPS)
+  set(shard_obj "${shard_cpp}.o")
+  add_custom_command(
+    OUTPUT ${shard_obj}
+    COMMAND
+    ${clang_exe} --target=${LLVM_HOST_TRIPLE} ${shard_cpp} -I ${CMAKE_CURRENT_SOURCE_DIR}/include -c -o ${shard_obj} ${SYCL_JIT_RESOURCE_CXX_FLAGS}
+    DEPENDS
+    ${shard_cpp}
+    ${SYCL_JIT_RESOURCE_CPP}
+  )
+  list(APPEND SYCL_JIT_RESOURCE_SHARD_OBJS ${shard_obj})
+endforeach()
 
 add_custom_command(
   OUTPUT ${SYCL_JIT_RESOURCE_OBJ}
@@ -140,6 +166,7 @@ add_llvm_library(sycl-jit
    lib/helper/ErrorHelper.cpp
 
    ${SYCL_JIT_RESOURCE_OBJ}
+   ${SYCL_JIT_RESOURCE_SHARD_OBJS}
 
    SHARED
 

--- a/sycl-jit/jit-compiler/utils/generate.py
+++ b/sycl-jit/jit-compiler/utils/generate.py
@@ -82,30 +82,24 @@ def main():
                 rel_path = os.path.relpath(file_path, toolchain_dir).replace(
                     os.sep, "/"
                 )
-                shard_out.write(
-                    f"""extern const char {symbol}[] = {{
+                shard_out.write(f"""extern const char {symbol}[] = {{
 #embed "{file_path}" if_empty(0)
     , 0}};
-"""
-                )
+""")
                 externs.append(f"extern const char {symbol}[{array_size}];")
-                entries.append(
-                    f"""
+                entries.append(f"""
 {{
     {{"{args.prefix}{rel_path}"}} ,
     []() {{ return resource_string_view{{{symbol}}}; }}()
-}},"""
-                )
+}},""")
 
     with open(args.output, "w") as out:
         out.write("\n#include <Resource.h>\n\n")
         for extern_decl in externs:
             out.write(extern_decl + "\n")
-        out.write(
-            """
+        out.write("""
 namespace jit_compiler::resource {
-const resource_file ToolchainFiles[] = {"""
-        )
+const resource_file ToolchainFiles[] = {""")
         for entry in entries:
             out.write(entry)
         out.write(

--- a/sycl-jit/jit-compiler/utils/generate.py
+++ b/sycl-jit/jit-compiler/utils/generate.py
@@ -19,45 +19,95 @@ def main():
     parser.add_argument(
         "--prefix", type=str, required=True, help="Prefix for file locations"
     )
+    parser.add_argument(
+        "--shard-dir",
+        type=str,
+        required=True,
+        help="Directory to write out-of-line shard files for embedded files",
+    )
+    parser.add_argument(
+        "--num-shards",
+        type=int,
+        default=16,
+        help="Number of out-of-line shard translation units to spread "
+        "embedded files across. This is a fixed count (rather than one "
+        "shard per file) so CMake can declare the shard compile commands "
+        "at configure time, before generate.py has run.",
+    )
     args = parser.parse_args()
 
     # abspath also strips trailing "/"
     toolchain_dir = os.path.abspath(args.toolchain_dir)
 
+    os.makedirs(args.shard_dir, exist_ok=True)
+
+    def collect_files(dir):
+        for root, _, files in os.walk(dir):
+            for file in files:
+                file_path = os.path.join(root, file)
+                # We only need .bc files from libdevice:
+                if re.search(r"[/\\]libsycl-.*\.(o|obj|spv)$", file_path):
+                    continue
+                yield file_path
+
+    all_files = [
+        (os.path.getsize(file_path), file_path)
+        for file_path in collect_files(toolchain_dir)
+    ]
+
+    # Greedily bin-pack every embedded file into a fixed number of shards
+    # (largest file first, always placed into the currently-lightest shard)
+    # so the per-shard compile time is roughly balanced. This keeps all
+    # #embed's out of resource.cpp itself, which otherwise would serialize
+    # at the tail of the build with nothing left to overlap it with.
+    all_files.sort(reverse=True)
+    shard_sizes = [0] * args.num_shards
+    shard_members = [[] for _ in range(args.num_shards)]
+    for size, file_path in all_files:
+        shard_index = shard_sizes.index(min(shard_sizes))
+        shard_members[shard_index].append(file_path)
+        shard_sizes[shard_index] += size
+
+    externs = []
+    entries = []
+    symbol_index = 0
+    for shard_index in range(args.num_shards):
+        shard_path = os.path.join(args.shard_dir, f"resource-shard-{shard_index}.cpp")
+        with open(shard_path, "w") as shard_out:
+            for file_path in shard_members[shard_index]:
+                symbol = f"ToolchainShardData{symbol_index}"
+                symbol_index += 1
+                size = os.path.getsize(file_path)
+                array_size = size + 1  # trailing 0 appended below
+                rel_path = os.path.relpath(file_path, toolchain_dir).replace(
+                    os.sep, "/"
+                )
+                shard_out.write(
+                    f"""extern const char {symbol}[] = {{
+#embed "{file_path}" if_empty(0)
+    , 0}};
+"""
+                )
+                externs.append(f"extern const char {symbol}[{array_size}];")
+                entries.append(
+                    f"""
+{{
+    {{"{args.prefix}{rel_path}"}} ,
+    []() {{ return resource_string_view{{{symbol}}}; }}()
+}},"""
+                )
+
     with open(args.output, "w") as out:
+        out.write("\n#include <Resource.h>\n\n")
+        for extern_decl in externs:
+            out.write(extern_decl + "\n")
         out.write(
             """
-#include <Resource.h>
-
 namespace jit_compiler::resource {
 const resource_file ToolchainFiles[] = {"""
         )
-
-        def process_file(file_path):
-            # We only need .bc files from libdevice:
-            if re.search(r"[/\\]libsycl-.*\.(o|obj|spv)$", file_path):
-                return
-            out.write(
-                f"""
-{{
-    {{"{args.prefix}{os.path.relpath(file_path, toolchain_dir).replace(os.sep, "/")}"}} ,
-    []() {{
-    static const char data[] = {{
-    #embed "{file_path}" if_empty(0)
-        , 0}};
-    return resource_string_view{{data}};
-    }}()
-}},"""
-            )
-
-        def process_dir(dir):
-            for root, _, files in os.walk(dir):
-                for file in files:
-                    file_path = os.path.join(root, file)
-                    process_file(file_path)
-
-        process_dir(args.toolchain_dir)
-
+        for entry in entries:
+            out.write(entry)
         out.write(
             f"""
 }};


### PR DESCRIPTION
In downstream, resource.cpp #embeds ~1.5GB of SYCL headers, libclc, and libdevice binaries into a single TU, which took ~2m13s to compile at O2.

generate.py now bin-packs all embedded files across a fixed number of resource-shard-N.cpp translation units, leaving resource.cpp itself with no #embeds at all.

CMPLRLLVM-77210