### PR TITLE
[SYCL][Driver] Fix spurious OpenMP error with --save-temps and -fsycl-targets

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9250,7 +9250,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   // For all the host SYCL offloading compile jobs we need to pass the targets
   // information using -fsycl-targets= option.
-  if (isa<CompileJobAction>(JA) && JA.isHostOffloading(Action::OFK_SYCL)) {
+  // Skip the TY_LLVM_BC case: with --save-temps the compile phase is a
+  // separate cc1 invocation that does not need -fsycl-targets=, and passing it
+  // (an alias for --offload-targets=) would trigger spurious OpenMP target
+  // triple validation on SYCL-specific names like 'intel_gpu_pvc'.
+  if (isa<CompileJobAction>(JA) && JA.isHostOffloading(Action::OFK_SYCL) &&
+      JA.getType() != types::TY_LLVM_BC) {
     SmallString<128> TargetInfo("-fsycl-targets=");
 
     if (Arg *Tgts = Args.getLastArg(options::OPT_offload_targets_EQ)) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9248,30 +9248,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   addOpenMPHostOffloadingArgs(C, JA, Args, CmdArgs);
 
-  // For all the host SYCL offloading compile jobs we need to pass the targets
-  // information using -fsycl-targets= option.
-  // Skip the TY_LLVM_BC case: with --save-temps the compile phase is a
-  // separate cc1 invocation that does not need -fsycl-targets=, and passing it
-  // (an alias for --offload-targets=) would trigger spurious OpenMP target
-  // triple validation on SYCL-specific names like 'intel_gpu_pvc'.
-  if (isa<CompileJobAction>(JA) && JA.isHostOffloading(Action::OFK_SYCL) &&
-      JA.getType() != types::TY_LLVM_BC) {
-    SmallString<128> TargetInfo("-fsycl-targets=");
-
-    if (Arg *Tgts = Args.getLastArg(options::OPT_offload_targets_EQ)) {
-      for (unsigned i = 0; i < Tgts->getNumValues(); ++i) {
-        if (i)
-          TargetInfo += ',';
-        // We need to get the string from the triple because it may be not
-        // exactly the same as the one we get directly from the arguments.
-        llvm::Triple T(Tgts->getValue(i));
-        TargetInfo += T.getTriple();
-      }
-    } else
-      // Use the default.
-      TargetInfo += C.getDriver().getSYCLDeviceTriple().normalize();
-    CmdArgs.push_back(Args.MakeArgString(TargetInfo.str()));
-  }
   if (Args.hasFlag(options::OPT_fdevirtualize_speculatively,
                    options::OPT_fno_devirtualize_speculatively,
                    /*Default value*/ false))

--- a/clang/test/Driver/sycl-offload-save-temps-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-save-temps-old-model.cpp
@@ -40,3 +40,18 @@
 // RUN: | FileCheck %s --check-prefix=CHK_LLVM_PASSES
 // CHK_LLVM_PASSES-NOT: clang{{.*}} "-triple" "spir64-unknown-unknown" {{.*}} "-disable-llvm-passes"
 // CHK_LLVM_PASSES: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-disable-llvm-passes"
+
+/// -save-temps must not inject -fsycl-targets= into the host compile step
+/// that emits LLVM BC. That step is a separate cc1 invocation (-emit-llvm-bc)
+/// and does not need the targets info; passing -fsycl-targets= (an alias for
+/// --offload-targets=) would trigger spurious OpenMP target triple validation
+/// on SYCL-specific names like 'intel_gpu_pvc', causing:
+///   error: OpenMP target is invalid: 'intel_gpu_pvc'
+// RUN: %clangxx -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHK-NO-FSYCL-TARGETS-IN-HOST-BC
+// RUN: %clangxx -fsycl --no-offload-new-driver -fsycl-targets=intel_gpu_pvc -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHK-NO-FSYCL-TARGETS-IN-HOST-BC
+/// Verify the host compile step emitting BC is present but without -fsycl-targets=.
+/// The NOT must precede the positive match so FileCheck scans the same line window.
+// CHK-NO-FSYCL-TARGETS-IN-HOST-BC-NOT: "-fsycl-is-host"{{.*}}"-emit-llvm-bc"{{.*}}"-fsycl-targets=
+// CHK-NO-FSYCL-TARGETS-IN-HOST-BC: clang{{.*}} "-fsycl-is-host"{{.*}} "-emit-llvm-bc"{{.*}} "-o" "{{.*}}.bc"

--- a/clang/test/Driver/sycl-offload-save-temps-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-save-temps-old-model.cpp
@@ -41,12 +41,10 @@
 // CHK_LLVM_PASSES-NOT: clang{{.*}} "-triple" "spir64-unknown-unknown" {{.*}} "-disable-llvm-passes"
 // CHK_LLVM_PASSES: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-disable-llvm-passes"
 
-/// -save-temps must not inject -fsycl-targets= into the host compile step
-/// that emits LLVM BC. That step is a separate cc1 invocation (-emit-llvm-bc)
-/// and does not need the targets info; passing -fsycl-targets= (an alias for
-/// --offload-targets=) would trigger spurious OpenMP target triple validation
-/// on SYCL-specific names like 'intel_gpu_pvc', causing:
-///   error: OpenMP target is invalid: 'intel_gpu_pvc'
+/// -fsycl-targets= must never appear in any host cc1 invocation. It is not
+/// consumed by the host compile and passing it (an alias for --offload-targets=)
+/// triggers spurious OpenMP target triple validation on SYCL-specific names
+/// like 'intel_gpu_pvc', causing: error: OpenMP target is invalid: 'intel_gpu_pvc'
 // RUN: %clangxx -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHK-NO-FSYCL-TARGETS-IN-HOST-BC
 // RUN: %clangxx -fsycl --no-offload-new-driver -fsycl-targets=intel_gpu_pvc -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \

--- a/clang/test/Driver/sycl-offload-save-temps.cpp
+++ b/clang/test/Driver/sycl-offload-save-temps.cpp
@@ -32,12 +32,10 @@
 // CHK_LLVM_PASSES-NOT: clang{{.*}} "-triple" "spir64-unknown-unknown" {{.*}} "-disable-llvm-passes"
 // CHK_LLVM_PASSES: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-disable-llvm-passes"
 
-/// -save-temps must not inject -fsycl-targets= into the host compile step
-/// that emits LLVM BC. That step is a separate cc1 invocation (-emit-llvm-bc)
-/// and does not need the targets info; passing -fsycl-targets= (an alias for
-/// --offload-targets=) would trigger spurious OpenMP target triple validation
-/// on SYCL-specific names like 'intel_gpu_pvc', causing:
-///   error: OpenMP target is invalid: 'intel_gpu_pvc'
+/// -fsycl-targets= must never appear in any host cc1 invocation. It is not
+/// consumed by the host compile and passing it (an alias for --offload-targets=)
+/// triggers spurious OpenMP target triple validation on SYCL-specific names
+/// like 'intel_gpu_pvc', causing: error: OpenMP target is invalid: 'intel_gpu_pvc'
 // RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64_gen-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
 // RUN: | FileCheck %s --check-prefix=CHK-NO-FSYCL-TARGETS-IN-HOST-BC
 // RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=intel_gpu_pvc -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \

--- a/clang/test/Driver/sycl-offload-save-temps.cpp
+++ b/clang/test/Driver/sycl-offload-save-temps.cpp
@@ -31,3 +31,18 @@
 // RUN: | FileCheck %s --check-prefix=CHK_LLVM_PASSES
 // CHK_LLVM_PASSES-NOT: clang{{.*}} "-triple" "spir64-unknown-unknown" {{.*}} "-disable-llvm-passes"
 // CHK_LLVM_PASSES: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-disable-llvm-passes"
+
+/// -save-temps must not inject -fsycl-targets= into the host compile step
+/// that emits LLVM BC. That step is a separate cc1 invocation (-emit-llvm-bc)
+/// and does not need the targets info; passing -fsycl-targets= (an alias for
+/// --offload-targets=) would trigger spurious OpenMP target triple validation
+/// on SYCL-specific names like 'intel_gpu_pvc', causing:
+///   error: OpenMP target is invalid: 'intel_gpu_pvc'
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64_gen-unknown-unknown -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHK-NO-FSYCL-TARGETS-IN-HOST-BC
+// RUN: %clangxx -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL -fsycl-targets=intel_gpu_pvc -target x86_64-unknown-linux-gnu -save-temps %s -### 2>&1 \
+// RUN: | FileCheck %s --check-prefix=CHK-NO-FSYCL-TARGETS-IN-HOST-BC
+/// Verify the host compile step emitting BC is present but without -fsycl-targets=.
+/// The NOT must precede the positive match so FileCheck scans the same line window.
+// CHK-NO-FSYCL-TARGETS-IN-HOST-BC-NOT: "-fsycl-is-host"{{.*}}"-emit-llvm-bc"{{.*}}"-fsycl-targets=
+// CHK-NO-FSYCL-TARGETS-IN-HOST-BC: clang{{.*}} "-fsycl-is-host"{{.*}} "-emit-llvm-bc"{{.*}} "-o" "{{.*}}.bc"


### PR DESCRIPTION
## Problem

`clang++ --save-temps -fsycl -fsycl-targets=intel_gpu_pvc -o t t.cpp` fails with:
```
error: OpenMP target is invalid: 'intel_gpu_pvc'
```
The same command without `--save-temps` works fine.

## Root Cause

Without `--save-temps`, the driver collapses preprocess + compile + backend + assemble into a single cc1 invocation (`-emit-obj`). The outermost action in `constructJob` is an `AssembleJobAction`, so the block that injects `-fsycl-targets=` into cc1 args (guarded by `isa<CompileJobAction>(JA)`) never fires.

With `--save-temps`, collapsing is disabled and the host compile becomes a separate cc1 invocation emitting LLVM BC (`-emit-llvm-bc`, output type `TY_LLVM_BC`). The guard fires and `-fsycl-targets=intel_gpu_pvc` is added to that cc1's arguments.

Since `-fsycl-targets=` is an alias for `--offload-targets=`, `CompilerInvocation.cpp` unconditionally validates the value as an OpenMP target triple. `intel_gpu_pvc` is a SYCL-specific shorthand, not a valid triple, so it fails with the misleading OpenMP error.

## Fix

Remove the block in Clang::ConstructJob that injected -fsycl-targets= into
host SYCL compile cc1 invocations.

The block was introduced for the old offload model but has been effectively
dead for some time: without --save-temps the host compile is a single collapsed
cc1 step whose JA is an AssembleJobAction, so isa<CompileJobAction>(JA) is
never true and the block never fires.

With --save-temps, collapsing is disabled and the host compile becomes a
separate CompileJobAction emitting LLVM BC. The block would fire and add
-fsycl-targets=intel_gpu_pvc to that cc1's args. Since -fsycl-targets= is an
alias for --offload-targets=, CompilerInvocation.cpp unconditionally validates
the value as an OpenMP target triple, and intel_gpu_pvc (a SYCL-specific
shorthand, not a valid triple) produces:
  error: OpenMP target is invalid: 'intel_gpu_pvc'

The fix is to remove the block entirely: -fsycl-targets= is not consumed by
any host cc1 code path (not in Sema, CodeGen, or Parse) and the host compile
has no use for it. The fix applies to both the old and new offload drivers.

## Testing

Added tests to `sycl-offload-save-temps.cpp` and `sycl-offload-save-temps-old-model.cpp` verifying that the host `-emit-llvm-bc` step does not receive `-fsycl-targets=` for both `spir64_gen-unknown-unknown` and `intel_gpu_pvc` targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)