### PR TITLE
[SYCL] Make enable_profiling and enable_ipc properties match the spec

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_reusable_events.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_reusable_events.asciidoc
@@ -182,7 +182,7 @@ This extension adds the following property, which can be used with `make_event`:
 namespace sycl::ext::oneapi::experimental {
 
 struct enable_profiling {
-  enable_profiling(bool enable);  (1)
+  enable_profiling(bool enable = true);  (1)
 };
 using enable_profiling_key = enable_profiling;
 

--- a/sycl/include/sycl/ext/oneapi/experimental/detail/ipc_common.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/detail/ipc_common.hpp
@@ -17,12 +17,20 @@ inline namespace _V1 {
 namespace ext::oneapi::experimental {
 
 // Shared by the inter-process-communication extensions.
-struct enable_ipc_key
-    : detail::compile_time_property_key<detail::PropKind::EnableIPC> {
-  using value_t = property_value<enable_ipc_key>;
+struct enable_ipc
+    : detail::run_time_property_key<enable_ipc, detail::PropKind::EnableIPC> {
+  constexpr enable_ipc(bool enable = true) : value(enable) {}
+  bool value;
 };
 
-inline constexpr enable_ipc_key::value_t enable_ipc;
+using enable_ipc_key = enable_ipc;
+
+inline bool operator==(const enable_ipc &lhs, const enable_ipc &rhs) {
+  return lhs.value == rhs.value;
+}
+inline bool operator!=(const enable_ipc &lhs, const enable_ipc &rhs) {
+  return !(lhs == rhs);
+}
 
 } // namespace ext::oneapi::experimental
 } // namespace _V1

--- a/sycl/include/sycl/ext/oneapi/experimental/reusable_events.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/reusable_events.hpp
@@ -22,12 +22,27 @@ namespace sycl {
 inline namespace _V1 {
 namespace ext::oneapi::experimental {
 
-struct enable_profiling_key
-    : detail::compile_time_property_key<detail::PropKind::EnableProfiling> {
-  using value_t = property_value<enable_profiling_key>;
+struct enable_profiling
+    : detail::run_time_property_key<enable_profiling,
+                                    detail::PropKind::EnableProfiling> {
+  constexpr enable_profiling(bool enable = true) : value(enable) {}
+  bool value;
 };
 
-inline constexpr enable_profiling_key::value_t enable_profiling;
+using enable_profiling_key = enable_profiling;
+
+inline bool operator==(const enable_profiling &lhs,
+                       const enable_profiling &rhs) {
+  return lhs.value == rhs.value;
+}
+inline bool operator!=(const enable_profiling &lhs,
+                       const enable_profiling &rhs) {
+  return !(lhs == rhs);
+}
+
+template <>
+struct is_property_key_of<enable_profiling_key, sycl::event> : std::true_type {
+};
 
 template <>
 struct is_property_key_of<enable_ipc_key, sycl::event> : std::true_type {};
@@ -40,12 +55,17 @@ enum make_event_flags : uint32_t {
 
 __SYCL_EXPORT sycl::event make_event(const sycl::context &ctxt, uint32_t Flags);
 
-template <typename PropertyListT> uint32_t getMakeEventFlags() {
+template <typename PropertyListT>
+uint32_t getMakeEventFlags(const PropertyListT &props) {
   uint32_t Flags = 0;
-  if constexpr (PropertyListT::template has_property<enable_profiling_key>())
-    Flags |= make_event_flag_enable_profiling;
-  if constexpr (PropertyListT::template has_property<enable_ipc_key>())
-    Flags |= make_event_flag_enable_ipc;
+  if constexpr (PropertyListT::template has_property<enable_profiling_key>()) {
+    if (props.template get_property<enable_profiling_key>().value)
+      Flags |= make_event_flag_enable_profiling;
+  }
+  if constexpr (PropertyListT::template has_property<enable_ipc_key>()) {
+    if (props.template get_property<enable_ipc_key>().value)
+      Flags |= make_event_flag_enable_ipc;
+  }
   return Flags;
 }
 } // namespace detail
@@ -55,9 +75,8 @@ inline sycl::event make_event(const sycl::context &ctxt,
                               PropertyListT props = {}) {
   static_assert(is_property_list_v<PropertyListT>,
                 "Props must be a sycl::ext::oneapi::experimental::properties");
-  (void)props;
 
-  return detail::make_event(ctxt, detail::getMakeEventFlags<PropertyListT>());
+  return detail::make_event(ctxt, detail::getMakeEventFlags(props));
 }
 
 template <typename PropertyListT = empty_properties_t>

--- a/sycl/include/sycl/ext/oneapi/virtual_mem/physical_mem.hpp
+++ b/sycl/include/sycl/ext/oneapi/virtual_mem/physical_mem.hpp
@@ -37,7 +37,10 @@ public:
                size_t NumBytes,
                const PropertyListT &PropList = empty_properties_t{}) {
 
-    bool EnableIPC = PropList.template has_property<enable_ipc_key>();
+    bool EnableIPC = false;
+    if constexpr (PropertyListT::template has_property<enable_ipc_key>()) {
+      EnableIPC = PropList.template get_property<enable_ipc_key>().value;
+    }
 
     create(SyclDevice, SyclContext, NumBytes, EnableIPC);
   }

--- a/sycl/test-e2e/Experimental/ipc_event_basic.cpp
+++ b/sycl/test-e2e/Experimental/ipc_event_basic.cpp
@@ -23,7 +23,8 @@ int main() {
     return 1;
 
   // 2. make_event(enable_ipc) produces an IPC-capable event.
-  sycl::event IpcEvt = exp::make_event(Ctx, exp::properties{exp::enable_ipc});
+  sycl::event IpcEvt =
+      exp::make_event(Ctx, exp::properties{exp::enable_ipc{true}});
   if (!IpcEvt.ext_oneapi_ipc_enabled())
     return 2;
 

--- a/sycl/test-e2e/Experimental/ipc_event_consumer_signal.cpp
+++ b/sycl/test-e2e/Experimental/ipc_event_consumer_signal.cpp
@@ -70,7 +70,8 @@ static int producer(const std::string &Exe) {
       {"sigdata_handles_ready", "sigdata_signal_done",
        "sigdata_producer_synced", "sigdata_consumer_done"});
 
-  sycl::event Evt = exp::make_event(Ctx, exp::properties{exp::enable_ipc});
+  sycl::event Evt =
+      exp::make_event(Ctx, exp::properties{exp::enable_ipc{true}});
   ipc::handle EvtHandle = ipc::event::get(Evt);
 
   // Allocate and poison the shared buffer before exporting it.

--- a/sycl/test-e2e/Experimental/ipc_event_lifetime.cpp
+++ b/sycl/test-e2e/Experimental/ipc_event_lifetime.cpp
@@ -22,7 +22,7 @@ int main() {
 
   {
     sycl::event ProducerEvt =
-        exp::make_event(Ctx, exp::properties{exp::enable_ipc});
+        exp::make_event(Ctx, exp::properties{exp::enable_ipc{true}});
     exp::enqueue_signal_event(Q, ProducerEvt);
     ProducerEvt.wait();
 

--- a/sycl/test-e2e/Experimental/ipc_event_multi_process.cpp
+++ b/sycl/test-e2e/Experimental/ipc_event_multi_process.cpp
@@ -50,7 +50,7 @@ int spawner(int argc, char *argv[]) {
 #endif
 
   sycl::event ProducerEvt =
-      exp::make_event(Ctx, exp::properties{exp::enable_ipc});
+      exp::make_event(Ctx, exp::properties{exp::enable_ipc{true}});
   exp::enqueue_signal_event(Q, ProducerEvt);
   ProducerEvt.wait();
 

--- a/sycl/test-e2e/Experimental/ipc_event_negative.cpp
+++ b/sycl/test-e2e/Experimental/ipc_event_negative.cpp
@@ -42,7 +42,7 @@ int main() {
   // 2. get on an imported event -> errc::invalid (cannot be re-exported).
   {
     sycl::event Producer =
-        exp::make_event(Ctx, exp::properties{exp::enable_ipc});
+        exp::make_event(Ctx, exp::properties{exp::enable_ipc{true}});
     exp::enqueue_signal_event(Q, Producer);
     Producer.wait();
     ipc::handle H = ipc::event::get(Producer);

--- a/sycl/test-e2e/Experimental/ipc_event_repeated_signal.cpp
+++ b/sycl/test-e2e/Experimental/ipc_event_repeated_signal.cpp
@@ -79,7 +79,8 @@ static int producer(const std::string &Exe) {
        "repeat_signal2_ready", "repeat_consumed2", "repeat_consumer_failed",
        "repeat_producer_done", "repeat_consumer_done"});
 
-  sycl::event Evt = exp::make_event(Ctx, exp::properties{exp::enable_ipc});
+  sycl::event Evt =
+      exp::make_event(Ctx, exp::properties{exp::enable_ipc{true}});
   ipc::handle EvtHandle = ipc::event::get(Evt);
 
   int *Buf = sycl::malloc_device<int>(NumElems, Q);

--- a/sycl/test-e2e/Experimental/ipc_event_round_trip.cpp
+++ b/sycl/test-e2e/Experimental/ipc_event_round_trip.cpp
@@ -31,7 +31,7 @@ int main() {
 
   // 1. Create + signal the producer event via the reusable-events API.
   sycl::event ProducerEvt =
-      exp::make_event(Ctx, exp::properties{exp::enable_ipc});
+      exp::make_event(Ctx, exp::properties{exp::enable_ipc{true}});
   exp::enqueue_signal_event(Q, ProducerEvt);
   ProducerEvt.wait();
 

--- a/sycl/test-e2e/Experimental/ipc_physical_memory.cpp
+++ b/sycl/test-e2e/Experimental/ipc_physical_memory.cpp
@@ -63,7 +63,7 @@ int spawner(int argc, char *argv[]) {
       syclexp::reserve_virtual_mem(0, AlignedByteSize, Context);
 
   // Create physical memory with IPC enabled
-  syclexp::properties PropList{syclexp::enable_ipc};
+  syclexp::properties PropList{syclexp::enable_ipc{true}};
   syclexp::physical_mem PhysMem{Device, Context, AlignedByteSize, PropList};
 
   // Map physical memory to virtual address

--- a/sycl/test-e2e/Experimental/ipc_physical_memory_multi_range.cpp
+++ b/sycl/test-e2e/Experimental/ipc_physical_memory_multi_range.cpp
@@ -88,7 +88,7 @@ int spawner(int argc, char *argv[]) {
   try {
     for (size_t R = 0; R < NumRanges; ++R)
       PhysMemVec.emplace_back(Dev, Ctx, AlignedByteSize,
-                              syclexp::properties{syclexp::enable_ipc});
+                              syclexp::properties{syclexp::enable_ipc{true}});
   } catch (const sycl::exception &E) {
     if (std::string_view{E.what()}.find("UNSUPPORTED_FEATURE") !=
         std::string_view::npos) {

--- a/sycl/test-e2e/Experimental/reusable_events/kernel_timing.cpp
+++ b/sycl/test-e2e/Experimental/reusable_events/kernel_timing.cpp
@@ -25,7 +25,7 @@ int main() {
   std::vector<int> data(N, 1);
   sycl::buffer<int> buf(data.data(), sycl::range<1>(N));
 
-  syclex::properties PropList{syclex::enable_profiling};
+  syclex::properties PropList{syclex::enable_profiling{true}};
   auto start_event = syclex::make_event(ctx, PropList);
   auto end_event = syclex::make_event(ctx, PropList);
 

--- a/sycl/unittests/Extensions/InterProcessCommunication/Event.cpp
+++ b/sycl/unittests/Extensions/InterProcessCommunication/Event.cpp
@@ -158,8 +158,8 @@ protected:
 // UR handle (lazy materialization).
 TEST_F(IPCEventTests, MakeEventIPCFlagSet) {
   {
-    sycl::event Evt =
-        syclexp::make_event(Ctxt, syclexp::properties{syclexp::enable_ipc});
+    sycl::event Evt = syclexp::make_event(
+        Ctxt, syclexp::properties{syclexp::enable_ipc{true}});
     EXPECT_TRUE(Evt.ext_oneapi_ipc_enabled());
   }
   // No UR handle was ever materialized, so nothing to release.
@@ -182,8 +182,8 @@ TEST_F(IPCEventTests, MakeEventNoIPCFlag) {
 // correct data.
 TEST_F(IPCEventTests, GetCallsURAndReturnsHandle) {
   {
-    sycl::event Evt =
-        syclexp::make_event(Ctxt, syclexp::properties{syclexp::enable_ipc});
+    sycl::event Evt = syclexp::make_event(
+        Ctxt, syclexp::properties{syclexp::enable_ipc{true}});
 
     sycl::ext::oneapi::experimental::ipc::handle H = ipcevt::get(Evt);
 
@@ -216,8 +216,8 @@ TEST_F(IPCEventTests, GetOnNonIPCEventThrows) {
 // ipc::event::put calls urIPCPutEventHandleExp with the handle data.
 TEST_F(IPCEventTests, PutCallsUR) {
   {
-    sycl::event Evt =
-        syclexp::make_event(Ctxt, syclexp::properties{syclexp::enable_ipc});
+    sycl::event Evt = syclexp::make_event(
+        Ctxt, syclexp::properties{syclexp::enable_ipc{true}});
 
     sycl::ext::oneapi::experimental::ipc::handle H = ipcevt::get(Evt);
     EXPECT_EQ(urIPCGetEventHandleExp_counter, 1);
@@ -293,7 +293,8 @@ TEST_F(IPCEventTests, MakeEventNoAspectThrows) {
 
   bool caught = false;
   try {
-    (void)syclexp::make_event(Ctxt, syclexp::properties{syclexp::enable_ipc});
+    (void)syclexp::make_event(Ctxt,
+                              syclexp::properties{syclexp::enable_ipc{true}});
   } catch (const sycl::exception &E) {
     caught = true;
     EXPECT_EQ(E.code(),
@@ -308,8 +309,8 @@ TEST_F(IPCEventTests, MakeEventIPCAndProfilingThrows) {
   bool caught = false;
   try {
     (void)syclexp::make_event(
-        Ctxt,
-        syclexp::properties{syclexp::enable_ipc, syclexp::enable_profiling});
+        Ctxt, syclexp::properties{syclexp::enable_ipc{true},
+                                  syclexp::enable_profiling{true}});
   } catch (const sycl::exception &E) {
     caught = true;
     EXPECT_EQ(E.code(), sycl::make_error_code(sycl::errc::invalid));

--- a/sycl/unittests/Extensions/InterProcessCommunication/PhysicalMemory.cpp
+++ b/sycl/unittests/Extensions/InterProcessCommunication/PhysicalMemory.cpp
@@ -169,7 +169,7 @@ protected:
 
 TEST_F(IPCPhysMemTests, IPCGetPut) {
   {
-    syclexp::properties PropList{syclexp::enable_ipc};
+    syclexp::properties PropList{syclexp::enable_ipc{true}};
     syclexp::physical_mem PhysMem{Dev, Ctxt, PhysMemSize, PropList};
 
     syclexp::ipc::handle IPCMemHandle =
@@ -251,7 +251,7 @@ TEST_F(IPCPhysMemTests, IPCGetNoFlagEnableIpc) {
 
 TEST_F(IPCPhysMemTests, IPCCreateDevNoAspect) {
   mock::getCallbacks().set_after_callback("urDeviceGetInfo", nullptr);
-  syclexp::properties PropList{syclexp::enable_ipc};
+  syclexp::properties PropList{syclexp::enable_ipc{true}};
   bool exception = false;
 
   try {

--- a/sycl/unittests/Extensions/ReusableEvents.cpp
+++ b/sycl/unittests/Extensions/ReusableEvents.cpp
@@ -391,7 +391,7 @@ TEST_F(ReusableEventsTest, ProfilingInfoQuery) {
   sycl::platform Plt = Dev.get_platform();
 
   sycl::context Ctx{Dev};
-  syclex::properties PropList{syclex::enable_profiling};
+  syclex::properties PropList{syclex::enable_profiling{true}};
   auto event = syclex::make_event(Ctx, PropList);
   sycl::queue Queue{Ctx, Dev, sycl::property::queue::in_order{}};
 


### PR DESCRIPTION
Convert `enable_profiling` (from `sycl_ext_oneapi_reusable_event`) and `enable_ipc` (from `sycl_ext_oneapi_inter_process_communication`) from compile-time flag properties to runtime properties that accept a `bool enable` argument. This matches what both extension specs already document and examples in those specs imply that those are runtime properties. Current implementation is not able to compile examples provided in the specification.

As a runtime property, the same properties list can express either state:
```
  syclex::make_event(
      ctx,
      syclex::properties{syclex::enable_profiling{some_runtime_bool},
                         syclex::enable_ipc{another_runtime_bool}});

```
And allows to avoid this kind of branching:
```
    if (enable_profiling) {
        return syclex::make_event(context, syclex::enable_profiling);
    } else if (enable_ipc) {
        return syclex::make_event(context, syclex::enable_ipc);
    } else
        return syclex::make_event(context);
    }

```
Assisted-By: Claude