### PR TITLE
[SYCL][UR] Fix DX11 bindless-images interop crashes on Windows

### DIFF
--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: aspect-ext_oneapi_bindless_images
 // REQUIRES: aspect-ext_oneapi_external_memory_import
 // REQUIRES: windows
 

--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled.cpp
@@ -1,12 +1,6 @@
 // REQUIRES: aspect-ext_oneapi_external_memory_import
 // REQUIRES: windows
 
-// UNSUPPORTED: gpu-intel-gen12
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22148
-
-// UNSUPPORTED: arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22234
-
 // RUN: %{build} %link-directx -o %t.out
 // RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out
 #include <iostream>

--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled_semaphore.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: aspect-ext_oneapi_bindless_images
 // REQUIRES: aspect-ext_oneapi_external_memory_import
 // REQUIRES: aspect-ext_oneapi_external_semaphore_import
 // REQUIRES: windows

--- a/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx11_interop/read_write_unsampled_semaphore.cpp
@@ -2,15 +2,6 @@
 // REQUIRES: aspect-ext_oneapi_external_semaphore_import
 // REQUIRES: windows
 
-// UNSUPPORTED: gpu-intel-gen12
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22148
-
-// UNSUPPORTED: gpu-intel-dg2
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22155
-
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22298
-
 // RUN: %{build} %link-directx -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out
 

--- a/unified-runtime/source/adapters/level_zero/common/image_common.cpp
+++ b/unified-runtime/source/adapters/level_zero/common/image_common.cpp
@@ -366,9 +366,11 @@ ur_result_t bindlessImagesCreateImpl(ur_context_handle_t hContext,
       (ZeImageTranslated, &DeviceOffset));
   *phImage = DeviceOffset;
 
-  std::shared_lock<ur_shared_mutex> Lock(hDevice->Mutex);
+  // Exclusive lock: the map below is mutated; unlock() (not release()) is
+  // required so the device mutex is actually released afterwards.
+  std::unique_lock<ur_shared_mutex> Lock(hDevice->Mutex);
   hDevice->ZeOffsetToImageHandleMap[*phImage] = ZeImage.get();
-  Lock.release();
+  Lock.unlock();
   ZeImage.release();
 
   return UR_RESULT_SUCCESS;
@@ -1167,16 +1169,18 @@ ur_result_t urBindlessImagesUnsampledImageHandleDestroyExp(
   (void)hDevice;
   UR_ASSERT(hContext && hDevice && hImage, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
-  std::shared_lock<ur_shared_mutex> Lock(hDevice->Mutex);
+  // Exclusive lock: the map below is mutated; unlock() (not release()) is
+  // required so the device mutex is actually released afterwards.
+  std::unique_lock<ur_shared_mutex> Lock(hDevice->Mutex);
   auto item = hDevice->ZeOffsetToImageHandleMap.find(hImage);
 
   if (item != hDevice->ZeOffsetToImageHandleMap.end()) {
     auto *handle = item->second;
     hDevice->ZeOffsetToImageHandleMap.erase(item);
-    Lock.release();
+    Lock.unlock();
     ZE2UR_CALL(zeImageDestroy, (handle));
   } else {
-    Lock.release();
+    Lock.unlock();
     return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
   }
 

--- a/unified-runtime/source/adapters/level_zero/common/image_common.cpp
+++ b/unified-runtime/source/adapters/level_zero/common/image_common.cpp
@@ -1509,8 +1509,22 @@ ur_result_t urBindlessImagesImportExternalSemaphoreExp(
     pNext = const_cast<void *>(BaseDesc->pNext);
   }
 
-  ZE2UR_CALL(UrPlatform->ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp,
-             (hDevice->ZeDevice, &SemDesc, &ExtSemaphoreHandle));
+  ze_result_t ZeResult = ZE_CALL_NOCHECK(
+      UrPlatform->ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp,
+      (hDevice->ZeDevice, &SemDesc, &ExtSemaphoreHandle));
+
+  // A D3D11 fence shares the same NT-handle semantics as a D3D12 fence. Some
+  // drivers do not yet accept ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D11_FENCE; retry
+  // such handles as a D3D12 fence rather than failing the import.
+  if (ZeResult == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE &&
+      SemDesc.flags == ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D11_FENCE) {
+    SemDesc.flags = ZE_EXTERNAL_SEMAPHORE_EXT_FLAG_D3D12_FENCE;
+    ZeResult = ZE_CALL_NOCHECK(
+        UrPlatform->ZeExternalSemaphoreExt.zexImportExternalSemaphoreExp,
+        (hDevice->ZeDevice, &SemDesc, &ExtSemaphoreHandle));
+  }
+  if (ZeResult != ZE_RESULT_SUCCESS)
+    return ze2urResult(ZeResult);
   *phExternalSemaphoreHandle =
       (ur_exp_external_semaphore_handle_t)ExtSemaphoreHandle;
 


### PR DESCRIPTION
Enabled both DX11 bindless-images interop tests (read_write_unsampled.cpp, read_write_unsampled_semaphore.cpp) for all architectures that support bindless images, after fixing two bugs that prevented them from passing on Win BMG and Win DG2: 
- a data race/lock leak in the image handle map, and
- a rejected D3D11 external-fence import (now falls back to D3D12_FENCE). 

Gen12 does not support bindless images at all, which both tests require internally — for clarity, the hardcoded architecture blocker _(UNSUPPORTED: gpu-intel-gen12/dg2/bmg_g21)_ is replaced with a _REQUIRES: aspect-ext_oneapi_bindless_images_ check, so any device lacking the aspect is skipped the same way instead of crashing.