### PR TITLE
[SYCL] Prepare fence_space for removal

### DIFF
--- a/sycl/include/sycl/access/access.hpp
+++ b/sycl/include/sycl/access/access.hpp
@@ -39,11 +39,13 @@ enum class mode {
   atomic = 1029
 };
 
-enum class fence_space {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+enum class __SYCL_DEPRECATED("Removed in SYCL 2020") fence_space {
   local_space = 0,
   global_space = 1,
   global_and_local = 2
 };
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 enum class placeholder { false_t = 0, true_t = 1 };
 

--- a/sycl/include/sycl/detail/helpers.hpp
+++ b/sycl/include/sycl/detail/helpers.hpp
@@ -185,6 +185,7 @@ getSPIRVMemorySemanticsMask(memory_order) {
   return __spv::MemorySemanticsMask::None;
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 inline constexpr uint32_t
 getSPIRVMemorySemanticsMask(const access::fence_space AccessSpace,
                             const __spv::MemorySemanticsMask LocalScopeMask =
@@ -229,6 +230,7 @@ getSPIRVMemorySemanticsMask(const access::fence_space AccessSpace,
                  __spv::MemorySemanticsMask::CrossWorkgroupMemory |
                  LocalScopeMask);
 }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 inline constexpr bool is_power_of_two(int x) { return (x & (x - 1)) == 0; }
 } // namespace detail

--- a/sycl/include/sycl/group.hpp
+++ b/sycl/include/sycl/group.hpp
@@ -297,10 +297,11 @@ public:
     detail::workGroupBarrier();
   }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   /// Executes a work-group mem-fence with memory ordering on the local address
   /// space, global address space or both based on the value of \p accessSpace.
   template <access::mode accessMode = access::mode::read_write>
-  void mem_fence(
+  __SYCL_DEPRECATED("Removed in SYCL 2020") void mem_fence(
       [[maybe_unused]]
       typename std::enable_if_t<accessMode == access::mode::read ||
                                     accessMode == access::mode::write ||
@@ -320,6 +321,7 @@ public:
     __spirv_MemoryBarrier(__spv::Scope::Workgroup, flags);
 #endif
   }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   /// Asynchronously copies a number of elements specified by \p numElements
   /// from the source pointed by \p src to destination pointed by \p dest

--- a/sycl/include/sycl/group.hpp
+++ b/sycl/include/sycl/group.hpp
@@ -301,7 +301,8 @@ public:
   /// Executes a work-group mem-fence with memory ordering on the local address
   /// space, global address space or both based on the value of \p accessSpace.
   template <access::mode accessMode = access::mode::read_write>
-  __SYCL_DEPRECATED("Removed in SYCL 2020") void mem_fence(
+  __SYCL_DEPRECATED("Removed in SYCL 2020")
+  void mem_fence(
       [[maybe_unused]]
       typename std::enable_if_t<accessMode == access::mode::read ||
                                     accessMode == access::mode::write ||


### PR DESCRIPTION
fence_space is a legacy SYCL 1.2.1 enum. Deprecate it and prepare for removal. Also handle related API and helpers.