### PR TITLE
[UR] Allow ShTest external execution in unified-runtime test config

### DIFF
--- a/unified-runtime/test/lit.cfg.py
+++ b/unified-runtime/test/lit.cfg.py
@@ -22,7 +22,17 @@ config.test_exec_root = path.join(config.ur_obj_root, "test")
 
 # Default test configuration - unit tests (that use formats.GoogleTest) use a different test suite specified by
 # lit.cfg.py (which does not inherit from this one)
-config.test_format = lit.formats.ShTest(True)
+#
+# force_execute_external is required to keep using external shell execution
+# (needed by these tests, e.g. LD_LIBRARY_PATH manipulation and %maybe-v1/
+# %maybe-v2 RUN-line prefixes) on newer lit versions (LLVM-23+) where
+# ShTest(execute_external=True) alone is deprecated and raises a ValueError.
+# Older lit releases (e.g. the lit==18.1.8 PyPI package used by some CI jobs)
+# don't recognize this keyword argument at all, so fall back gracefully.
+try:
+    config.test_format = lit.formats.ShTest(True, force_execute_external=True)
+except TypeError:
+    config.test_format = lit.formats.ShTest(True)
 config.suffixes = [".test"]
 
 


### PR DESCRIPTION
lit.formats.ShTest(execute_external=True) alone is deprecated in newer
lit versions and now raises a ValueError instead of just warning,
causing llvm-lit to fail parsing unified-runtime/test/lit.cfg.py (used
by the test/adapters/ suite) with:

  fatal: unable to parse config file '.../unified-runtime/test/lit.cfg.py'
  ValueError: execute_external=True is deprected as of LLVM-23 ...

Pass force_execute_external=True to keep using external shell execution
(required by these tests, e.g. LD_LIBRARY_PATH manipulation and %maybe-v1/
%maybe-v2 RUN-line prefixes) while acknowledging the deprecation, per the
migration guidance in lit's own error message.

However, some CI jobs use the pip-installed lit==18.1.8 package instead
of the repo's own bundled llvm/utils/lit, and that older lit release
doesn't have the force_execute_external parameter at all, so passing it
unconditionally raised:

  TypeError: ShTest.__init__() got an unexpected keyword argument
  'force_execute_external'

Wrap the call in a try/except TypeError so it falls back to the plain
ShTest(True) call on lit versions that don't support (or need)
force_execute_external, while still using it on newer lit versions
(LLVM-23+) where it's required to avoid the deprecation ValueError.
