### PR TITLE
[SYCL][Doc] Clarify IPC event handle data size guarantee

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_inter_process_communication.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_inter_process_communication.asciidoc
@@ -1259,7 +1259,9 @@ handle get(const sycl::event &evt)
 _Returns:_ An IPC "handle" to this event. The bytes of this handle can be
 transferred to another process on the same system, and the other process can
 use the handle to get an event object synchronized with event `evt` through a
-call to the `open` function.
+call to the `open` function. For a given platform, the size of the handle data
+(returned by `handle::data()` or `handle::data_view()`) is the same for all
+handles associated with `sycl::event` object type.
 
 _Throws:_ An exception with the `errc::invalid` error code if event `evt` was
 not created with the `enable_ipc` property.


### PR DESCRIPTION
Add the same clarification that was added for physical_mem in #22522. State explicitly that the size of the handle data returned by 'ipc::event::get' is the same for all handles associated with 'sycl::event' object type on a given platform.