### PR TITLE
[SYCL] Update ESIMD tests to use access_mode

### DIFF
--- a/sycl/test-e2e/ESIMD/BitonicSortK.hpp
+++ b/sycl/test-e2e/ESIMD/BitonicSortK.hpp
@@ -604,8 +604,8 @@ int BitonicSort::Solve(uint32_t *pInputs, uint32_t *pOutputs, uint32_t size) {
       buffer<uint32_t, 1> bufo(pOutputs, range<1>(size));
       // enqueue sort265 kernel
       auto e = pQueue_->submit([&](handler &cgh) {
-        auto acci = bufi.get_access<access::mode::read>(cgh);
-        auto acco = bufo.get_access<access::mode::write>(cgh);
+        auto acci = bufi.get_access<access_mode::read>(cgh);
+        auto acco = bufo.get_access<access_mode::write>(cgh);
         cgh.parallel_for<class Sort256>(
             SortGlobalRange * SortLocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
               using namespace sycl::ext::intel::esimd;
@@ -649,7 +649,7 @@ int BitonicSort::Solve(uint32_t *pInputs, uint32_t *pOutputs, uint32_t size) {
         for (int j = i; j >= 8; j--) {
           buffer<uint32_t, 1> buf(pOutputs, range<1>(size));
           mergeEvent[k] = pQueue_->submit([&](handler &cgh) {
-            auto acc = buf.get_access<access::mode::read_write>(cgh);
+            auto acc = buf.get_access<access_mode::read_write>(cgh);
             cgh.parallel_for<class Merge>(
                 MergeGlobalRange * MergeLocalRange,
                 [=](id<1> tid) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/InlineAsm/asm_glb.cpp
+++ b/sycl/test-e2e/ESIMD/InlineAsm/asm_glb.cpp
@@ -48,9 +48,9 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class Test>(
           GlobalRange * LocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/InlineAsm/asm_simd_mask.cpp
+++ b/sycl/test-e2e/ESIMD/InlineAsm/asm_simd_mask.cpp
@@ -44,9 +44,9 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class Test>(
           GlobalRange * LocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/InlineAsm/asm_simd_view.cpp
+++ b/sycl/test-e2e/ESIMD/InlineAsm/asm_simd_view.cpp
@@ -44,9 +44,9 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class Test>(
           GlobalRange * LocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/InlineAsm/asm_vadd.cpp
+++ b/sycl/test-e2e/ESIMD/InlineAsm/asm_vadd.cpp
@@ -44,9 +44,9 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class Test>(
           GlobalRange * LocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/acc_gather_scatter_rgba.hpp
+++ b/sycl/test-e2e/ESIMD/acc_gather_scatter_rgba.hpp
@@ -109,8 +109,8 @@ bool test(queue q) {
     buffer<T, 1> OutBuf(B, range<1>(size));
     range<1> glob_range{numWorkItems};
     auto e = q.submit([&](handler &cgh) {
-      auto InAcc = InBuf.template get_access<access::mode::read_write>(cgh);
-      auto OutAcc = OutBuf.template get_access<access::mode::read_write>(cgh);
+      auto InAcc = InBuf.template get_access<access_mode::read_write>(cgh);
+      auto OutAcc = OutBuf.template get_access<access_mode::read_write>(cgh);
       Kernel<T, VL, STRIDE, CH_MASK> kernel(InAcc, OutAcc);
       cgh.parallel_for(glob_range, kernel);
     });

--- a/sycl/test-e2e/ESIMD/acc_gather_scatter_rgba_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/acc_gather_scatter_rgba_stateless_64.cpp
@@ -39,7 +39,7 @@ int main(void) {
             << "\n";
   try {
     q.submit([&](handler &cgh) {
-       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       auto PA = bufa.get_access<access_mode::read_write>(cgh);
        cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
          uint64_t offsetStart = (Size - VL) * sizeof(uint64_t);
          simd<uint64_t, VL> offset(offsetStart, sizeof(uint64_t));

--- a/sycl/test-e2e/ESIMD/accessor.hpp
+++ b/sycl/test-e2e/ESIMD/accessor.hpp
@@ -36,8 +36,8 @@ int main() {
       std::cout << "Running on "
                 << q.get_device().get_info<sycl::info::device::name>() << "\n";
 
-      auto acc0 = buf0.get_access<access::mode::read_write>(cgh);
-      auto acc1 = buf1.get_access<access::mode::write>(cgh);
+      auto acc0 = buf0.get_access<access_mode::read_write>(cgh);
+      auto acc1 = buf1.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<class Test>(range<1>(1),
                                    [=](sycl::id<1> i) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/accessor_gather_scatter.hpp
+++ b/sycl/test-e2e/ESIMD/accessor_gather_scatter.hpp
@@ -57,7 +57,7 @@ template <typename T, unsigned VL, unsigned STRIDE> bool test(queue q) {
     range<1> glob_range{size / VL};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      auto acc = buf.template get_access<access_mode::read_write>(cgh);
       Kernel<T, VL, STRIDE> kernel(acc);
       cgh.parallel_for(glob_range, kernel);
     });

--- a/sycl/test-e2e/ESIMD/accessor_gather_scatter_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_gather_scatter_stateless_64.cpp
@@ -34,7 +34,7 @@ int main(void) {
             << "\n";
   try {
     q.submit([&](handler &cgh) {
-       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       auto PA = bufa.get_access<access_mode::read_write>(cgh);
        cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
          uint64_t offsetStart = (Size - VL) * sizeof(uint64_t);
          simd<uint64_t, VL> offset(offsetStart, sizeof(uint64_t));

--- a/sycl/test-e2e/ESIMD/accessor_load_store.hpp
+++ b/sycl/test-e2e/ESIMD/accessor_load_store.hpp
@@ -50,7 +50,7 @@ template <typename T> bool test(queue q, size_t size) {
     range<1> glob_range{size};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      auto acc = buf.template get_access<access_mode::read_write>(cgh);
       Kernel<T> kernel(acc);
       cgh.parallel_for(glob_range, kernel);
     });

--- a/sycl/test-e2e/ESIMD/accessor_load_store_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_load_store_stateless_64.cpp
@@ -34,7 +34,7 @@ int main(void) {
             << "\n";
   try {
     q.submit([&](handler &cgh) {
-       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       auto PA = bufa.get_access<access_mode::read_write>(cgh);
        cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
          uint64_t offset = (Size - VL) * sizeof(uint64_t);
          simd<uint64_t, VL> va = block_load<uint64_t, VL>(PA, 0);

--- a/sycl/test-e2e/ESIMD/accessor_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_stateless_64.cpp
@@ -36,7 +36,7 @@ int main(void) {
               << "\n";
 
     q.submit([&](handler &cgh) {
-       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       auto PA = bufa.get_access<access_mode::read_write>(cgh);
        cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
          uint64_t offset = (Size - VL) * sizeof(uint64_t);
          simd<uint64_t, VL> va;

--- a/sycl/test-e2e/ESIMD/accessor_stateless_ctor_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_stateless_ctor_64.cpp
@@ -36,7 +36,7 @@ int main(void) {
               << "\n";
 
     q.submit([&](handler &cgh) {
-       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       auto PA = bufa.get_access<access_mode::read_write>(cgh);
        cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
          uint64_t offset = (Size - VL) * sizeof(uint64_t);
          simd<uint64_t, VL> va(PA, 0);

--- a/sycl/test-e2e/ESIMD/aot_mixed.cpp
+++ b/sycl/test-e2e/ESIMD/aot_mixed.cpp
@@ -70,9 +70,9 @@ bool test_esimd(queue q) {
     buffer<float, 1> bufc(C, range<1>(Size));
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class TestESIMD>(
           Size / VL, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;
@@ -122,9 +122,9 @@ bool test_sycl(queue q) {
     buffer<float, 1> bufc(C, range<1>(Size));
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class TestSYCL>(Size,
                                        [=](id<1> i) { PC[i] = PA[i] + PB[i]; });
     });

--- a/sycl/test-e2e/ESIMD/api/ballot.cpp
+++ b/sycl/test-e2e/ESIMD/api/ballot.cpp
@@ -38,8 +38,8 @@ template <class T, int N> bool test(queue &Q) {
     buffer<decltype(Res), 1> RB(&Res, range<1>(1));
 
     auto E = Q.submit([&](handler &CGH) {
-      auto In = PB.template get_access<access::mode::read>(CGH);
-      auto Out = RB.template get_access<access::mode::write>(CGH);
+      auto In = PB.template get_access<access_mode::read>(CGH);
+      auto Out = RB.template get_access<access_mode::write>(CGH);
 
       CGH.parallel_for(sycl::range<1>{1}, [=](id<1>) SYCL_ESIMD_KERNEL {
         simd<T, N> Mask;

--- a/sycl/test-e2e/ESIMD/api/functional/operators/operator_assignment_glb.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/operators/operator_assignment_glb.cpp
@@ -50,9 +50,9 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class Test>(
           GlobalRange * LocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/api/functional/operators/operator_assignment_glb_mask.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/operators/operator_assignment_glb_mask.cpp
@@ -48,8 +48,8 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class Test>(
           GlobalRange * LocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
@@ -98,8 +98,8 @@ bool test_impl(queue q, int offset, T (&&gold)[N]) {
     sycl::buffer<T, 1> dst_buf(dm.dst, VL);
 
     q.submit([&](handler &cgh) {
-       auto src_acc = src_buf.template get_access<access::mode::read>(cgh);
-       auto dst_acc = dst_buf.template get_access<access::mode::write>(cgh);
+       auto src_acc = src_buf.template get_access<access_mode::read>(cgh);
+       auto dst_acc = dst_buf.template get_access<access_mode::write>(cgh);
 
        cgh.single_task([=]() SYCL_ESIMD_KERNEL {
          simd<T, VL> src(src_acc, 0);

--- a/sycl/test-e2e/ESIMD/api/saturation_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/saturation_smoke.cpp
@@ -83,8 +83,8 @@ bool test(queue q) {
     sycl::buffer<To, 1> dst_buf(dm.dst, N);
 
     auto e = q.submit([&](handler &cgh) {
-      auto src_acc = src_buf.template get_access<access::mode::read>(cgh);
-      auto dst_acc = dst_buf.template get_access<access::mode::write>(cgh);
+      auto src_acc = src_buf.template get_access<access_mode::read>(cgh);
+      auto dst_acc = dst_buf.template get_access<access_mode::write>(cgh);
 
       cgh.single_task([=]() SYCL_ESIMD_KERNEL {
         simd<From, N> x(src_acc, 0);

--- a/sycl/test-e2e/ESIMD/api/simd_binop_integer_promotion.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_binop_integer_promotion.cpp
@@ -52,9 +52,9 @@ template <typename T> bool test(queue q) {
     range<1> glob_range{1};
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufA.template get_access<access::mode::read>(cgh);
-      auto PB = bufB.template get_access<access::mode::read>(cgh);
-      auto PC = bufC.template get_access<access::mode::write>(cgh);
+      auto PA = bufA.template get_access<access_mode::read>(cgh);
+      auto PB = bufB.template get_access<access_mode::read>(cgh);
+      auto PC = bufC.template get_access<access_mode::write>(cgh);
       cgh.parallel_for<KernelName<T>>(
           glob_range, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::experimental::esimd;

--- a/sycl/test-e2e/ESIMD/api/simd_copy_to_from.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_copy_to_from.cpp
@@ -84,8 +84,8 @@ bool testAcc(queue &Q, T *Src, T *Dst, unsigned Off, Flags) {
     buffer<T, 1> DstB(Dst, range<1>(Off + N));
 
     Q.submit([&](handler &CGH) {
-       auto SrcA = SrcB.template get_access<access::mode::read>(CGH);
-       auto DstA = DstB.template get_access<access::mode::write>(CGH);
+       auto SrcA = SrcB.template get_access<access_mode::read>(CGH);
+       auto DstA = DstB.template get_access<access_mode::write>(CGH);
 
        CGH.parallel_for(sycl::range<1>{1}, [=](id<1>) SYCL_ESIMD_KERNEL {
          simd<T, N> Vals;

--- a/sycl/test-e2e/ESIMD/api/simd_copy_to_from_stateful.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_copy_to_from_stateful.cpp
@@ -89,8 +89,8 @@ bool testAcc(queue &Q, T *Src, T *Dst, unsigned Off, Flags) {
     buffer<T, 1> DstB(Dst, range<1>(Off + N));
 
     Q.submit([&](handler &CGH) {
-       auto SrcA = SrcB.template get_access<access::mode::read>(CGH);
-       auto DstA = DstB.template get_access<access::mode::write>(CGH);
+       auto SrcA = SrcB.template get_access<access_mode::read>(CGH);
+       auto DstA = DstB.template get_access<access_mode::write>(CGH);
 
        CGH.parallel_for(sycl::range<1>{1}, [=](id<1>) SYCL_ESIMD_KERNEL {
          simd<T, N> Vals;

--- a/sycl/test-e2e/ESIMD/api/simd_memory_access.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_memory_access.cpp
@@ -87,7 +87,7 @@ template <typename T, int N, bool IsAcc> bool test(queue q, size_t size) {
       range<1> glob_range{size / N};
 
       auto e = q.submit([&](handler &cgh) {
-        auto acc = buf.template get_access<access::mode::read_write>(cgh);
+        auto acc = buf.template get_access<access_mode::read_write>(cgh);
         Kernel<T, N, true> kernel(acc);
         cgh.parallel_for(glob_range, kernel);
       });

--- a/sycl/test-e2e/ESIMD/api/simd_negation_operator.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_negation_operator.cpp
@@ -37,8 +37,8 @@ bool test(queue q, const std::array<T, VL> &input,
     range<1> glob_range{1};
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufA.template get_access<access::mode::read>(cgh);
-      auto PB = bufB.template get_access<access::mode::write>(cgh);
+      auto PA = bufA.template get_access<access_mode::read>(cgh);
+      auto PB = bufB.template get_access<access_mode::write>(cgh);
       cgh.parallel_for(glob_range, [=](id<1> i) SYCL_ESIMD_KERNEL {
         using namespace sycl::ext::intel::esimd;
         simd<T, VL> va;

--- a/sycl/test-e2e/ESIMD/api/simd_subscript_operator.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_subscript_operator.cpp
@@ -45,8 +45,8 @@ template <class T> bool test(queue &q) {
     range<1> glob_range{1};
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufA.template get_access<access::mode::read>(cgh);
-      auto PB = bufB.template get_access<access::mode::read_write>(cgh);
+      auto PA = bufA.template get_access<access_mode::read>(cgh);
+      auto PB = bufB.template get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<T>(glob_range, [=](id<1> i) SYCL_ESIMD_KERNEL {
         using namespace sycl::ext::intel::esimd;
         unsigned int offset = i * VL * sizeof(T);

--- a/sycl/test-e2e/ESIMD/api/simd_view_copy_move_assign.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_view_copy_move_assign.cpp
@@ -38,8 +38,8 @@ bool test(queue q, std::string str, F funcUnderTest) {
     buffer<T, 1> BufB(B, range<1>(Size));
 
     q.submit([&](handler &cgh) {
-       auto PA = BufA.template get_access<access::mode::read_write>(cgh);
-       auto PB = BufB.template get_access<access::mode::read_write>(cgh);
+       auto PA = BufA.template get_access<access_mode::read_write>(cgh);
+       auto PB = BufB.template get_access<access_mode::read_write>(cgh);
        cgh.parallel_for(range<1>{Size / VL}, [=](id<1> i) SYCL_ESIMD_KERNEL {
          using namespace sycl::ext::intel::esimd;
          unsigned int offset = i * VL * sizeof(T);

--- a/sycl/test-e2e/ESIMD/api/simd_view_negation_operator.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_view_negation_operator.cpp
@@ -37,8 +37,8 @@ bool test(queue q, const std::array<T, VL> &input,
     range<1> glob_range{1};
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufA.template get_access<access::mode::read>(cgh);
-      auto PB = bufB.template get_access<access::mode::write>(cgh);
+      auto PA = bufA.template get_access<access_mode::read>(cgh);
+      auto PB = bufB.template get_access<access_mode::write>(cgh);
       cgh.parallel_for(glob_range, [=](id<1> i) SYCL_ESIMD_KERNEL {
         using namespace sycl::ext::intel::esimd;
         simd<T, VL> va;

--- a/sycl/test-e2e/ESIMD/api/simd_view_subscript_operator.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_view_subscript_operator.cpp
@@ -48,8 +48,8 @@ template <class T> bool test(queue &q) {
     range<1> glob_range{1};
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufA.template get_access<access::mode::read>(cgh);
-      auto PB = bufB.template get_access<access::mode::read_write>(cgh);
+      auto PA = bufA.template get_access<access_mode::read>(cgh);
+      auto PB = bufB.template get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<TestID<T>>(glob_range, [=](id<1> i) SYCL_ESIMD_KERNEL {
         using namespace sycl::ext::intel::esimd;
         simd<T, VL> va;

--- a/sycl/test-e2e/ESIMD/api/slm_gather_scatter_heavy.cpp
+++ b/sycl/test-e2e/ESIMD/api/slm_gather_scatter_heavy.cpp
@@ -382,8 +382,8 @@ bool test_impl(queue q) {
     range<1> glob_range{size / VL};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acc_in = buf_in.template get_access<access::mode::read_write>(cgh);
-      auto acc_out = buf_out.template get_access<access::mode::read_write>(cgh);
+      auto acc_in = buf_in.template get_access<access_mode::read_write>(cgh);
+      auto acc_out = buf_out.template get_access<access_mode::read_write>(cgh);
       constexpr auto WG_SIZE = STRIDE; // for simplicity of the test
       KernelType kernel(acc_in, acc_out, MaskedLane);
       cgh.parallel_for(nd_range<1>{glob_range, range<1>(WG_SIZE)}, kernel);

--- a/sycl/test-e2e/ESIMD/clz_ctz.cpp
+++ b/sycl/test-e2e/ESIMD/clz_ctz.cpp
@@ -43,8 +43,8 @@ template <typename T, bool CLZ> bool test(queue &q) {
     queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.template get_access<access::mode::read>(cgh);
-      auto PB = bufb.template get_access<access::mode::write>(cgh);
+      auto PA = bufa.template get_access<access_mode::read>(cgh);
+      auto PB = bufb.template get_access<access_mode::write>(cgh);
       cgh.parallel_for(GlobalRange * LocalRange,
                        [=](id<1> i) SYCL_ESIMD_KERNEL {
                          using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/ext_math.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math.cpp
@@ -346,10 +346,10 @@ bool test(queue &Q, const std::string &Name, InitF Init = InitNarrow<T>{},
     sycl::range<1> LocalRange{1};
 
     auto E = Q.submit([&](handler &CGH) {
-      auto PA = BufA.template get_access<access::mode::read>(CGH);
-      auto PC = BufC.template get_access<access::mode::write>(CGH);
+      auto PA = BufA.template get_access<access_mode::read>(CGH);
+      auto PC = BufC.template get_access<access_mode::write>(CGH);
       if constexpr (IsBinOp) {
-        auto PB = BufB.template get_access<access::mode::read>(CGH);
+        auto PB = BufB.template get_access<access_mode::read>(CGH);
         BinaryDeviceFunc<T, N, Op, Kernel, decltype(PA), decltype(PC)> F(PA, PB,
                                                                          PC);
         CGH.parallel_for(nd_range<1>{GlobalRange, LocalRange}, F);

--- a/sycl/test-e2e/ESIMD/fma.cpp
+++ b/sycl/test-e2e/ESIMD/fma.cpp
@@ -36,9 +36,9 @@ template <typename T> bool test(queue q) {
     buffer<T, 1> bufc(C, range<1>(Size));
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.template get_access<access::mode::read>(cgh);
-      auto PB = bufb.template get_access<access::mode::read>(cgh);
-      auto PC = bufc.template get_access<access::mode::write>(cgh);
+      auto PA = bufa.template get_access<access_mode::read>(cgh);
+      auto PB = bufb.template get_access<access_mode::read>(cgh);
+      auto PC = bufc.template get_access<access_mode::write>(cgh);
       cgh.single_task([=]() SYCL_ESIMD_KERNEL {
         using namespace sycl::ext::intel::esimd;
         unsigned int offset = 0;

--- a/sycl/test-e2e/ESIMD/fp_call_from_func.cpp
+++ b/sycl/test-e2e/ESIMD/fp_call_from_func.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
     buffer<int, 1> buf(output, range<1>(1));
 
     q.submit([&](handler &cgh) {
-      auto acc = buf.get_access<access::mode::write>(cgh);
+      auto acc = buf.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<KernelID>(
           sycl::range<1>{1},

--- a/sycl/test-e2e/ESIMD/fp_in_phi.cpp
+++ b/sycl/test-e2e/ESIMD/fp_in_phi.cpp
@@ -38,8 +38,8 @@ bool test(queue q, bool flag) {
     buffer<int, 1> y_buf(Y.data(), Y.size());
 
     q.submit([&](handler &cgh) {
-      auto o_acc = o_buf.get_access<access::mode::write>(cgh);
-      auto y_acc = y_buf.get_access<access::mode::write>(cgh);
+      auto o_acc = o_buf.get_access<access_mode::write>(cgh);
+      auto y_acc = y_buf.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<KernelID>(sycl::range<1>{1},
                                  [=](id<1> i) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/fp_in_select.cpp
+++ b/sycl/test-e2e/ESIMD/fp_in_select.cpp
@@ -31,7 +31,7 @@ bool test(queue q, bool flag) {
     buffer<int, 1> buf(output, range<1>(1));
 
     q.submit([&](handler &cgh) {
-      auto acc = buf.get_access<access::mode::write>(cgh);
+      auto acc = buf.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<KernelID>(sycl::range<1>{1},
                                  [=](id<1> i) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/frem.cpp
+++ b/sycl/test-e2e/ESIMD/frem.cpp
@@ -38,9 +38,9 @@ template <typename T> bool test(queue q) {
     buffer<T, 1> bufc(C, range<1>(Size));
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.template get_access<access::mode::read>(cgh);
-      auto PB = bufb.template get_access<access::mode::read>(cgh);
-      auto PC = bufc.template get_access<access::mode::write>(cgh);
+      auto PA = bufa.template get_access<access_mode::read>(cgh);
+      auto PB = bufb.template get_access<access_mode::read>(cgh);
+      auto PC = bufc.template get_access<access_mode::write>(cgh);
       cgh.single_task([=]() SYCL_ESIMD_KERNEL {
         using namespace sycl::ext::intel::esimd;
         unsigned int offset = 0;

--- a/sycl/test-e2e/ESIMD/grf.cpp
+++ b/sycl/test-e2e/ESIMD/grf.cpp
@@ -66,7 +66,7 @@ int main(void) {
   try {
     buffer<float, 1> bufa(A.data(), range<1>(Size));
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class SyclKernel>(Size,
                                          [=](id<1> i) { PA[i] = PA[i] + 1; });
     });
@@ -86,7 +86,7 @@ int main(void) {
   try {
     buffer<float, 1> bufa(A.data(), range<1>(Size));
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class EsimdKernel>(Size, [=](id<1> i) SYCL_ESIMD_KERNEL {
         unsigned int offset = i * VL * sizeof(float);
         simd<float, VL> va;
@@ -116,7 +116,7 @@ int main(void) {
     sycl::ext::oneapi::experimental::properties prop{grf_size<256>};
 #endif
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class EsimdKernelSpecifiedGRF>(
           Size, prop, [=](id<1> i) SYCL_ESIMD_KERNEL {
             unsigned int offset = i * VL * sizeof(float);

--- a/sycl/test-e2e/ESIMD/histogram.cpp
+++ b/sycl/test-e2e/ESIMD/histogram.cpp
@@ -155,7 +155,7 @@ int main(int argc, char *argv[]) {
       nd_range<1> Range(GlobalRange, LocalRange);
 
       auto e = q.submit([&](handler &cgh) {
-        auto readAcc = Img.get_access<uint4, access::mode::read>(cgh);
+        auto readAcc = Img.get_access<uint4, access_mode::read>(cgh);
 
         cgh.parallel_for<class Hist>(
             Range, [=](nd_item<1> ndi) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/histogram_2d.cpp
+++ b/sycl/test-e2e/ESIMD/histogram_2d.cpp
@@ -157,7 +157,7 @@ int main(int argc, char *argv[]) {
       nd_range<2> Range(GlobalRange, LocalRange);
 
       auto e = q.submit([&](handler &cgh) {
-        auto readAcc = Img.get_access<uint4, access::mode::read>(cgh);
+        auto readAcc = Img.get_access<uint4, access_mode::read>(cgh);
 
         cgh.parallel_for<class Hist>(
             Range, [=](nd_item<2> ndi) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/linear/linear.cpp
+++ b/sycl/test-e2e/ESIMD/linear/linear.cpp
@@ -86,8 +86,8 @@ int main(int argc, char *argv[]) {
 
     for (int iter = 0; iter <= num_iters; ++iter) {
       auto e = q.submit([&](handler &cgh) {
-        auto accInput = imgInput.get_access<uint4, access::mode::read>(cgh);
-        auto accOutput = imgOutput.get_access<uint4, access::mode::write>(cgh);
+        auto accInput = imgInput.get_access<uint4, access_mode::read>(cgh);
+        auto accOutput = imgOutput.get_access<uint4, access_mode::write>(cgh);
 
         cgh.parallel_for<class Test>(
             GlobalRange * LocalRange, [=](item<2> it) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/local_accessor_copy_to_from.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_copy_to_from.cpp
@@ -48,7 +48,7 @@ template <typename T, unsigned VL> bool test(queue q) {
     nd_range<1> NDRange{range<1>{GlobalRange}, range<1>{LocalRange}};
     q.submit([&](handler &CGH) {
        auto LocalAcc = local_accessor<T, 1>(Size, CGH);
-       auto Acc = buf.template get_access<access::mode::read_write>(CGH);
+       auto Acc = buf.template get_access<access_mode::read_write>(CGH);
        CGH.parallel_for(NDRange, [=](nd_item<1> Item) SYCL_ESIMD_KERNEL {
          uint32_t GID = Item.get_global_id(0);
          uint32_t LID = Item.get_local_id(0);

--- a/sycl/test-e2e/ESIMD/local_accessor_gather_scatter.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_gather_scatter.cpp
@@ -45,7 +45,7 @@ template <typename T, unsigned VL, unsigned STRIDE> bool test(queue q) {
     nd_range<1> glob_range{range<1>{1}, range<1>{1}};
 
     q.submit([&](handler &cgh) {
-       auto acc = buf.template get_access<access::mode::read_write>(cgh);
+       auto acc = buf.template get_access<access_mode::read_write>(cgh);
        auto LocalAcc = local_accessor<T, 1>(size * STRIDE, cgh);
        cgh.parallel_for(glob_range, [=](nd_item<1> ndi) SYCL_ESIMD_KERNEL {
          using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/local_accessor_gather_scatter_rgba.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_gather_scatter_rgba.cpp
@@ -83,7 +83,7 @@ template <typename T, unsigned VL, auto CH_MASK> bool test(queue q) {
 
     buffer<T, 1> OutBuf(A, range<1>(size));
     q.submit([&](handler &cgh) {
-       auto OutAcc = OutBuf.template get_access<access::mode::read_write>(cgh);
+       auto OutAcc = OutBuf.template get_access<access_mode::read_write>(cgh);
        auto LocalAcc = local_accessor<T, 1>(VL * NUM_RGBA_CHANNELS, cgh);
 
        cgh.parallel_for(Range, [=](nd_item<1> ndi) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_surf.hpp
+++ b/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_surf.hpp
@@ -44,11 +44,11 @@ int main() {
     auto buf_3 = buffer{vec_3};
     auto buf_4 = buffer{vec_4};
     q.submit([&](handler &h) {
-      auto access_0 = buf_0.template get_access<access::mode::read_write>(h);
-      auto access_1 = buf_1.template get_access<access::mode::read_write>(h);
-      auto access_2 = buf_2.template get_access<access::mode::read_write>(h);
-      auto access_3 = buf_3.template get_access<access::mode::read_write>(h);
-      auto access_4 = buf_4.template get_access<access::mode::read_write>(h);
+      auto access_0 = buf_0.template get_access<access_mode::read_write>(h);
+      auto access_1 = buf_1.template get_access<access_mode::read_write>(h);
+      auto access_2 = buf_2.template get_access<access_mode::read_write>(h);
+      auto access_3 = buf_3.template get_access<access_mode::read_write>(h);
+      auto access_4 = buf_4.template get_access<access_mode::read_write>(h);
       h.parallel_for<class SimplestKernel>(
           range<1>{size / SIMDSize}, [=](id<1> id) SYCL_ESIMD_KERNEL {
             auto offset = id[0] * SIMDSize * sizeof(int);

--- a/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_surf_load.hpp
+++ b/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_surf_load.hpp
@@ -77,8 +77,8 @@ bool test(uint32_t pmask = 0xffffffff) {
     buffer<T, 1> bufi(in.data(), in.size());
 
     auto e = q.submit([&](handler &cgh) {
-      auto acco = bufo.template get_access<access::mode::write>(cgh);
-      auto acci = bufi.template get_access<access::mode::read>(cgh);
+      auto acco = bufo.template get_access<access_mode::write>(cgh);
+      auto acci = bufi.template get_access<access_mode::read>(cgh);
       cgh.parallel_for<KernelID<case_num>>(
           Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
             uint16_t globalID = ndi.get_global_id(0);

--- a/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_surf_store.hpp
+++ b/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_surf_store.hpp
@@ -73,7 +73,7 @@ bool test(uint32_t pmask = 0xffffffff) {
     buffer<T, 1> bufo(out.data(), out.size());
 
     auto e = q.submit([&](handler &cgh) {
-      auto acco = bufo.template get_access<access::mode::write>(cgh);
+      auto acco = bufo.template get_access<access_mode::write>(cgh);
       cgh.parallel_for<KernelID<case_num>>(
           Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
             uint16_t globalID = ndi.get_global_id(0);

--- a/sycl/test-e2e/ESIMD/lsc/atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/atomic_smoke.cpp
@@ -325,7 +325,7 @@ bool test(queue q, const Config &cfg) {
   try {
     buffer<T, 1> buf(arr, range<1>(size));
     auto e = q.submit([&](handler &cgh) {
-      auto accessor = buf.template get_access<access::mode::read_write>(cgh);
+      auto accessor = buf.template get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<TestID<T, N, ImplF>>(
           rng, [=](nd_item<1> gid) SYCL_ESIMD_KERNEL {
             int i = gid.get_global_id(0);

--- a/sycl/test-e2e/ESIMD/lsc/lsc_argument_type_deduction.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_argument_type_deduction.cpp
@@ -31,7 +31,7 @@ template <unsigned SIMDSize> int testAccessor(queue q) {
   try {
     auto buf_0 = buffer{vec_0};
     q.submit([&](handler &h) {
-      auto access_0 = buf_0.template get_access<access::mode::read_write>(h);
+      auto access_0 = buf_0.template get_access<access_mode::read_write>(h);
 
       h.parallel_for(
           range<1>{size / SIMDSize}, [=](id<1> id) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/lsc/lsc_block_load_store_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_block_load_store_stateless_64.cpp
@@ -35,7 +35,7 @@ int main(void) {
             << "\n";
   try {
     q.submit([&](handler &cgh) {
-       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       auto PA = bufa.get_access<access_mode::read_write>(cgh);
        cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
          uint64_t offset = (Size - VL) * sizeof(uint64_t);
 #ifdef TEST_FLAG

--- a/sycl/test-e2e/ESIMD/lsc/lsc_gather_scatter_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_gather_scatter_stateless_64.cpp
@@ -35,7 +35,7 @@ int main() {
             << "\n";
   try {
     q.submit([&](handler &cgh) {
-       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       auto PA = bufa.get_access<access_mode::read_write>(cgh);
        cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
          uint64_t offsetStart = (Size - VL) * sizeof(uint64_t);
          simd<uint64_t, VL> offset(offsetStart, sizeof(uint64_t));

--- a/sycl/test-e2e/ESIMD/lsc/lsc_local_accessor_gather_scatter.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_local_accessor_gather_scatter.cpp
@@ -47,7 +47,7 @@ template <typename T, unsigned VL, unsigned STRIDE> bool test(queue q) {
     nd_range<1> glob_range{range<1>{1}, range<1>{1}};
 
     q.submit([&](handler &cgh) {
-       auto acc = buf.template get_access<access::mode::read_write>(cgh);
+       auto acc = buf.template get_access<access_mode::read_write>(cgh);
        auto LocalAcc = local_accessor<T, 1>(size * STRIDE, cgh);
        cgh.parallel_for(glob_range, [=](nd_item<1> ndi) SYCL_ESIMD_KERNEL {
          using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/lsc/lsc_predicate.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_predicate.cpp
@@ -34,8 +34,8 @@ template <unsigned SIMDSize> int testAccessor(queue q) {
     auto buf_0 = buffer{vec_0};
     auto buf_2 = buffer{vec_2};
     q.submit([&](handler &h) {
-      auto access_0 = buf_0.template get_access<access::mode::read_write>(h);
-      auto access_2 = buf_2.template get_access<access::mode::read_write>(h);
+      auto access_0 = buf_0.template get_access<access_mode::read_write>(h);
+      auto access_2 = buf_2.template get_access<access_mode::read_write>(h);
 
       h.parallel_for(
           range<1>{size / SIMDSize}, [=](id<1> id) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/lsc/lsc_predicate_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_predicate_stateless.cpp
@@ -36,8 +36,8 @@ template <unsigned SIMDSize> int testAccessor(queue q) {
     auto buf_0 = buffer{vec_0};
     auto buf_2 = buffer{vec_2};
     q.submit([&](handler &h) {
-      auto access_0 = buf_0.template get_access<access::mode::read_write>(h);
-      auto access_2 = buf_2.template get_access<access::mode::read_write>(h);
+      auto access_0 = buf_0.template get_access<access_mode::read_write>(h);
+      auto access_2 = buf_2.template get_access<access_mode::read_write>(h);
 
       h.parallel_for(
           range<1>{size / SIMDSize}, [=](id<1> id) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/lsc/lsc_slm.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_slm.cpp
@@ -42,11 +42,11 @@ int main() {
     auto buf_3 = buffer{vec_3};
     auto buf_4 = buffer{vec_4};
     q.submit([&](handler &h) {
-      auto access_0 = buf_0.template get_access<access::mode::read_write>(h);
-      auto access_1 = buf_1.template get_access<access::mode::read_write>(h);
-      auto access_2 = buf_2.template get_access<access::mode::read_write>(h);
-      auto access_3 = buf_3.template get_access<access::mode::read_write>(h);
-      auto access_4 = buf_4.template get_access<access::mode::read_write>(h);
+      auto access_0 = buf_0.template get_access<access_mode::read_write>(h);
+      auto access_1 = buf_1.template get_access<access_mode::read_write>(h);
+      auto access_2 = buf_2.template get_access<access_mode::read_write>(h);
+      auto access_3 = buf_3.template get_access<access_mode::read_write>(h);
+      auto access_4 = buf_4.template get_access<access_mode::read_write>(h);
       h.parallel_for<class SimplestKernel>(
           range<1>{size / SIMDSize}, [=](id<1> id) SYCL_ESIMD_KERNEL {
             auto offset = id * SIMDSize * sizeof(int);

--- a/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[]) {
     for (int iter = 0; iter <= num_iters; ++iter) {
       auto e = q.submit([&](sycl::handler &cgh) {
         auto accOutput =
-            imgOutput.get_access<uint4, sycl::access::mode::write>(cgh);
+            imgOutput.get_access<uint4, sycl::access_mode::write>(cgh);
 
         cgh.parallel_for<class Test>(
             GlobalRange * LocalRange, [=](item<2> it) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot_spec.cpp
+++ b/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot_spec.cpp
@@ -144,7 +144,7 @@ int main(int argc, char *argv[]) {
     for (int iter = 0; iter <= num_iters; ++iter) {
       auto e = q.submit([&](sycl::handler &cgh) {
         auto accOutput =
-            imgOutput.get_access<uint4, sycl::access::mode::write>(cgh);
+            imgOutput.get_access<uint4, sycl::access_mode::write>(cgh);
 
         cgh.set_specialization_constant<CrunchConst>(crunch);
         cgh.set_specialization_constant<XoffConst>(xoff);

--- a/sycl/test-e2e/ESIMD/mask_compress_store_acc.cpp
+++ b/sycl/test-e2e/ESIMD/mask_compress_store_acc.cpp
@@ -35,7 +35,7 @@ template <int N> bool test() {
 
     auto e = Queue.submit([&](sycl::handler &cgh) {
       auto OutputAcc_out =
-          OutputAcc_buffer.get_access<access::mode::read_write>(cgh);
+          OutputAcc_buffer.get_access<access_mode::read_write>(cgh);
 
       auto kernel = ([=]() [[intel::sycl_explicit_simd]] {
         simd<uint32_t, N> Input(1, 1);

--- a/sycl/test-e2e/ESIMD/mask_expand_load.cpp
+++ b/sycl/test-e2e/ESIMD/mask_expand_load.cpp
@@ -44,7 +44,7 @@ template <int N> bool test(sycl::queue &Queue) {
   buffer<uint32_t, 1> InputAcc_buffer(Input.data(), Input.size());
 
   Queue.submit([&](sycl::handler &cgh) {
-    auto InputAcc = InputAcc_buffer.get_access<access::mode::read>(cgh);
+    auto InputAcc = InputAcc_buffer.get_access<access_mode::read>(cgh);
     auto Kernel = ([=]() SYCL_ESIMD_KERNEL {
       simd_mask<N> Mask;
       for (int i = 0; i < N; i++)

--- a/sycl/test-e2e/ESIMD/matrix_transpose.cpp
+++ b/sycl/test-e2e/ESIMD/matrix_transpose.cpp
@@ -303,7 +303,7 @@ bool runTest(unsigned MZ, unsigned block_size, unsigned num_iters,
       double etime = 0;
       if (block_size == 16 && MZ >= 16) {
         auto e = q.submit([&](handler &cgh) {
-          auto acc = buf.get_access<access::mode::read_write>(cgh);
+          auto acc = buf.get_access<access_mode::read_write>(cgh);
           cgh.parallel_for<class K16>(
               Range, [=](nd_item<2> ndi) SYCL_ESIMD_KERNEL {
                 transpose16(acc, MZ, ndi.get_global_id(0),
@@ -315,7 +315,7 @@ bool runTest(unsigned MZ, unsigned block_size, unsigned num_iters,
           etime = esimd_test::report_time("kernel time", e, e);
       } else if (block_size == 8) {
         auto e = q.submit([&](handler &cgh) {
-          auto acc = buf.get_access<access::mode::read_write>(cgh);
+          auto acc = buf.get_access<access_mode::read_write>(cgh);
           cgh.parallel_for<class K08>(
               Range, [=](nd_item<2> ndi) SYCL_ESIMD_KERNEL {
                 transpose8(acc, MZ, ndi.get_global_id(0), ndi.get_global_id(1));

--- a/sycl/test-e2e/ESIMD/matrix_transpose2.cpp
+++ b/sycl/test-e2e/ESIMD/matrix_transpose2.cpp
@@ -303,8 +303,8 @@ bool runTest(unsigned MZ, unsigned block_size, unsigned num_iters,
       double etime = 0;
       if (block_size == 16 && MZ >= 16) {
         auto e = q.submit([&](handler &cgh) {
-          auto accInput = imgM.get_access<uint4, access::mode::read>(cgh);
-          auto accOutput = imgM.get_access<uint4, access::mode::write>(cgh);
+          auto accInput = imgM.get_access<uint4, access_mode::read>(cgh);
+          auto accOutput = imgM.get_access<uint4, access_mode::write>(cgh);
           cgh.parallel_for<class K16>(
               Range, [=](nd_item<2> ndi) SYCL_ESIMD_KERNEL {
                 transpose16(accInput, accOutput, MZ, ndi.get_global_id(0),
@@ -315,8 +315,8 @@ bool runTest(unsigned MZ, unsigned block_size, unsigned num_iters,
         etime = esimd_test::report_time("kernel time", e, e);
       } else if (block_size == 8) {
         auto e = q.submit([&](handler &cgh) {
-          auto accInput = imgM.get_access<uint4, access::mode::read>(cgh);
-          auto accOutput = imgM.get_access<uint4, access::mode::write>(cgh);
+          auto accInput = imgM.get_access<uint4, access_mode::read>(cgh);
+          auto accOutput = imgM.get_access<uint4, access_mode::write>(cgh);
           cgh.parallel_for<class K08>(
               Range, [=](nd_item<2> ndi) SYCL_ESIMD_KERNEL {
                 transpose8(accInput, accOutput, MZ, ndi.get_global_id(0),

--- a/sycl/test-e2e/ESIMD/named_barriers/allocate_barrier.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/allocate_barrier.cpp
@@ -95,7 +95,7 @@ bool test(QueueTY q) {
     sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acc = buf.template get_access<access::mode::write>(cgh);
+      auto acc = buf.template get_access<access_mode::write>(cgh);
       cgh.parallel_for<KernelID<case_num>>(
           Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
             // Threads - 1 named barriers required

--- a/sycl/test-e2e/ESIMD/named_barriers/exec_in_order.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/exec_in_order.cpp
@@ -59,7 +59,7 @@ bool test(QueueTY q) {
     sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acc = buf.template get_access<access::mode::write>(cgh);
+      auto acc = buf.template get_access<access_mode::write>(cgh);
       cgh.parallel_for<KernelID<case_num>>(
           Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
             // Threads - 1 named barriers required

--- a/sycl/test-e2e/ESIMD/named_barriers/exec_in_order_branched.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/exec_in_order_branched.cpp
@@ -58,7 +58,7 @@ bool test(QueueTY q) {
     sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acc = buf.get_access<access::mode::write>(cgh);
+      auto acc = buf.get_access<access_mode::write>(cgh);
       cgh.parallel_for<KernelID<case_num>>(
           Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
             // Threads - 1 named barriers required

--- a/sycl/test-e2e/ESIMD/named_barriers/loop.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/loop.cpp
@@ -47,7 +47,7 @@ bool test(QueueTY q) {
     sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acc = buf.get_access<access::mode::write>(cgh);
+      auto acc = buf.get_access<access_mode::write>(cgh);
       cgh.parallel_for<KernelID<case_num>>(
           Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
             // 2 named barriers, id 0 reserved for unnamed

--- a/sycl/test-e2e/ESIMD/named_barriers/loop_extended.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/loop_extended.cpp
@@ -48,7 +48,7 @@ bool test(QueueTY q) {
     sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acc = buf.get_access<access::mode::write>(cgh);
+      auto acc = buf.get_access<access_mode::write>(cgh);
       cgh.parallel_for<KernelID<case_num>>(
           Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
             // 2 named barriers, id 0 reserved for unnamed

--- a/sycl/test-e2e/ESIMD/named_barriers/multiple_wg.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/multiple_wg.cpp
@@ -49,7 +49,7 @@ bool test(QueueTY q) {
     sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acc = buf.get_access<access::mode::write>(cgh);
+      auto acc = buf.get_access<access_mode::write>(cgh);
       cgh.parallel_for<KernelID<case_num>>(
           Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
             // 1 named barrier, id 0 reserved for unnamed

--- a/sycl/test-e2e/ESIMD/named_barriers/single_wg.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/single_wg.cpp
@@ -51,7 +51,7 @@ bool test(QueueTY q) {
     sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acc = buf.get_access<access::mode::write>(cgh);
+      auto acc = buf.get_access<access_mode::write>(cgh);
       cgh.parallel_for<KernelID<case_num>>(
           Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
             // 1 named barrier, id 0 reserved for unnamed

--- a/sycl/test-e2e/ESIMD/noinline_call_from_func.cpp
+++ b/sycl/test-e2e/ESIMD/noinline_call_from_func.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
     buffer<int, 1> buf(output, range<1>(1));
 
     q.submit([&](handler &cgh) {
-      auto acc = buf.get_access<access::mode::write>(cgh);
+      auto acc = buf.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<KernelID>(
           sycl::range<1>{1},

--- a/sycl/test-e2e/ESIMD/popcount.cpp
+++ b/sycl/test-e2e/ESIMD/popcount.cpp
@@ -43,8 +43,8 @@ template <typename T> bool test(queue &q) {
     queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.template get_access<access::mode::read>(cgh);
-      auto PB = bufb.template get_access<access::mode::write>(cgh);
+      auto PA = bufa.template get_access<access_mode::read>(cgh);
+      auto PB = bufb.template get_access<access_mode::write>(cgh);
       cgh.parallel_for(GlobalRange * LocalRange,
                        [=](id<1> i) SYCL_ESIMD_KERNEL {
                          using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/regression/big_const_initializer.cpp
+++ b/sycl/test-e2e/ESIMD/regression/big_const_initializer.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
 
   try {
     queue.submit([&](sycl::handler &cgh) {
-      auto r_acc = r.template get_access<sycl::access::mode::write>(cgh);
+      auto r_acc = r.template get_access<sycl::access_mode::write>(cgh);
       cgh.parallel_for<class Test>(
           sycl::range<1>{nsamples / SIMD_WIDTH},
           [=](sycl::item<1> item) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/regression/copyto_char_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/copyto_char_test.cpp
@@ -56,7 +56,7 @@ template <int NumElems, bool IsAcc, int ResultOffset = 0> int test_to_copy() {
       DataT *init_ref_ptr = initial_ref_data.data();
       DataT *ref_data_for_fill_ptr = ref_data_for_fill.data();
       auto acc =
-          output_buf.template get_access<sycl::access::mode::read_write>(cgh);
+          output_buf.template get_access<sycl::access_mode::read_write>(cgh);
 
       cgh.single_task([=]() SYCL_ESIMD_KERNEL {
         simd<DataT, NumElems> src_simd_obj;

--- a/sycl/test-e2e/ESIMD/regression/fmod_compatibility_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/fmod_compatibility_test.cpp
@@ -16,7 +16,7 @@
 #include <sycl/detail/core.hpp>
 #include <vector>
 
-constexpr auto sycl_write = sycl::access::mode::write;
+constexpr auto sycl_write = sycl::access_mode::write;
 #define SIMD 16
 
 int test_fmod(float x, float y) {

--- a/sycl/test-e2e/ESIMD/regression/half_conversion_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/half_conversion_test.cpp
@@ -42,7 +42,7 @@ template <class Ty> bool test(queue q, int inc) {
       std::cout << "Running on "
                 << q.get_device().get_info<::sycl::info::device::name>()
                 << "\n";
-      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      auto acc = buf.template get_access<access_mode::read_write>(cgh);
       cgh.single_task([=]() SYCL_ESIMD_KERNEL {
         simd<uint32_t, 1> offsets(0);
         simd<Ty, 1> vec = gather<Ty, 1>(acc, offsets);

--- a/sycl/test-e2e/ESIMD/regression/operator_decrement.cpp
+++ b/sycl/test-e2e/ESIMD/regression/operator_decrement.cpp
@@ -40,7 +40,7 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class Test>(
           GlobalRange * LocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/regression/sycl_esimd_mixed_unnamed.cpp
+++ b/sycl/test-e2e/ESIMD/regression/sycl_esimd_mixed_unnamed.cpp
@@ -61,7 +61,7 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for(GlobalRange * LocalRange,
                        [=](id<1> i) { PA[i] = PA[i] + 1; });
     });
@@ -92,7 +92,7 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for(GlobalRange * LocalRange,
                        [=](id<1> i) SYCL_ESIMD_KERNEL {
                          using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/regression/tanh_fix_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/tanh_fix_test.cpp
@@ -16,7 +16,7 @@
 #include <sycl/ext/intel/esimd/simd.hpp>
 #include <vector>
 
-constexpr auto sycl_write = sycl::access::mode::write;
+constexpr auto sycl_write = sycl::access_mode::write;
 #define SIMD 16
 
 int test_tanh(float x) {

--- a/sycl/test-e2e/ESIMD/regression/unused_load.cpp
+++ b/sycl/test-e2e/ESIMD/regression/unused_load.cpp
@@ -34,7 +34,7 @@ int main() {
       std::cout << "Running on "
                 << q.get_device().get_info<sycl::info::device::name>() << "\n";
 
-      auto acc0 = buf0.get_access<access::mode::read_write>(cgh);
+      auto acc0 = buf0.get_access<access_mode::read_write>(cgh);
 
       cgh.parallel_for<class Test>(range<1>(1),
                                    [=](sycl::id<1> i) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/regression/variable_gather_mask.cpp
+++ b/sycl/test-e2e/ESIMD/regression/variable_gather_mask.cpp
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
     sycl::buffer<int, 1> Bbuf(B, range<1>(VL));
 
     return q.submit([&](handler &cgh) {
-      auto b = Bbuf.template get_access<access::mode::read_write>(cgh);
+      auto b = Bbuf.template get_access<access_mode::read_write>(cgh);
       KernelAcc kernel(b);
       cgh.single_task(kernel);
     });

--- a/sycl/test-e2e/ESIMD/spec_const/Inputs/spec-const-2020-common.hpp
+++ b/sycl/test-e2e/ESIMD/spec_const/Inputs/spec-const-2020-common.hpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
       sycl::buffer<container_t, 1> buf(output.data(), output.size());
 
       q.submit([&](sycl::handler &cgh) {
-         auto acc = buf.get_access<sycl::access::mode::write>(cgh);
+         auto acc = buf.get_access<sycl::access_mode::write>(cgh);
          if (i % 2 != 0)
            cgh.set_specialization_constant<ConstID>(REDEF_VAL);
          cgh.single_task<TestKernel>([=](kernel_handler kh) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/spec_const/spec_const_redefine.cpp
+++ b/sycl/test-e2e/ESIMD/spec_const/spec_const_redefine.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
         cgh.set_specialization_constant<SC1>(9999);
         cgh.set_specialization_constant<SC0>(sc_set[0]);
         cgh.set_specialization_constant<SC1>(sc_set[1]);
-        auto acc = buf.get_access<sycl::access::mode::write>(cgh);
+        auto acc = buf.get_access<sycl::access_mode::write>(cgh);
         cgh.single_task<class KernelAAA>(
             [=](kernel_handler kh) SYCL_ESIMD_KERNEL {
               auto SC0Val = kh.get_specialization_constant<SC0>();

--- a/sycl/test-e2e/ESIMD/sycl_esimd_mix.cpp
+++ b/sycl/test-e2e/ESIMD/sycl_esimd_mix.cpp
@@ -61,7 +61,7 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class SyclKernel>(GlobalRange * LocalRange,
                                          [=](id<1> i) { PA[i] = PA[i] + 1; });
     });
@@ -92,7 +92,7 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class EsimdKernel>(
           GlobalRange * LocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/template.cpp
+++ b/sycl/test-e2e/ESIMD/template.cpp
@@ -25,9 +25,9 @@ sycl::event createKernel(sycl::queue &q, buffer<T, 1> &bufa, buffer<T, 1> &bufb,
   // We need that many threads in each group
   range<1> LocalRange{1};
   return q.submit([&](handler &cgh) {
-    auto PA = bufa.template get_access<access::mode::read>(cgh);
-    auto PB = bufb.template get_access<access::mode::read>(cgh);
-    auto PC = bufc.template get_access<access::mode::write>(cgh);
+    auto PA = bufa.template get_access<access_mode::read>(cgh);
+    auto PB = bufb.template get_access<access_mode::read>(cgh);
+    auto PC = bufc.template get_access<access_mode::write>(cgh);
     cgh.parallel_for<class Test>(GlobalRange * LocalRange,
                                  [=](id<1> i) SYCL_ESIMD_KERNEL {
                                    using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
@@ -281,7 +281,7 @@ bool test_acc(queue &q, const Config &cfg) {
       buffer<T, 1> arr_buf(arr, range<1>(size));
       auto e = q.submit([&](handler &cgh) {
         auto arr_acc =
-            arr_buf.template get_access<access::mode::read_write>(cgh);
+            arr_buf.template get_access<access_mode::read_write>(cgh);
         cgh.parallel_for(rng, [=](nd_item<1> ndi) SYCL_ESIMD_KERNEL {
           int i = ndi.get_global_id(0);
           simd<Toffset, N> offsets(cfg.start_ind * sizeof(T),

--- a/sycl/test-e2e/ESIMD/vadd_1d.cpp
+++ b/sycl/test-e2e/ESIMD/vadd_1d.cpp
@@ -43,9 +43,9 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class Test>(
           GlobalRange * LocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/vadd_2d.cpp
+++ b/sycl/test-e2e/ESIMD/vadd_2d.cpp
@@ -49,9 +49,9 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto accA = imgA.get_access<uint4, access::mode::read>(cgh);
-      auto accB = imgB.get_access<uint4, access::mode::read>(cgh);
-      auto accC = imgC.get_access<uint4, access::mode::write>(cgh);
+      auto accA = imgA.get_access<uint4, access_mode::read>(cgh);
+      auto accB = imgB.get_access<uint4, access_mode::read>(cgh);
+      auto accC = imgC.get_access<uint4, access_mode::write>(cgh);
 
       cgh.parallel_for<class Test>(
           GlobalRange * LocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {

--- a/sycl/test-e2e/ESIMD/vadd_2d_acc.cpp
+++ b/sycl/test-e2e/ESIMD/vadd_2d_acc.cpp
@@ -49,9 +49,9 @@ int main(void) {
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class Test>(
           Range, [=](nd_item<2> ndi) SYCL_ESIMD_KERNEL {
             using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/InvokeSimd/Feature/popcnt_emu.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/popcnt_emu.cpp
@@ -108,7 +108,7 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto out_accessor = buf.get_access<access::mode::write>(cgh);
+      auto out_accessor = buf.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<class Test>(
           nd_range<1>(GlobalRange, LocalRange),

--- a/sycl/test-e2e/InvokeSimd/Feature/scale.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/scale.cpp
@@ -90,8 +90,8 @@ template <class T, class QueueTY> bool test(QueueTY q) {
     sycl::range<1> LocalRange{VL};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acca = bufa.template get_access<access::mode::read>(cgh);
-      auto accc = bufc.template get_access<access::mode::write>(cgh);
+      auto acca = bufa.template get_access<access_mode::read>(cgh);
+      auto accc = bufc.template get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<TestID<T>>(
           nd_range<1>(GlobalRange, LocalRange),

--- a/sycl/test-e2e/InvokeSimd/Feature/void_retval.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/void_retval.cpp
@@ -91,9 +91,9 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<class Test>(
           nd_range<1>(GlobalRange, LocalRange),

--- a/sycl/test-e2e/InvokeSimd/Regression/call_vadd_1d_spill.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/call_vadd_1d_spill.cpp
@@ -93,16 +93,16 @@ bool test(QueueTY q, float *A, float *B, float *C, float *P, float *Q, float *R,
     sycl::range<1> LocalRange{VL};
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PP = bufp.get_access<access::mode::read>(cgh);
-      auto PQ = bufq.get_access<access::mode::read>(cgh);
-      auto PR = bufr.get_access<access::mode::read>(cgh);
-      auto PX = bufx.get_access<access::mode::read>(cgh);
-      auto PY = bufy.get_access<access::mode::read>(cgh);
-      auto PZ = bufz.get_access<access::mode::read>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PP = bufp.get_access<access_mode::read>(cgh);
+      auto PQ = bufq.get_access<access_mode::read>(cgh);
+      auto PR = bufr.get_access<access_mode::read>(cgh);
+      auto PX = bufx.get_access<access_mode::read>(cgh);
+      auto PY = bufy.get_access<access_mode::read>(cgh);
+      auto PZ = bufz.get_access<access_mode::read>(cgh);
 
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<TestID<Size, VL, use_invoke_simd, CaseNum>>(
           nd_range<1>(GlobalRange, LocalRange),

--- a/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
@@ -73,9 +73,9 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<class Test>(
           nd_range<1>(GlobalRange, LocalRange),

--- a/sycl/test-e2e/InvokeSimd/Spec/ESIMD_to_unmarked_function.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ESIMD_to_unmarked_function.cpp
@@ -107,9 +107,9 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<class Test>(
           nd_range<1>(GlobalRange, LocalRange),

--- a/sycl/test-e2e/InvokeSimd/Spec/function_overloads.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/function_overloads.cpp
@@ -105,8 +105,8 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<class Test>(
           nd_range<1>(GlobalRange, LocalRange),

--- a/sycl/test-e2e/InvokeSimd/Spec/nested_ESIMD_to_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/nested_ESIMD_to_ESIMD.cpp
@@ -91,9 +91,9 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<class Test>(
           nd_range<1>(GlobalRange, LocalRange),

--- a/sycl/test-e2e/InvokeSimd/Spec/nested_SPMD_to_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/nested_SPMD_to_ESIMD.cpp
@@ -96,9 +96,9 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read>(cgh);
-      auto PB = bufb.get_access<access::mode::read>(cgh);
-      auto PC = bufc.get_access<access::mode::write>(cgh);
+      auto PA = bufa.get_access<access_mode::read>(cgh);
+      auto PB = bufb.get_access<access_mode::read>(cgh);
+      auto PC = bufc.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<class Test>(
           nd_range<1>(GlobalRange, LocalRange),

--- a/sycl/test-e2e/InvokeSimd/Spec/uniform_retval.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/uniform_retval.cpp
@@ -160,8 +160,8 @@ template <class T, bool return_SIMD, class QueueTY> bool test(QueueTY q) {
     sycl::range<1> LocalRange{VL};
 
     auto e = q.submit([&](handler &cgh) {
-      auto acca = bufa.template get_access<access::mode::read>(cgh);
-      auto accc = bufc.template get_access<access::mode::write>(cgh);
+      auto acca = bufa.template get_access<access_mode::read>(cgh);
+      auto accc = bufc.template get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<TestID<T, return_SIMD>>(
           nd_range<1>(GlobalRange, LocalRange),


### PR DESCRIPTION
access::mode is deprecated in favor of access_mode.
PR to add deprecations: https://github.com/intel/llvm/pull/22803