### PR TITLE
[SYCL] Deprecate sampler and access targets

### DIFF
--- a/sycl/include/sycl/access/access.hpp
+++ b/sycl/include/sycl/access/access.hpp
@@ -25,7 +25,7 @@ enum class target {
   local __SYCL2020_DEPRECATED("use `local_accessor` instead") = 2016,
   image __SYCL_DEPRECATED("removed in SYCL 2020") = 2017,
   host_buffer __SYCL2020_DEPRECATED("use 'host_accessor' instead") = 2018,
-  host_image  __SYCL_DEPRECATED("removed in SYCL 2020") = 2019,
+  host_image __SYCL_DEPRECATED("removed in SYCL 2020") = 2019,
   image_array __SYCL_DEPRECATED("removed in SYCL 2020") = 2020,
   host_task = 2021,
 };

--- a/sycl/include/sycl/access/access.hpp
+++ b/sycl/include/sycl/access/access.hpp
@@ -23,10 +23,10 @@ enum class target {
   global_buffer __SYCL2020_DEPRECATED("use 'target::device' instead") = device,
   constant_buffer __SYCL2020_DEPRECATED("use 'target::device' instead") = 2015,
   local __SYCL2020_DEPRECATED("use `local_accessor` instead") = 2016,
-  image = 2017,
+  image __SYCL_DEPRECATED("removed in SYCL 2020") = 2017,
   host_buffer __SYCL2020_DEPRECATED("use 'host_accessor' instead") = 2018,
-  host_image = 2019,
-  image_array = 2020,
+  host_image  __SYCL_DEPRECATED("removed in SYCL 2020") = 2019,
+  image_array __SYCL_DEPRECATED("removed in SYCL 2020") = 2020,
   host_task = 2021,
 };
 

--- a/sycl/include/sycl/sampler.hpp
+++ b/sycl/include/sycl/sampler.hpp
@@ -62,7 +62,8 @@ class sampler_impl;
 /// \sa sycl_api_acc
 ///
 /// \ingroup sycl_api
-class __SYCL_EXPORT __SYCL_SPECIAL_CLASS __SYCL_TYPE(sampler) sampler {
+class __SYCL_EXPORT __SYCL_SPECIAL_CLASS __SYCL_TYPE(sampler)
+    __SYCL_DEPRECATED("sampler has been removed in SYCL 2020") sampler {
   friend sycl::detail::ImplUtils;
 
 public:

--- a/sycl/test-e2e/Basic/sampler/sampler.cpp
+++ b/sycl/test-e2e/Basic/sampler/sampler.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // TODO: Can we move it to sycl/test?
-// RUN: %{build} -Wno-error=unused-command-line-argument -fsycl-dead-args-optimization -o %t.out
+// RUN: %{build} -Wno-error=unused-command-line-argument -Wno-error=deprecated-declarations -fsycl-dead-args-optimization -o %t.out
 // RUN: %{run} %t.out
 
 //==--------------- sampler.cpp - SYCL sampler basic test ------------------==//

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -53,6 +53,7 @@ int main() {
   (void)Queue.get();
 
   cl_sampler ClSampler;
+  // expected-warning@+2 {{sampler has been removed in SYCL 2020}}
   // expected-error@+1 {{no matching constructor for initialization of 'sycl::sampler'}}
   sycl::sampler Sampler{ClSampler, Ctx};
   (void)Sampler;


### PR DESCRIPTION
The sampler class has been removed in SYCL 2020. Deprecate removed access targets as well.