### PR TITLE
[SYCL] Update Sanitizer tests to use access_mode

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/common/kernel-filter.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/kernel-filter.cpp
@@ -19,7 +19,7 @@ int main() {
   sycl::buffer<int, 1> buf(v.data(), v.size());
 
   Q.submit([&](sycl::handler &h) {
-    auto buf_acc = buf.get_access<sycl::access::mode::read_write>(h);
+    auto buf_acc = buf.get_access<sycl::access_mode::read_write>(h);
     auto loc_acc = sycl::local_accessor<int>(group_size, h);
     h.parallel_for<class MyKernel>(
         sycl::nd_range<1>(N, group_size), [=](sycl::nd_item<1> item) {

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer.cpp
@@ -21,7 +21,7 @@ int main() {
     // we need to cover that pattern here.
     sycl::buffer<int, 1> buf(v.data(), v.size());
     q.submit([&](sycl::handler &h) {
-       auto A = buf.get_access<sycl::access::mode::read_write>(h);
+       auto A = buf.get_access<sycl::access_mode::read_write>(h);
        h.parallel_for<class Test>(
            sycl::nd_range<1>(N + 1, 1),
            [=](sycl::nd_item<1> item) { A[item.get_global_id()] *= 2; });

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_2d.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_2d.cpp
@@ -20,7 +20,7 @@ int main() {
   sycl::queue q;
 
   q.submit([&](sycl::handler &cgh) {
-     auto accessor = buf.get_access<sycl::access::mode::read_write>(cgh);
+     auto accessor = buf.get_access<sycl::access_mode::read_write>(cgh);
      cgh.parallel_for<class Test>(
          sycl::nd_range<2>({size_x, size_y + 1}, {1, 1}),
          [=](sycl::nd_item<2> item) {

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_3d.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_3d.cpp
@@ -25,7 +25,7 @@ int main() {
   sycl::queue q;
 
   q.submit([&](sycl::handler &cgh) {
-     auto accessor = buf.get_access<sycl::access::mode::read_write>(cgh);
+     auto accessor = buf.get_access<sycl::access_mode::read_write>(cgh);
 
      cgh.parallel_for<class Test>(
          sycl::nd_range<3>({size_x, size_y, size_z + 1}, {1, 1, 1}),

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_copy_fill.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/buffer_copy_fill.cpp
@@ -22,17 +22,17 @@ int main() {
     sycl::buffer<int, 1> buf(v.size());
 
     q.submit([&](sycl::handler &h) {
-       auto A = buf.get_access<sycl::access::mode::write>(h);
+       auto A = buf.get_access<sycl::access_mode::write>(h);
        h.copy(&v[0], A);
      }).wait();
 
     q.submit([&](sycl::handler &h) {
-       auto A = buf.get_access<sycl::access::mode::write>(h);
+       auto A = buf.get_access<sycl::access_mode::write>(h);
        h.fill(A, 1);
      }).wait();
 
     q.submit([&](sycl::handler &h) {
-       auto A = buf.get_access<sycl::access::mode::read_write>(h);
+       auto A = buf.get_access<sycl::access_mode::read_write>(h);
        h.parallel_for<class Test>(
            sycl::nd_range<1>(N + 1, 1),
            [=](sycl::nd_item<1> item) { A[item.get_global_id()] *= 2; });

--- a/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/subbuffer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/out-of-bounds/buffer/subbuffer.cpp
@@ -21,7 +21,7 @@ int main() {
     sycl::buffer<int> sub_buf(buf, {size_x / 2}, {size_x / 2});
 
     q.submit([&](sycl::handler &cgh) {
-       auto accessor = sub_buf.get_access<sycl::access::mode::read_write>(cgh);
+       auto accessor = sub_buf.get_access<sycl::access_mode::read_write>(cgh);
        cgh.parallel_for<class Test>(
            sycl::nd_range<1>(size_x / 2 + 1, 1),
            [=](sycl::nd_item<1> item) { accessor[item.get_global_id()] *= 2; });

--- a/sycl/test-e2e/MemorySanitizer/check_buffer.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_buffer.cpp
@@ -17,7 +17,7 @@ int main() {
 
   sycl::buffer<int, 1> buf1(sycl::range<1>(1));
   q.submit([&](sycl::handler &h) {
-     auto array1 = buf1.get_access<sycl::access::mode::read_write>(h);
+     auto array1 = buf1.get_access<sycl::access_mode::read_write>(h);
      h.single_task<class MyKernel>([=]() { foo(array1[0], array1[0]); });
    }).wait();
   // CHECK: use-of-uninitialized-value

--- a/sycl/test-e2e/MemorySanitizer/check_buffer_memset_memcpy.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_buffer_memset_memcpy.cpp
@@ -17,12 +17,12 @@ void check_memset(sycl::queue &q) {
   const int Pattern = 0;
 
   q.submit([&](sycl::handler &h) {
-     auto array = buf.get_access<sycl::access::mode::read_write>(h);
+     auto array = buf.get_access<sycl::access_mode::read_write>(h);
      h.fill(array, Pattern);
    }).wait();
 
   q.submit([&](sycl::handler &h) {
-     auto array = buf.get_access<sycl::access::mode::read_write>(h);
+     auto array = buf.get_access<sycl::access_mode::read_write>(h);
      h.single_task<class MyKernel1>(
          [=]() { array[0] = foo(array[0], array[1]); });
    }).wait();
@@ -39,13 +39,13 @@ void check_memcpy(sycl::queue &q) {
   sycl::buffer<int, 1> buf2(host, sycl::range<1>(2));
 
   q.submit([&](sycl::handler &h) {
-     auto array1 = buf1.get_access<sycl::access::mode::read_write>(h);
-     auto array2 = buf2.get_access<sycl::access::mode::read_write>(h);
+     auto array1 = buf1.get_access<sycl::access_mode::read_write>(h);
+     auto array2 = buf2.get_access<sycl::access_mode::read_write>(h);
      h.copy(array2, array1);
    }).wait();
 
   q.submit([&](sycl::handler &h) {
-     auto array = buf1.get_access<sycl::access::mode::read_write>(h);
+     auto array = buf1.get_access<sycl::access_mode::read_write>(h);
      h.single_task<class MyKernel2>(
          [=]() { array[0] = foo(array[0], array[1]); });
    }).wait();

--- a/sycl/test-e2e/MemorySanitizer/check_large_access.cpp
+++ b/sycl/test-e2e/MemorySanitizer/check_large_access.cpp
@@ -17,7 +17,7 @@ int main() {
   sycl::queue myQueue;
   myQueue
       .submit([&](sycl::handler &cgh) {
-        auto B = b.get_access<sycl::access::mode::read_write>(cgh);
+        auto B = b.get_access<sycl::access_mode::read_write>(cgh);
         cgh.parallel_for<class MyKernel>(
             sycl::range<1>{2}, [=](sycl::id<1> ID) {
               B[ID] = sycl::int3{(sycl::int3)ID[0]} / B[ID];

--- a/sycl/test-e2e/ThreadSanitizer/check_buffer.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_buffer.cpp
@@ -23,7 +23,7 @@ int main() {
     // we need to cover that pattern here.
     sycl::buffer<int, 1> buf(v.data(), v.size());
     q.submit([&](sycl::handler &h) {
-       auto A = buf.get_access<sycl::access::mode::read_write>(h);
+       auto A = buf.get_access<sycl::access_mode::read_write>(h);
        h.parallel_for<class Test>(
            sycl::nd_range<1>(N, 1),
            [=](sycl::nd_item<1> it) { A[0] += it.get_global_linear_id(); });

--- a/sycl/test-e2e/ThreadSanitizer/check_sub_buffer.cpp
+++ b/sycl/test-e2e/ThreadSanitizer/check_sub_buffer.cpp
@@ -23,7 +23,7 @@ int main() {
     sycl::buffer<int> sub_buf(buf, {size_x / 2}, {size_x / 2});
 
     q.submit([&](sycl::handler &cgh) {
-       auto accessor = sub_buf.get_access<sycl::access::mode::read_write>(cgh);
+       auto accessor = sub_buf.get_access<sycl::access_mode::read_write>(cgh);
        cgh.parallel_for<class Test>(sycl::nd_range<1>(size_x / 2, 1),
                                     [=](sycl::nd_item<1> it) {
                                       accessor[0] += it.get_global_linear_id();


### PR DESCRIPTION
access::mode is deprecated in favor of access_mode.
PR to add deprecations: https://github.com/intel/llvm/pull/22803