### PR TITLE
[SYCL][NFC] Drop unused NullPtr from SYCLOffloadWrapper wrapImage

### DIFF
--- a/llvm/lib/Frontend/Offloading/SYCLOffloadWrapper.cpp
+++ b/llvm/lib/Frontend/Offloading/SYCLOffloadWrapper.cpp
@@ -537,7 +537,6 @@ struct Wrapper {
 
   Constant *wrapImage(const SYCLImage &Image, Twine ImageID,
                       StringRef OffloadKindTag) {
-    auto *NullPtr = Constant::getNullValue(PointerType::getUnqual(C));
     // DeviceImageStructVersion change log:
     // -- version 2: updated to PI 1.2 binary image format
     // -- version 3: removed ManifestStart, ManifestEnd pointers


### PR DESCRIPTION
282e8cc93e49 removed the use of NullPtr from the function. Found the issue when diff downstream and upstream files.