### PR TITLE
[SYCL][Test] Update NVPTX short-ptr tests after #206512 merge

### DIFF
--- a/clang/test/CodeGenSYCL/nvptx-short-ptr.cpp
+++ b/clang/test/CodeGenSYCL/nvptx-short-ptr.cpp
@@ -20,9 +20,9 @@
 
 // Targeting a 32-bit NVPTX, check that we see universal 32-bit pointers (the
 // option changes nothing)
-// CHECK32: target datalayout = "e-p:32:32-p6:32:32-p7:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64"
+// CHECK32: target datalayout = "e-p:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64"
 
 // Targeting a 64-bit NVPTX target, check that we see 32-bit pointers for
 // shared (3), const (4), and local (5) address spaces only.
 // CHECK64-DEFAULT: target datalayout = "e-p6:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64"
-// CHECK64-SHORT: target datalayout = "e-p3:32:32-p4:32:32-p5:32:32-p6:32:32-p7:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64"
+// CHECK64-SHORT: target datalayout = "e-p3:32:32-p4:32:32-p5:32:32-p6:32:32-p7:32:32-p101:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64"


### PR DESCRIPTION
Update CHECK lines in `nvptx-short-ptr.cpp` upstream aef1e4f24985 ([NVPTX] Support short entry param pointers #206512)
- 32-bit NVPTX datalayout no longer explicitly lists p6/p7 (inherited from p:32:32)
- 64-bit short-ptr mode now includes p101:32:32 for entry parameters

CMPLRLLVM-77114