### PR TITLE
[CI] Fix postcommit run conditions for devops directory

### DIFF
--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -17,9 +17,9 @@ on:
     - .github/workflows/sycl-linux-build.yml
     - .github/workflows/sycl-linux-run-tests.yml
     - .github/workflows/sycl-macos-build-and-test.yml
-    - ./devops/actions/cleanup
-    - ./devops/actions/cached_checkout
-    - ./devops/dependencies.json
+    - devops/actions/cleanup/**
+    - devops/actions/cached_checkout/**
+    - devops/dependencies.json
 
 concurrency:
   #  Cancel a currently running workflow from the same PR or commit hash.


### PR DESCRIPTION
Postcommit wasn't being run on PRs changing `devops/dependencies.json`, seems the problem was the leading `./`.