### PR TITLE
[SYCL][Graph] Add e2e tests for new UR error codes

### DIFF
--- a/sycl/test-e2e/Graph/Inputs/exception_recording_event_wait.cpp
+++ b/sycl/test-e2e/Graph/Inputs/exception_recording_event_wait.cpp
@@ -21,10 +21,6 @@ int main() {
 
   auto GraphEvent = Queue.single_task([]() {});
 
-  // TODO: The SYCL graph spec mandates errc::invalid but L0 graph's generic
-  // error codes make it difficult to determine the root cause. Once L0 graph
-  // expands their error codes we can add our handling and return the correct
-  // SYCL code along with a descriptive message to the user.
 #ifdef GRAPH_E2E_NATIVE_RECORDING
   if (!expectException([&]() { GraphEvent.wait(); },
                        "event wait during graph recording", errc::runtime)) {

--- a/sycl/test-e2e/Graph/Inputs/exception_recording_queue_wait.cpp
+++ b/sycl/test-e2e/Graph/Inputs/exception_recording_queue_wait.cpp
@@ -17,10 +17,6 @@ int main() {
 #endif
   Graph.begin_recording(Queue);
 
-  // TODO: The SYCL graph spec mandates errc::invalid but L0 graph's generic
-  // error codes make it difficult to determine the root cause. Once L0 graph
-  // expands their error codes we can add our handling and return the correct
-  // SYCL code along with a descriptive message to the user.
 #ifdef GRAPH_E2E_NATIVE_RECORDING
   if (!expectException([&]() { Queue.wait(); },
                        "queue wait during graph recording", errc::runtime)) {

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_external_event.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_external_event.cpp
@@ -1,0 +1,65 @@
+// REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// Tests that mixing events across a graph recording boundary throws
+// errc::runtime. Exercises the UR this external event path in
+// two directions:
+//   1. An event produced before begin_recording that is waited on while a
+//      graph is being recorded (external event pulled into the graph).
+//   2. An event recorded into the graph that is waited on outside of the graph
+//      (internal graph event escaping the recording).
+
+#include "../../graph_common.hpp"
+
+#include <sycl/ext/oneapi/experimental/reusable_events.hpp>
+#include <sycl/properties/all_properties.hpp>
+
+int main() {
+  queue Queue{property::queue::in_order{}};
+
+  exp_ext::command_graph Graph{
+      Queue.get_context(),
+      Queue.get_device(),
+      {exp_ext::property::graph::enable_native_recording{}}};
+
+  // Event produced before recording began, i.e. external to the graph.
+  auto ExternalEvent = Queue.single_task([]() {});
+  auto ReusableEvent = exp_ext::make_event(Queue.get_context());
+  exp_ext::enqueue_signal_event(Queue, ReusableEvent);
+
+  Graph.begin_recording(Queue);
+
+  // Waiting on an external event during recording fails in the runtime.
+  bool Success = expectException(
+      [&] { Queue.single_task(ExternalEvent, []() {}); },
+      "external event dependency of kernel recorded into graph", errc::runtime);
+  Success &= expectException(
+      [&] { exp_ext::enqueue_wait_event(Queue, ReusableEvent); },
+      "external reusable event wait during graph recording", errc::runtime);
+
+  // Event recorded into the graph, i.e. internal to the graph.
+  auto InternalEvent1 = Queue.single_task([]() {});
+  auto InternalEvent2 = Queue.ext_oneapi_submit_barrier();
+  exp_ext::enqueue_signal_event(Queue, ReusableEvent);
+
+  Graph.end_recording();
+
+  // Waiting on an internal graph event outside of the graph fails in the
+  // runtime.
+  Success &= expectException(
+      [&] { InternalEvent1.wait(); },
+      "internal graph event wait outside graph recording", errc::runtime);
+  Success &= expectException(
+      [&] { Queue.ext_oneapi_submit_barrier({InternalEvent2}); },
+      "internal graph event dependency of barrier outside graph recording",
+      errc::runtime);
+  Success &= expectException(
+      [&] { exp_ext::enqueue_wait_event(Queue, ReusableEvent); },
+      "internal reusable event wait outside graph recording", errc::runtime);
+
+  return Success ? 0 : 1;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_external_event.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_external_event.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
 // REQUIRES: linux
-// REQUIRES-INTEL-DRIVERx: lin: 39938
+// REQUIRES-INTEL-DRIVER: lin: 39938
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
@@ -8,7 +8,7 @@
 // RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Tests that mixing events across a graph recording boundary throws
-// errc::runtime. Exercises the UR this external event path in
+// errc::runtime. Exercises the UR external event path in
 // two directions:
 //   1. An event produced before begin_recording that is waited on while a
 //      graph is being recorded (external event pulled into the graph).

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_external_event.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_external_event.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+// REQUIRES: linux
+// REQUIRES-INTEL-DRIVERx: lin: 39938
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_merge.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_merge.cpp
@@ -1,0 +1,62 @@
+// REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// Tests that an illegal attempt to merge two graph recordings throws
+// errc::runtime. A merge attempt arises when work already being captured
+// by one graph is pulled into the capture of a second graph via a cross-graph
+// dependency.
+
+#include "../../graph_common.hpp"
+
+#include <sycl/properties/all_properties.hpp>
+
+int main() {
+  queue QueueA{property::queue::in_order{}};
+  queue QueueB{QueueA.get_context(), QueueA.get_device(),
+               property::queue::in_order{}};
+
+  exp_ext::command_graph GraphA{
+      QueueA.get_context(),
+      QueueA.get_device(),
+      {exp_ext::property::graph::enable_native_recording{}}};
+  exp_ext::command_graph GraphB{
+      QueueB.get_context(),
+      QueueB.get_device(),
+      {exp_ext::property::graph::enable_native_recording{}}};
+
+  constexpr size_t N = 1024;
+  int *Data = malloc_device<int>(N, QueueA);
+
+  GraphA.begin_recording(QueueA);
+  GraphB.begin_recording(QueueB);
+
+  auto EventA = QueueA.parallel_for(sycl::range<1>{N},
+                                    [=](sycl::id<1> Idx) { Data[Idx] = Idx; });
+
+  // Recording work on QueueB that depends on QueueA's in-progress capture
+  // would merge the two separate recordings, which is illegal.
+  if (!expectException(
+          [&]() {
+            QueueB.submit([&](handler &CGH) {
+              CGH.depends_on(EventA);
+              CGH.parallel_for(sycl::range<1>{N},
+                               [=](sycl::id<1> Idx) { Data[Idx] += 1; });
+            });
+          },
+          "merging two graph recordings", errc::runtime)) {
+    GraphA.end_recording(QueueA);
+    GraphB.end_recording(QueueB);
+    free(Data, QueueA);
+    return 1;
+  }
+
+  GraphA.end_recording(QueueA);
+  GraphB.end_recording(QueueB);
+  free(Data, QueueA);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_merge.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_merge.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+// REQUIRES: linux
+// REQUIRES-INTEL-DRIVER: lin: 39428
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_unjoined_fork.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_unjoined_fork.cpp
@@ -1,0 +1,50 @@
+// REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{%{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// Tests that ending a recording with forked branches that were not rejoined
+// throws errc::runtime. A fork is created when work branches off the recorded
+// stream without being joined back before end_recording.
+
+#include "../../graph_common.hpp"
+
+#include <sycl/properties/all_properties.hpp>
+
+int main() {
+  queue Queue1{property::queue::in_order{}};
+  queue Queue2{Queue1.get_context(), Queue1.get_device(),
+               property::queue::in_order{}};
+
+  exp_ext::command_graph Graph{
+      Queue1.get_context(),
+      Queue1.get_device(),
+      {exp_ext::property::graph::enable_native_recording{}}};
+
+  constexpr size_t N = 1024;
+  int *Data = malloc_device<int>(N, Queue1);
+
+  Graph.begin_recording(Queue1);
+
+  // Create a branch off the recorded stream that is never joined back before
+  // ending the recording.
+  auto ForkEvent = Queue1.parallel_for(
+      sycl::range<1>{N}, [=](sycl::id<1> Idx) { Data[Idx] = Idx; });
+  Queue2.submit([&](handler &CGH) {
+    CGH.depends_on(ForkEvent);
+    CGH.parallel_for(sycl::range<1>{N},
+                     [=](sycl::id<1> Idx) { Data[Idx] += 1; });
+  });
+
+  if (!expectException([&]() { Graph.end_recording(); },
+                       "end_recording with unjoined forks", errc::runtime)) {
+    free(Data, Queue1);
+    return 1;
+  }
+
+  free(Data, Queue1);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_unjoined_fork.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_unjoined_fork.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
+// REQUIRES: linux
+// REQUIRES-INTEL-DRIVER: lin: 39428
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
Adds e2e tests assessing new error scenarios in the native graph backend. These cases were previously forbidden by native graphs but did not always return errors from L0.