### PR TITLE
[SYCL][E2E] Disable enqueue_functions_sub_group_size test

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/enqueue_functions_sub_group_size.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/enqueue_functions_sub_group_size.cpp
@@ -2,6 +2,9 @@
 // UNSUPPORTED: cuda, hip
 // UNSUPPORTED-INTENDED: Device incompatible error
 
+// UNSUPPORTED: native_cpu
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22772
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Disable enqueue_functions_sub_group_size test

issue tracker: https://github.com/intel/llvm/issues/22772 