### PR TITLE
[SYCL] Update Adapters tests to use access_mode

### DIFF
--- a/sycl/test-e2e/Adapters/enqueue-arg-order-buffer.cpp
+++ b/sycl/test-e2e/Adapters/enqueue-arg-order-buffer.cpp
@@ -90,11 +90,11 @@ void testDetailConvertToArrayOfN() {
 
 // class to give access to protected function getLinearIndex
 template <typename T, int Dims>
-class AccTest : public accessor<T, Dims, access::mode::read_write,
+class AccTest : public accessor<T, Dims, access_mode::read_write,
                                 access::target::host_buffer,
                                 access::placeholder::false_t> {
   using AccessorT =
-      accessor<T, Dims, access::mode::read_write, access::target::host_buffer,
+      accessor<T, Dims, access_mode::read_write, access::target::host_buffer,
                access::placeholder::false_t>;
 
 public:
@@ -178,8 +178,8 @@ void testcopyD2HBuffer() {
     buffer<float, 1> buffer_to_1D(data_to_1D.data(), range<1>(width));
     queue myQueue;
     myQueue.submit([&](handler &cgh) {
-      auto read = buffer_from_1D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_1D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_1D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_1D.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class copyD2H_1D>(
           buffer_from_1D.get_range(),
           [=](id<1> index) { write[index] = read[index] * -1; });
@@ -192,8 +192,8 @@ void testcopyD2HBuffer() {
     buffer<float, 2> buffer_to_2D(data_to_2D.data(), range<2>(height, width));
     queue myQueue;
     myQueue.submit([&](handler &cgh) {
-      auto read = buffer_from_2D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_2D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_2D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_2D.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class copyD2H_2D>(
           buffer_from_2D.get_range(),
           [=](id<2> index) { write[index] = read[index] * -1; });
@@ -207,8 +207,8 @@ void testcopyD2HBuffer() {
                                   range<3>(depth, height, width));
     queue myQueue;
     myQueue.submit([&](handler &cgh) {
-      auto read = buffer_from_3D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_3D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_3D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_3D.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class copyD2H_3D>(
           buffer_from_3D.get_range(),
           [=](id<3> index) { write[index] = read[index] * -1; });
@@ -242,8 +242,8 @@ void testcopyH2DBuffer() {
     queue myQueue{myCtx, Dev};
     queue otherQueue{otherCtx, Dev};
     myQueue.submit([&](handler &cgh) {
-      auto read = buffer_from_1D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_1D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_1D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_1D.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class copyH2D_1D>(
           buffer_from_1D.get_range(),
           [=](id<1> index) { write[index] = read[index] * -1; });
@@ -251,8 +251,8 @@ void testcopyH2DBuffer() {
     myQueue.wait();
 
     otherQueue.submit([&](handler &cgh) {
-      auto read = buffer_from_1D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_1D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_1D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_1D.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class copyH2D_1D_2nd>(
           buffer_from_1D.get_range(),
           [=](id<1> index) { write[index] = read[index] * 10; });
@@ -271,16 +271,16 @@ void testcopyH2DBuffer() {
     queue myQueue{myCtx, Dev};
     queue otherQueue{otherCtx, Dev};
     myQueue.submit([&](handler &cgh) {
-      auto read = buffer_from_2D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_2D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_2D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_2D.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class copyH2D_2D>(
           buffer_from_2D.get_range(),
           [=](id<2> index) { write[index] = read[index] * -1; });
     });
 
     otherQueue.submit([&](handler &cgh) {
-      auto read = buffer_from_2D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_2D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_2D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_2D.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class copyH2D_2D_2nd>(
           buffer_from_2D.get_range(),
           [=](id<2> index) { write[index] = read[index] * 10; });
@@ -300,16 +300,16 @@ void testcopyH2DBuffer() {
     queue myQueue{myCtx, Dev};
     queue otherQueue{otherCtx, Dev};
     myQueue.submit([&](handler &cgh) {
-      auto read = buffer_from_3D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_3D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_3D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_3D.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class copyH2D_3D>(
           buffer_from_3D.get_range(),
           [=](id<3> index) { write[index] = read[index] * -1; });
     });
 
     otherQueue.submit([&](handler &cgh) {
-      auto read = buffer_from_3D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_3D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_3D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_3D.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class copyH2D_3D_2nd>(
           buffer_from_3D.get_range(),
           [=](id<3> index) { write[index] = read[index] * 10; });
@@ -340,20 +340,20 @@ void testcopyD2DBuffer() {
 
     queue myQueue;
     auto e1 = myQueue.submit([&](handler &cgh) {
-      auto read = buffer_from_1D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_1D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_1D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_1D.get_access<access_mode::write>(cgh);
       cgh.copy(read, write);
     });
     auto e2 = myQueue.submit([&](handler &cgh) {
       cgh.depends_on(e1);
-      auto read = buffer_from_2D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_2D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_2D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_2D.get_access<access_mode::write>(cgh);
       cgh.copy(read, write);
     });
     auto e3 = myQueue.submit([&](handler &cgh) {
       cgh.depends_on(e2);
-      auto read = buffer_from_3D.get_access<access::mode::read>(cgh);
-      auto write = buffer_to_3D.get_access<access::mode::write>(cgh);
+      auto read = buffer_from_3D.get_access<access_mode::read>(cgh);
+      auto write = buffer_to_3D.get_access<access_mode::write>(cgh);
       cgh.copy(read, write);
     });
 
@@ -373,17 +373,17 @@ void testFill_Buffer() {
 
     queue myQueue;
     auto e1 = myQueue.submit([&](handler &cgh) {
-      auto acc1D = buffer_1D.get_access<sycl::access::mode::write>(cgh);
+      auto acc1D = buffer_1D.get_access<sycl::access_mode::write>(cgh);
       cgh.fill(acc1D, float{1});
     });
     auto e2 = myQueue.submit([&](handler &cgh) {
       cgh.depends_on(e1);
-      auto acc2D = buffer_2D.get_access<sycl::access::mode::write>(cgh);
+      auto acc2D = buffer_2D.get_access<sycl::access_mode::write>(cgh);
       cgh.fill(acc2D, float{2});
     });
     auto e3 = myQueue.submit([&](handler &cgh) {
       cgh.depends_on(e2);
-      auto acc3D = buffer_3D.get_access<sycl::access::mode::write>(cgh);
+      auto acc3D = buffer_3D.get_access<sycl::access_mode::write>(cgh);
       cgh.fill(acc3D, float{3});
     });
   } // ~buffer

--- a/sycl/test-e2e/Adapters/enqueue-arg-order-image.cpp
+++ b/sycl/test-e2e/Adapters/enqueue-arg-order-image.cpp
@@ -73,8 +73,8 @@ void testcopyD2HImage() {
   // image with write accessor to it in kernel
   const sycl::image_channel_order ChanOrder = sycl::image_channel_order::rgba;
   const sycl::image_channel_type ChanType = sycl::image_channel_type::fp32;
-  constexpr auto SYCLRead = sycl::access::mode::read;
-  constexpr auto SYCLWrite = sycl::access::mode::write;
+  constexpr auto SYCLRead = sycl::access_mode::read;
+  constexpr auto SYCLWrite = sycl::access_mode::write;
 
   const sycl::range<1> ImgSize_1D(width);
   // for a buffer, a range<2> would be  (height, width).
@@ -162,8 +162,8 @@ void testcopyH2DImage() {
 
   const sycl::image_channel_order ChanOrder = sycl::image_channel_order::rgba;
   const sycl::image_channel_type ChanType = sycl::image_channel_type::fp32;
-  constexpr auto SYCLRead = sycl::access::mode::read;
-  constexpr auto SYCLWrite = sycl::access::mode::write;
+  constexpr auto SYCLRead = sycl::access_mode::read;
+  constexpr auto SYCLWrite = sycl::access_mode::write;
 
   const sycl::range<1> ImgSize_1D(width);
   // for a buffer, a range<2> would be  (height, width).

--- a/sycl/test-e2e/Adapters/interop-cuda-experimental.cpp
+++ b/sycl/test-e2e/Adapters/interop-cuda-experimental.cpp
@@ -34,9 +34,9 @@ bool check_queue(sycl::queue &Q) {
   sycl::buffer<double, 1> C_buff(C_Data, sycl::range<1>(vec_size));
 
   Q.submit([&](sycl::handler &cgh) {
-     auto A_acc = A_buff.get_access<sycl::access::mode::read>(cgh);
-     auto B_acc = B_buff.get_access<sycl::access::mode::read>(cgh);
-     auto C_acc = C_buff.get_access<sycl::access::mode::write>(cgh);
+     auto A_acc = A_buff.get_access<sycl::access_mode::read>(cgh);
+     auto B_acc = B_buff.get_access<sycl::access_mode::read>(cgh);
+     auto C_acc = C_buff.get_access<sycl::access_mode::write>(cgh);
      cgh.parallel_for(sycl::range<1>{vec_size}, [=](sycl::id<1> idx) {
        C_acc[idx] = A_acc[idx] + B_acc[idx];
      });

--- a/sycl/test-e2e/Adapters/interop-opencl.cpp
+++ b/sycl/test-e2e/Adapters/interop-opencl.cpp
@@ -29,7 +29,7 @@ int main() {
   sycl::buffer<int, 1> Buffer(&Data[0], sycl::range<1>(1));
   {
     Queue.submit([&](sycl::handler &cgh) {
-      auto Acc = Buffer.get_access<sycl::access::mode::read_write>(cgh);
+      auto Acc = Buffer.get_access<sycl::access_mode::read_write>(cgh);
       cgh.host_task([=](const sycl::interop_handle &ih) {
         (void)Acc;
         auto BufNative = ih.get_native_mem<sycl::backend::opencl>(Acc);

--- a/sycl/test-e2e/Adapters/level_zero/eager_init.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/eager_init.cpp
@@ -30,8 +30,8 @@
 #include <array>
 #include <iostream>
 
-constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
-constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
+constexpr sycl::access_mode sycl_read = sycl::access_mode::read;
+constexpr sycl::access_mode sycl_write = sycl::access_mode::write;
 
 /* This is the class used to name the kernel for the runtime.
  * This must be done when the kernel is expressed as a lambda. */

--- a/sycl/test-e2e/Adapters/level_zero/events_caching_leak.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/events_caching_leak.cpp
@@ -10,8 +10,8 @@
 #include <array>
 #include <sycl/detail/core.hpp>
 
-constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
-constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
+constexpr sycl::access_mode sycl_read = sycl::access_mode::read;
+constexpr sycl::access_mode sycl_write = sycl::access_mode::write;
 
 int main() {
   sycl::queue deviceQueue;

--- a/sycl/test-e2e/Adapters/level_zero/interop-buffer-multi-dim.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-buffer-multi-dim.cpp
@@ -72,7 +72,7 @@ int main() {
       auto Buf2D = BufferInterop.reinterpret<int>(range<2>(4, 6));
 
       Queue.submit([&](sycl::handler &CGH) {
-        auto Acc2D = Buf2D.get_access<sycl::access::mode::read_write>(CGH);
+        auto Acc2D = Buf2D.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel2D>([=]() {
           for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 6; j++) {
@@ -97,7 +97,7 @@ int main() {
       auto Buf3D = BufferInterop.reinterpret<int>(range<3>(4, 2, 3));
 
       Queue.submit([&](sycl::handler &CGH) {
-        auto Acc3D = Buf3D.get_access<sycl::access::mode::read_write>(CGH);
+        auto Acc3D = Buf3D.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel3D>([=]() {
           for (int i = 0; i < 4; i++) {
             for (int j = 0; j < 2; j++) {

--- a/sycl/test-e2e/Adapters/level_zero/interop-buffer-ownership.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-buffer-ownership.cpp
@@ -88,8 +88,7 @@ void test_copyback_and_free(
           BufferInteropInput, Context);
 
       auto Event = Queue1.submit([&](sycl::handler &CGH) {
-        auto Acc =
-            BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
+        auto Acc = BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel6>([=]() {
           for (int i = 0; i < 12; i++) {
             Acc[i] = 99;
@@ -100,8 +99,7 @@ void test_copyback_and_free(
 
       // Submit in a different context
       Queue2.submit([&](sycl::handler &CGH) {
-        auto Acc =
-            BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
+        auto Acc = BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel7>([=]() {
           for (int i = 0; i < 12; i++) {
             Acc[i] *= 2;

--- a/sycl/test-e2e/Adapters/level_zero/interop-buffer-ownership.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-buffer-ownership.cpp
@@ -89,7 +89,7 @@ void test_copyback_and_free(
 
       auto Event = Queue1.submit([&](sycl::handler &CGH) {
         auto Acc =
-            BufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+            BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel6>([=]() {
           for (int i = 0; i < 12; i++) {
             Acc[i] = 99;
@@ -101,7 +101,7 @@ void test_copyback_and_free(
       // Submit in a different context
       Queue2.submit([&](sycl::handler &CGH) {
         auto Acc =
-            BufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+            BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel7>([=]() {
           for (int i = 0; i < 12; i++) {
             Acc[i] *= 2;

--- a/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
@@ -93,8 +93,8 @@ int main() {
 
     Queue.submit([&](sycl::handler &CGH) {
       auto Acc1 =
-          HostBufferInterop1.get_access<sycl::access::mode::read_write>(CGH);
-      auto Acc2 = HostBufferInterop2.get_access<sycl::access::mode::read_write>(
+          HostBufferInterop1.get_access<sycl::access_mode::read_write>(CGH);
+      auto Acc2 = HostBufferInterop2.get_access<sycl::access_mode::read_write>(
           CGH, range<1>(12));
 
       CGH.single_task<class SimpleKernel1>([=]() {
@@ -127,8 +127,8 @@ int main() {
     auto SubBuffer2 = buffer(HostBufferInterop2, id<1>(3), range<1>(9));
 
     Queue.submit([&](sycl::handler &CGH) {
-      auto Acc1 = SubBuffer1.get_access<sycl::access::mode::read_write>(CGH);
-      auto Acc2 = SubBuffer2.get_access<sycl::access::mode::read_write>(CGH);
+      auto Acc1 = SubBuffer1.get_access<sycl::access_mode::read_write>(CGH);
+      auto Acc2 = SubBuffer2.get_access<sycl::access_mode::read_write>(CGH);
       CGH.single_task<class SimpleKernel2>([=]() {
         for (int i = 0; i < 3; i++) {
           Acc1[i] = 77;
@@ -160,7 +160,7 @@ int main() {
     queue Queue1(Context1, default_selector_v);
     Queue1.submit([&](sycl::handler &CGH) {
       auto Acc =
-          HostBufferInterop2.get_access<sycl::access::mode::read_write>(CGH);
+          HostBufferInterop2.get_access<sycl::access_mode::read_write>(CGH);
       CGH.single_task<class SimpleKernel3>([=]() {
         for (int i = 0; i < 12; i++) {
           Acc[i] = 99;
@@ -172,7 +172,7 @@ int main() {
     queue Queue2(Context2, default_selector_v);
     Queue2.submit([&](sycl::handler &CGH) {
       auto Acc =
-          HostBufferInterop2.get_access<sycl::access::mode::read_write>(CGH);
+          HostBufferInterop2.get_access<sycl::access_mode::read_write>(CGH);
       CGH.single_task<class SimpleKernel4>([=]() {
         for (int i = 0; i < 12; i++) {
           Acc[i] *= 2;
@@ -249,9 +249,9 @@ int main() {
 
     Queue.submit([&](sycl::handler &CGH) {
       auto Acc1 =
-          SharedBufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+          SharedBufferInterop.get_access<sycl::access_mode::read_write>(CGH);
       auto Acc2 =
-          DeviceBufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+          DeviceBufferInterop.get_access<sycl::access_mode::read_write>(CGH);
       CGH.single_task<class SimpleKernel5>([=]() {
         for (int i = 0; i < 12; i++) {
           Acc1[i] += 77;
@@ -277,7 +277,7 @@ int main() {
     // Use device buffer in two different contexts
     Queue.submit([&](sycl::handler &CGH) {
       auto Acc =
-          DeviceBufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+          DeviceBufferInterop.get_access<sycl::access_mode::read_write>(CGH);
       CGH.single_task<class SimpleKernel6>([=]() {
         for (int i = 0; i < 12; i++) {
           Acc[i] = 99;
@@ -291,7 +291,7 @@ int main() {
     queue Queue2{Context2, Dev2};
     Queue2.submit([&](sycl::handler &CGH) {
       auto Acc =
-          DeviceBufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+          DeviceBufferInterop.get_access<sycl::access_mode::read_write>(CGH);
       CGH.single_task<class SimpleKernel7>([=]() {
         for (int i = 0; i < 12; i++) {
           Acc[i] *= 2;
@@ -303,7 +303,7 @@ int main() {
     queue Queue3;
     Queue3.submit([&](sycl::handler &CGH) {
       auto Acc =
-          DeviceBufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+          DeviceBufferInterop.get_access<sycl::access_mode::read_write>(CGH);
       CGH.single_task<class SimpleKernel8>([=]() {
         for (int i = 0; i < 12; i++) {
           Acc[i] += 2;

--- a/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
@@ -88,8 +88,7 @@ int main() {
           BufferInteropInput, Context);
 
       auto Event = Queue1.submit([&](sycl::handler &CGH) {
-        auto Acc =
-            BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
+        auto Acc = BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel6>([=]() {
           for (int i = 0; i < 12; i++) {
             Acc[i] = 99;
@@ -100,8 +99,7 @@ int main() {
 
       // Submit in a different context
       Queue2.submit([&](sycl::handler &CGH) {
-        auto Acc =
-            BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
+        auto Acc = BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel7>([=]() {
           for (int i = 0; i < 12; i++) {
             Acc[i] *= 2;

--- a/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-get-native-mem.cpp
@@ -89,7 +89,7 @@ int main() {
 
       auto Event = Queue1.submit([&](sycl::handler &CGH) {
         auto Acc =
-            BufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+            BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel6>([=]() {
           for (int i = 0; i < 12; i++) {
             Acc[i] = 99;
@@ -101,7 +101,7 @@ int main() {
       // Submit in a different context
       Queue2.submit([&](sycl::handler &CGH) {
         auto Acc =
-            BufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+            BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel7>([=]() {
           for (int i = 0; i < 12; i++) {
             Acc[i] *= 2;
@@ -113,7 +113,7 @@ int main() {
 
       Queue1
           .submit([&](handler &CGH) {
-            auto BufferAcc = BufferInterop.get_access<access::mode::write>(CGH);
+            auto BufferAcc = BufferInterop.get_access<access_mode::write>(CGH);
             CGH.host_task([=](const interop_handle &IH) {
               void *DevicePtr =
                   IH.get_native_mem<backend::ext_oneapi_level_zero>(BufferAcc);

--- a/sycl/test-e2e/Adapters/level_zero/interop-image-get-native-mem.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-image-get-native-mem.cpp
@@ -93,7 +93,7 @@ int main() {
 
     Q.submit([&](handler &cgh) {
        auto image_acc =
-           image_2D.get_access<pixelT, sycl::access::mode::read>(cgh);
+           image_2D.get_access<pixelT, sycl::access_mode::read>(cgh);
        auto passBackAcc = passBack.get_host_access(sycl::write_only);
        cgh.host_task([=](const interop_handle &IH) {
          // There is nothing with image handles in the L0 API except
@@ -113,7 +113,7 @@ int main() {
 
     // Then use that image to read and stream out the data.
     Q.submit([&](handler &cgh) {
-       auto read_acc = NewImg.get_access<pixelT, sycl::access::mode::read>(cgh);
+       auto read_acc = NewImg.get_access<pixelT, sycl::access_mode::read>(cgh);
        sycl::stream out(2024, 400, cgh);
        cgh.single_task([=]() {
          for (unsigned y = 0; y < height; y++) {

--- a/sycl/test-e2e/Adapters/level_zero/interop-image-ownership.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-image-ownership.cpp
@@ -123,7 +123,7 @@ void test(sycl::ext::oneapi::level_zero::ownership Ownership) {
 
       Queue.submit([&](sycl::handler &cgh) {
         auto write_acc =
-            Image_2D.get_access<pixelT, sycl::access::mode::write>(cgh);
+            Image_2D.get_access<pixelT, sycl::access_mode::write>(cgh);
 
         cgh.parallel_for(ImgRange_2D, [=](sycl::item<2> Item) {
           auto location = sycl::int2{Item[0], Item[1]};

--- a/sycl/test-e2e/Adapters/level_zero/interop-image.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-image.cpp
@@ -117,7 +117,7 @@ int main() {
 
       Queue.submit([&](sycl::handler &cgh) {
         auto write_acc =
-            Image_1D.get_access<pixelT, sycl::access::mode::write>(cgh);
+            Image_1D.get_access<pixelT, sycl::access_mode::write>(cgh);
 
         cgh.parallel_for(ImgRange_1D, [=](sycl::item<1> Item) {
           int x = Item[0];
@@ -128,7 +128,7 @@ int main() {
       Queue.wait_and_throw();
 
       // now check with host accessor.
-      auto read_acc = Image_1D.get_access<pixelT, access::mode::read>();
+      auto read_acc = Image_1D.get_access<pixelT, access_mode::read>();
       for (int col = 0; col < width; col++) {
         const pixelT somePixel = read_acc.read(col);
         // const pixelT expectedPixel = {col,col,col,col};
@@ -161,7 +161,7 @@ int main() {
 
       Queue.submit([&](sycl::handler &cgh) {
         auto write_acc =
-            Image_2D.get_access<pixelT, sycl::access::mode::write>(cgh);
+            Image_2D.get_access<pixelT, sycl::access_mode::write>(cgh);
 
         cgh.parallel_for(ImgRange_2D, [=](sycl::item<2> Item) {
           auto location = sycl::int2{Item[0], Item[1]};
@@ -173,7 +173,7 @@ int main() {
       Queue.wait_and_throw();
 
       // now check with host accessor.
-      auto read_acc = Image_2D.get_access<pixelT, access::mode::read>();
+      auto read_acc = Image_2D.get_access<pixelT, access_mode::read>();
       for (int row = 0; row < height; row++) {
         for (int col = 0; col < width; col++) {
           auto location = sycl::int2{col, row};
@@ -210,7 +210,7 @@ int main() {
 
       Queue.submit([&](sycl::handler &cgh) {
         auto write_acc =
-            Image_3D.get_access<pixelT, sycl::access::mode::write>(cgh);
+            Image_3D.get_access<pixelT, sycl::access_mode::write>(cgh);
 
         cgh.parallel_for(ImgRange_3D, [=](sycl::item<3> Item) {
           auto location = sycl::int4{Item[0], Item[1], Item[2], 0};
@@ -222,7 +222,7 @@ int main() {
       Queue.wait_and_throw();
 
       // now check with host accessor.
-      auto read_acc = Image_3D.get_access<pixelT, access::mode::read>();
+      auto read_acc = Image_3D.get_access<pixelT, access_mode::read>();
       for (int row = 0; row < height; row++) {
         for (int col = 0; col < width; col++) {
           for (int z = 0; z < depth; z++) {

--- a/sycl/test-e2e/Adapters/level_zero/interop.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop.cpp
@@ -96,7 +96,7 @@ int main() {
   {
     sycl::buffer<int, 1> Buf(Arr, 1);
     QueueInterop.submit([&](sycl::handler &CGH) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(CGH);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(CGH);
       CGH.single_task<class SimpleKernel>([=]() { Acc[0] *= 3; });
     });
   }

--- a/sycl/test-e2e/Adapters/sycl-targets-order.cpp
+++ b/sycl/test-e2e/Adapters/sycl-targets-order.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
   // submit a command group(work) to the queue
   queue.submit([&](sycl::handler &cgh) {
     // get write only access to the buffer on a device
-    auto accessor = buffer.get_access<sycl::access::mode::write>(cgh);
+    auto accessor = buffer.get_access<sycl::access_mode::write>(cgh);
     // executing the kernel
     cgh.parallel_for<class FillBuffer>(NumOfWorkItems, [=](sycl::id<1> WIid) {
       // fill the buffer with indexes


### PR DESCRIPTION
access::mode is deprecated in favor of access_mode.
PR to add deprecations: https://github.com/intel/llvm/pull/22803