### PR TITLE
[SYCL][test-e2e] Add versioned level_zero_sdk lit features

### DIFF
--- a/sycl/test-e2e/E2EExpr.py
+++ b/sycl/test-e2e/E2EExpr.py
@@ -211,7 +211,7 @@ class TestE2EExpr(unittest.TestCase):
         # Any major/minor pair should match
         self.assertTrue(E2EExpr.is_build_specific("level_zero_sdk_2_130"))
 
-        # reject build malformed SDK values
+        # reject malformed SDK features
         self.assertFalse(E2EExpr.is_build_specific("level_zero_sdk_1"))
         self.assertFalse(E2EExpr.is_build_specific("level_zero_sdk_1_14_0"))
 

--- a/sycl/test-e2e/E2EExpr.py
+++ b/sycl/test-e2e/E2EExpr.py
@@ -208,9 +208,10 @@ class TestE2EExpr(unittest.TestCase):
         detected = {"level_zero_sdk_1_{}".format(minor) for minor in range(15)}
         E2EExpr.check_build_features({"level_zero_dev_kit"} | detected)
 
-        # Any major/minor pair should matche
+        # Any major/minor pair should match
         self.assertTrue(E2EExpr.is_build_specific("level_zero_sdk_2_130"))
-        # The pattern must not accept malformed names.
+
+        # reject build malformed SDK values
         self.assertFalse(E2EExpr.is_build_specific("level_zero_sdk_1"))
         self.assertFalse(E2EExpr.is_build_specific("level_zero_sdk_1_14_0"))
 

--- a/sycl/test-e2e/E2EExpr.py
+++ b/sycl/test-e2e/E2EExpr.py
@@ -1,7 +1,13 @@
+import re
+
 from lit.BooleanExpression import BooleanExpression
 
 
 class E2EExpr(BooleanExpression):
+    build_specific_feature_patterns = [
+        re.compile(r"level_zero_sdk_\d+_\d+$"),
+    ]
+
     build_specific_features = {
         "run-mode",
         "build-mode",
@@ -52,6 +58,13 @@ class E2EExpr(BooleanExpression):
         "new-offload-model",
     }
 
+    @staticmethod
+    def is_build_specific(feature):
+        return feature in E2EExpr.build_specific_features or any(
+            pattern.match(feature)
+            for pattern in E2EExpr.build_specific_feature_patterns
+        )
+
     def __init__(self, string, variables, build_only_mode, final_unknown_value):
         BooleanExpression.__init__(self, string, variables)
         self.build_only_mode = build_only_mode
@@ -77,7 +90,7 @@ class E2EExpr(BooleanExpression):
     def parseMATCH(self):
         token = self.token
         BooleanExpression.parseMATCH(self)
-        if token not in E2EExpr.build_specific_features and self.build_only_mode:
+        if not E2EExpr.is_build_specific(token) and self.build_only_mode:
             self.unknown = True
         else:
             self.unknown = False
@@ -122,7 +135,7 @@ class E2EExpr(BooleanExpression):
 
     @staticmethod
     def check_build_features(variables):
-        rt_features = [x for x in variables if x not in E2EExpr.build_specific_features]
+        rt_features = [x for x in variables if not E2EExpr.is_build_specific(x)]
         if rt_features:
             raise ValueError(
                 "Runtime features: "
@@ -190,6 +203,16 @@ class TestE2EExpr(unittest.TestCase):
         with self.assertRaises(ValueError):
             E2EExpr.check_build_features({"build-only", "rt-feature"})
         E2EExpr.check_build_features({"build-mode"})
+
+    def test_level_zero_sdk_features(self):
+        detected = {"level_zero_sdk_1_{}".format(minor) for minor in range(15)}
+        E2EExpr.check_build_features({"level_zero_dev_kit"} | detected)
+
+        # Any major/minor pair should matche
+        self.assertTrue(E2EExpr.is_build_specific("level_zero_sdk_2_130"))
+        # The pattern must not accept malformed names.
+        self.assertFalse(E2EExpr.is_build_specific("level_zero_sdk_1"))
+        self.assertFalse(E2EExpr.is_build_specific("level_zero_sdk_1_14_0"))
 
 
 if __name__ == "__main__":

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/ze_launch_kernel_with_args.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/ze_launch_kernel_with_args.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
-// REQUIRES: level_zero_dev_kit
+// REQUIRES: level_zero_dev_kit, level_zero_sdk_1_14
 
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out %S/../../Inputs/Kernels/saxpy.spv

--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -247,6 +247,9 @@ environment:
 * **aot_tool** - Ahead-of-time compilation tools availability;
 * **ocloc**, **opencl-aot** - Specific AOT tool availability;
 * **level_zero_dev_kit** - Level_Zero headers and libraries availability;
+* **level_zero_sdk_&lt;major&gt;_&lt;minor&gt;** - the available Level_Zero SDK headers
+  implement at least version `<major>.<minor>` of the Level Zero API
+  specification;
 * **cuda_dev_kit** - CUDA SDK headers and libraries availability;
 * **dump_ir**: - compiler can / cannot dump IR;
 * **llvm-spirv** - llvm-spirv tool availability;

--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -247,9 +247,8 @@ environment:
 * **aot_tool** - Ahead-of-time compilation tools availability;
 * **ocloc**, **opencl-aot** - Specific AOT tool availability;
 * **level_zero_dev_kit** - Level_Zero headers and libraries availability;
-* **level_zero_sdk_&lt;major&gt;_&lt;minor&gt;** - the available Level_Zero SDK headers
-  implement at least version `<major>.<minor>` of the Level Zero API
-  specification;
+* **level_zero_sdk_<major>_<minor>** - the available Level_Zero library
+  implements at least this version of the spec;
 * **cuda_dev_kit** - CUDA SDK headers and libraries availability;
 * **dump_ir**: - compiler can / cannot dump IR;
 * **llvm-spirv** - llvm-spirv tool availability;

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -389,18 +389,15 @@ config.level_zero_include = quote_path(
     )
 )
 
-level_zero_include_option = "-I" + config.level_zero_include
-
 level_zero_options = level_zero_options = (
     (" -L" + config.level_zero_libs_dir if config.level_zero_libs_dir else "")
     + " -lze_loader "
-    + " "
-    + level_zero_include_option
+    + " -I"
+    + config.level_zero_include
 )
 if cl_options:
     if is_windows_unc_network_path(level_zero_win_lib):
         level_zero_win_lib = normalize_windows_network_path(level_zero_win_lib)
-    level_zero_include_option = "/I" + config.level_zero_include
     level_zero_options = (
         " "
         + (
@@ -408,8 +405,8 @@ if cl_options:
             if config.level_zero_libs_dir
             else "ze_loader.lib"
         )
-        + " "
-        + level_zero_include_option
+        + " /I"
+        + config.level_zero_include
     )
 
 config.substitutions.append(("%level_zero_options", level_zero_options))
@@ -431,6 +428,8 @@ with test_env():
 if "level_zero_dev_kit" in config.available_features:
     # This trick relies on ZE_API_VERSION_CURRENT_M being defined as
     # ZE_MAKE_VERSION(<major>, <minor>). That could change in the future
+    include_flag = "/I" if cl_options else "-I"
+    level_zero_include_option = include_flag + config.level_zero_include
     check_l0_version_file = "l0_version.cpp"
     with open_check_file(check_l0_version_file) as fp:
         print("#include <level_zero/ze_api.h>", file=fp)

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -389,15 +389,18 @@ config.level_zero_include = quote_path(
     )
 )
 
+level_zero_include_option = "-I" + config.level_zero_include
+
 level_zero_options = level_zero_options = (
     (" -L" + config.level_zero_libs_dir if config.level_zero_libs_dir else "")
     + " -lze_loader "
-    + " -I"
-    + config.level_zero_include
+    + " "
+    + level_zero_include_option
 )
 if cl_options:
     if is_windows_unc_network_path(level_zero_win_lib):
         level_zero_win_lib = normalize_windows_network_path(level_zero_win_lib)
+    level_zero_include_option = "/I" + config.level_zero_include
     level_zero_options = (
         " "
         + (
@@ -405,8 +408,8 @@ if cl_options:
             if config.level_zero_libs_dir
             else "ze_loader.lib"
         )
-        + " /I"
-        + config.level_zero_include
+        + " "
+        + level_zero_include_option
     )
 
 config.substitutions.append(("%level_zero_options", level_zero_options))
@@ -420,6 +423,41 @@ with test_env():
         config.substitutions.append(("%level_zero_options", level_zero_options))
     else:
         config.substitutions.append(("%level_zero_options", ""))
+
+# Query which Level Zero spec version the SDK implements
+#
+# Adds a level_zero_sdk_<major>_<minor> feature for this version and every
+# earlier version.
+if "level_zero_dev_kit" in config.available_features:
+    # This trick relies on ZE_API_VERSION_CURRENT_M being defined as
+    # ZE_MAKE_VERSION(<major>, <minor>). That could change in the future
+    check_l0_version_file = "l0_version.cpp"
+    with open_check_file(check_l0_version_file) as fp:
+        print("#include <level_zero/ze_api.h>", file=fp)
+        print("#undef ZE_MAKE_VERSION", file=fp)
+        print("#define ZE_MAKE_VERSION(_maj, _min) LIT_L0_SPEC _maj _min", file=fp)
+        print("ZE_API_VERSION_CURRENT_M", file=fp)
+
+    with test_env():
+        # Preprocess only
+        sp = subprocess.getstatusoutput(
+            config.dpcpp_compiler
+            + " -E "
+            + check_l0_version_file
+            + " "
+            + level_zero_include_option
+        )
+    l0_spec_version = (
+        re.search(r"LIT_L0_SPEC\s+(\d+)\s+(\d+)", sp[1]) if sp[0] == 0 else None
+    )
+
+    if l0_spec_version:
+        l0_major, l0_minor = (int(g) for g in l0_spec_version.groups())
+        # add support for this version and previos versions
+        for minor in range(l0_minor + 1):
+            config.available_features.add(
+                "level_zero_sdk_{}_{}".format(l0_major, minor)
+            )
 
 test_preview = lit_config.params.get("test-preview-mode")
 if test_preview is not None and test_preview not in ["True", "False"]:


### PR DESCRIPTION
Some tests require relatively new Level Zero features that cannot be reasonably supported in drivers packaged for non-first-class-supported distros.

This PR adds a set of new lit features that follow the pattern `level_zero_sdk_<major>_<minor>` to allow tests to specify the minimum spec version that it requires.
