### PR TITLE
[UR] Fix umf::umf target not found in sibling subdirectories

### DIFF
--- a/unified-runtime/source/common/CMakeLists.txt
+++ b/unified-runtime/source/common/CMakeLists.txt
@@ -84,6 +84,10 @@ if(UR_USE_EXTERNAL_UMF)
 endif()
 if(umf_FOUND)
   message(STATUS "Using preinstalled UMF at ${umf_DIR}, ignoring UMF build related options")
+  # Promote umf::umf and umf::umf_headers IMPORTED targets to global scope so
+  # sibling subdirectories (loader, adapters) can link against them.
+  set_target_properties(umf::umf PROPERTIES IMPORTED_GLOBAL TRUE)
+  set_target_properties(umf::umf_headers PROPERTIES IMPORTED_GLOBAL TRUE)
   # Add an alias matching the FetchContent case
   add_library(umf::headers ALIAS umf::umf_headers)
 else()


### PR DESCRIPTION
find_package(umf) creates umf::umf/umf::umf_headers as IMPORTED targets, scoped to the directory they're created in (common/) and its subdirectories. Commit 078d46c733aa added target_link_libraries(... umf::umf umf::headers) in loader/ and adapters/level_zero/, which are siblings of common/, not descendants - so those targets aren't visible there.

This only fails in downstream where UR_USE_EXTERNAL_UMF finds a pre- installed UMF (e.g. umf_ROOT/umf_DIR set), taking the find_package() path instead of building UMF in-tree via add_subdirectory, whose targets are project-wide visible. Mark the imported targets IMPORTED_GLOBAL so all subdirectories can link against them.