### PR TITLE
[DO NOT MERGE] Test issues with Reapply "[llvm][clang] Enable IO sandbox for assert builds" (#184545)

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -754,7 +754,7 @@ else()
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()
 
-option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" OFF)
+option(LLVM_ENABLE_IO_SANDBOX "Enable IO sandboxing in supported tools" ${LLVM_ENABLE_ASSERTIONS})
 option(LLVM_ENABLE_EXPENSIVE_CHECKS "Enable expensive checks" OFF)
 
 set(LLVM_ABI_BREAKING_CHECKS "WITH_ASSERTS" CACHE STRING


### PR DESCRIPTION
This PR is used to check test failures with re-enabling IO sandbox.

Enabling IO sandbox would result in test failures in all code that still use old file system access API, and I suspect we have _a lot_ of code still using the old API: https://discourse.llvm.org/t/rfc-file-system-sandboxing-in-clang-llvm/88791