### PR TITLE
[SYCL] Update Graph tests to use access_mode

### DIFF
--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
@@ -32,7 +32,7 @@ int main() {
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
     auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
-      auto AccA = BufferA.get_access<access::mode::write>(CGH);
+      auto AccA = BufferA.get_access<access_mode::write>(CGH);
       CGH.copy(DataB.data(), AccA);
     });
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
@@ -30,7 +30,7 @@ int main() {
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
     auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
-      auto AccA = BufferA.get_access<access::mode::write>(CGH, range<1>(Size),
+      auto AccA = BufferA.get_access<access_mode::write>(CGH, range<1>(Size),
                                                           id<1>(Offset));
       CGH.copy(DataB.data(), AccA);
     });

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
@@ -31,7 +31,7 @@ int main() {
 
     auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
       auto AccA = BufferA.get_access<access_mode::write>(CGH, range<1>(Size),
-                                                          id<1>(Offset));
+                                                         id<1>(Offset));
       CGH.copy(DataB.data(), AccA);
     });
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_offsets.cpp
@@ -38,9 +38,9 @@ int main() {
 
     // Copy from A to B
     auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
-      auto AccA = BufferA.get_access<access::mode::read_write>(
+      auto AccA = BufferA.get_access<access_mode::read_write>(
           CGH, range<1>(Size - OffsetSrc), id<1>(OffsetSrc));
-      auto AccB = BufferB.get_access<access::mode::read_write>(
+      auto AccB = BufferB.get_access<access_mode::read_write>(
           CGH, range<1>(Size - OffsetDst), id<1>(OffsetDst));
       CGH.copy(AccA, AccB);
     });

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host.cpp
@@ -28,7 +28,7 @@ int main() {
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
     auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
-      auto AccA = BufferA.get_access<access::mode::read>(CGH);
+      auto AccA = BufferA.get_access<access_mode::read>(CGH);
       CGH.copy(AccA, DataB.data());
     });
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
@@ -33,7 +33,7 @@ int main() {
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
     auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
-      auto AccA = BufferA.get_access<access::mode::read>(CGH);
+      auto AccA = BufferA.get_access<access_mode::read>(CGH);
       CGH.copy(AccA, DataB.data());
     });
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_offset.cpp
@@ -31,7 +31,7 @@ int main() {
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
     auto NodeA = add_node(Graph, Queue, [&](handler &CGH) {
-      auto AccA = BufferA.get_access<access::mode::read>(
+      auto AccA = BufferA.get_access<access_mode::read>(
           CGH, range<1>(Size - Offset), id<1>(Offset));
       CGH.copy(AccA, DataB.data());
     });

--- a/sycl/test-e2e/Graph/Inputs/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/Inputs/debug_print_graph.cpp
@@ -38,7 +38,7 @@ int main() {
     });
 
     auto Last = add_node(Graph, Queue, [&](handler &CGH) {
-      auto Acc = BufferC.get_access<access::mode::read>(CGH);
+      auto Acc = BufferC.get_access<access_mode::read>(CGH);
       CGH.copy(Acc, DataD.data());
     });
 

--- a/sycl/test-e2e/Graph/Inputs/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/Inputs/debug_print_graph_verbose.cpp
@@ -38,7 +38,7 @@ int main() {
     });
 
     auto Last = add_node(Graph, Queue, [&](handler &CGH) {
-      auto AccA = BufferC.get_access<access::mode::read>(CGH);
+      auto AccA = BufferC.get_access<access_mode::read>(CGH);
       CGH.copy(AccA, DataD.data());
     });
 

--- a/sycl/test-e2e/Graph/Inputs/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/Inputs/interop-level-zero-get-native-mem.cpp
@@ -86,8 +86,7 @@ int main() {
           BufferInteropInput, Context);
 
       auto NodeA = add_node(Graph, Queue, [&](sycl::handler &CGH) {
-        auto Acc =
-            BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
+        auto Acc = BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel6>([=]() {
           for (int i = 0; i < 12; i++) {
             Acc[i] = 99;

--- a/sycl/test-e2e/Graph/Inputs/interop-level-zero-get-native-mem.cpp
+++ b/sycl/test-e2e/Graph/Inputs/interop-level-zero-get-native-mem.cpp
@@ -87,7 +87,7 @@ int main() {
 
       auto NodeA = add_node(Graph, Queue, [&](sycl::handler &CGH) {
         auto Acc =
-            BufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+            BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
         CGH.single_task<class SimpleKernel6>([=]() {
           for (int i = 0; i < 12; i++) {
             Acc[i] = 99;
@@ -100,7 +100,7 @@ int main() {
           [&](sycl::handler &CGH) {
             depends_on_helper(CGH, NodeA);
             auto Acc =
-                BufferInterop.get_access<sycl::access::mode::read_write>(CGH);
+                BufferInterop.get_access<sycl::access_mode::read_write>(CGH);
             CGH.single_task<class SimpleKernel7>([=]() {
               for (int i = 0; i < 12; i++) {
                 Acc[i] *= 2;
@@ -113,7 +113,7 @@ int main() {
           Graph, Queue,
           [&](handler &CGH) {
             depends_on_helper(CGH, NodeB);
-            auto BufferAcc = BufferInterop.get_access<access::mode::write>(CGH);
+            auto BufferAcc = BufferInterop.get_access<access_mode::write>(CGH);
             CGH.host_task([=](const interop_handle &IH) {
               void *DevicePtr =
                   IH.get_native_mem<backend::ext_oneapi_level_zero>(BufferAcc);

--- a/sycl/test-e2e/Graph/Inputs/kernel_bundle.cpp
+++ b/sycl/test-e2e/Graph/Inputs/kernel_bundle.cpp
@@ -31,7 +31,7 @@ int main() {
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
     add_node(Graph, Queue, ([&](sycl::handler &CGH) {
-               auto Acc = Buf.get_access<sycl::access::mode::write>(CGH);
+               auto Acc = Buf.get_access<sycl::access_mode::write>(CGH);
                CGH.use_kernel_bundle(KernelBundleExecutable);
                CGH.single_task<Kernel1Name>([=]() { Acc[0] = 42; });
              }));

--- a/sycl/test-e2e/Graph/Inputs/kernel_bundle_spirv.cpp
+++ b/sycl/test-e2e/Graph/Inputs/kernel_bundle_spirv.cpp
@@ -39,22 +39,21 @@ int main(int, char **argv) {
         Queue.get_device(),
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
-    add_node(Graph, Queue, ([&](sycl::handler &CGH) {
-               CGH.set_arg(
-                   0, input_buffer.get_access<sycl::access_mode::read>(CGH));
-               CGH.set_arg(
-                   1, output_buffer.get_access<sycl::access_mode::write>(CGH));
-               CGH.parallel_for(sycl::range<1>{N}, kernel);
-             }));
+    add_node(
+        Graph, Queue, ([&](sycl::handler &CGH) {
+          CGH.set_arg(0, input_buffer.get_access<sycl::access_mode::read>(CGH));
+          CGH.set_arg(1,
+                      output_buffer.get_access<sycl::access_mode::write>(CGH));
+          CGH.parallel_for(sycl::range<1>{N}, kernel);
+        }));
 
-    add_node(Graph, Queue, ([&](sycl::handler &CGH) {
-               CGH.set_arg(
-                   0, input_buffer.get_access<sycl::access_mode::read>(CGH));
-               CGH.set_arg(
-                   1,
-                   output_buffer2.get_access<sycl::access_mode::write>(CGH));
-               CGH.parallel_for(sycl::range<1>{N}, kernel);
-             }));
+    add_node(
+        Graph, Queue, ([&](sycl::handler &CGH) {
+          CGH.set_arg(0, input_buffer.get_access<sycl::access_mode::read>(CGH));
+          CGH.set_arg(1,
+                      output_buffer2.get_access<sycl::access_mode::write>(CGH));
+          CGH.parallel_for(sycl::range<1>{N}, kernel);
+        }));
 
     auto GraphExec = Graph.finalize();
 

--- a/sycl/test-e2e/Graph/Inputs/kernel_bundle_spirv.cpp
+++ b/sycl/test-e2e/Graph/Inputs/kernel_bundle_spirv.cpp
@@ -41,18 +41,18 @@ int main(int, char **argv) {
 
     add_node(Graph, Queue, ([&](sycl::handler &CGH) {
                CGH.set_arg(
-                   0, input_buffer.get_access<sycl::access::mode::read>(CGH));
+                   0, input_buffer.get_access<sycl::access_mode::read>(CGH));
                CGH.set_arg(
-                   1, output_buffer.get_access<sycl::access::mode::write>(CGH));
+                   1, output_buffer.get_access<sycl::access_mode::write>(CGH));
                CGH.parallel_for(sycl::range<1>{N}, kernel);
              }));
 
     add_node(Graph, Queue, ([&](sycl::handler &CGH) {
                CGH.set_arg(
-                   0, input_buffer.get_access<sycl::access::mode::read>(CGH));
+                   0, input_buffer.get_access<sycl::access_mode::read>(CGH));
                CGH.set_arg(
                    1,
-                   output_buffer2.get_access<sycl::access::mode::write>(CGH));
+                   output_buffer2.get_access<sycl::access_mode::write>(CGH));
                CGH.parallel_for(sycl::range<1>{N}, kernel);
              }));
 

--- a/sycl/test-e2e/Graph/Inputs/multiple_kernel_bundles.cpp
+++ b/sycl/test-e2e/Graph/Inputs/multiple_kernel_bundles.cpp
@@ -56,14 +56,14 @@ int main() {
         {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
     add_node(Graph, Queue, ([&](sycl::handler &CGH) {
-               auto Acc = Buf1.get_access<sycl::access::mode::write>(CGH);
+               auto Acc = Buf1.get_access<sycl::access_mode::write>(CGH);
                CGH.use_kernel_bundle(KernelBundleExecutable1);
                CGH.single_task<Kernel1Name>([=]() { Acc[0] = 42; });
              }));
 
     add_node(Graph, Queue, ([&](handler &CGH) {
                auto DataA =
-                   BufferA.template get_access<access::mode::read_write>(CGH);
+                   BufferA.template get_access<access_mode::read_write>(CGH);
                CGH.use_kernel_bundle(KernelBundleExecutable1);
                CGH.parallel_for(range<1>{Size},
                                 [=](item<1> Id) { DataA[Id]++; });
@@ -77,7 +77,7 @@ int main() {
     std::error_code ExceptionCode = make_error_code(sycl::errc::success);
     try {
       Graph.add([&](sycl::handler &CGH) {
-        auto Acc = Buf2.get_access<sycl::access::mode::write>(CGH);
+        auto Acc = Buf2.get_access<sycl::access_mode::write>(CGH);
         CGH.use_kernel_bundle(KernelBundleExecutable2);
         CGH.single_task<Kernel2Name>([=]() { Acc[0] = 24; });
       });

--- a/sycl/test-e2e/Graph/Inputs/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/Inputs/spec_constants_handler_api.cpp
@@ -74,11 +74,11 @@ bool test_default_values(sycl::queue Queue) {
 
     add_node(Graph, Queue, ([&](sycl::handler &CGH) {
                auto IntAcc =
-                   IntBuffer.get_access<sycl::access::mode::write>(CGH);
+                   IntBuffer.get_access<sycl::access_mode::write>(CGH);
                auto IntAcc2 =
-                   IntBuffer2.get_access<sycl::access::mode::write>(CGH);
+                   IntBuffer2.get_access<sycl::access_mode::write>(CGH);
                auto FloatAcc =
-                   FloatBuffer.get_access<sycl::access::mode::write>(CGH);
+                   FloatBuffer.get_access<sycl::access_mode::write>(CGH);
 
                CGH.single_task<TestDefaultValuesKernel>(
                    [=](sycl::kernel_handler KH) {
@@ -173,10 +173,10 @@ bool test_set_and_get_on_device(sycl::queue Queue) {
 
     add_node(
         Graph, Queue, ([&](sycl::handler &CGH) {
-          auto IntAcc = IntBuffer.get_access<sycl::access::mode::write>(CGH);
-          auto IntAcc2 = IntBuffer2.get_access<sycl::access::mode::write>(CGH);
+          auto IntAcc = IntBuffer.get_access<sycl::access_mode::write>(CGH);
+          auto IntAcc2 = IntBuffer2.get_access<sycl::access_mode::write>(CGH);
           auto FloatAcc =
-              FloatBuffer.get_access<sycl::access::mode::write>(CGH);
+              FloatBuffer.get_access<sycl::access_mode::write>(CGH);
 
           CGH.set_specialization_constant<IntId>(NewIntValue);
           CGH.set_specialization_constant<IntId2>(NewIntValue2);

--- a/sycl/test-e2e/Graph/Inputs/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/Inputs/spec_constants_handler_api.cpp
@@ -175,8 +175,7 @@ bool test_set_and_get_on_device(sycl::queue Queue) {
         Graph, Queue, ([&](sycl::handler &CGH) {
           auto IntAcc = IntBuffer.get_access<sycl::access_mode::write>(CGH);
           auto IntAcc2 = IntBuffer2.get_access<sycl::access_mode::write>(CGH);
-          auto FloatAcc =
-              FloatBuffer.get_access<sycl::access_mode::write>(CGH);
+          auto FloatAcc = FloatBuffer.get_access<sycl::access_mode::write>(CGH);
 
           CGH.set_specialization_constant<IntId>(NewIntValue);
           CGH.set_specialization_constant<IntId2>(NewIntValue2);

--- a/sycl/test-e2e/Graph/Inputs/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/Inputs/spec_constants_kernel_bundle_api.cpp
@@ -82,9 +82,9 @@ bool test_default_values(sycl::queue Queue) {
     add_node(Graph, Queue, ([&](sycl::handler &CGH) {
                CGH.use_kernel_bundle(ExecBundle);
                auto IntAcc =
-                   IntBuffer.get_access<sycl::access::mode::write>(CGH);
+                   IntBuffer.get_access<sycl::access_mode::write>(CGH);
                auto FloatAcc =
-                   FloatBuffer.get_access<sycl::access::mode::write>(CGH);
+                   FloatBuffer.get_access<sycl::access_mode::write>(CGH);
 
                CGH.single_task<TestDefaultValuesKernel>(
                    [=](sycl::kernel_handler KH) {
@@ -205,9 +205,9 @@ bool test_set_and_get_on_device(sycl::queue Queue) {
     add_node(
         Graph, Queue, ([&](sycl::handler &CGH) {
           CGH.use_kernel_bundle(ExecBundle);
-          auto IntAcc = IntBuffer.get_access<sycl::access::mode::write>(CGH);
+          auto IntAcc = IntBuffer.get_access<sycl::access_mode::write>(CGH);
           auto FloatAcc =
-              FloatBuffer.get_access<sycl::access::mode::write>(CGH);
+              FloatBuffer.get_access<sycl::access_mode::write>(CGH);
 
           CGH.single_task<TestSetAndGetOnDevice>([=](sycl::kernel_handler KH) {
             IntAcc[0] = KH.get_specialization_constant<IntId>();

--- a/sycl/test-e2e/Graph/Inputs/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/Inputs/spec_constants_kernel_bundle_api.cpp
@@ -206,8 +206,7 @@ bool test_set_and_get_on_device(sycl::queue Queue) {
         Graph, Queue, ([&](sycl::handler &CGH) {
           CGH.use_kernel_bundle(ExecBundle);
           auto IntAcc = IntBuffer.get_access<sycl::access_mode::write>(CGH);
-          auto FloatAcc =
-              FloatBuffer.get_access<sycl::access_mode::write>(CGH);
+          auto FloatAcc = FloatBuffer.get_access<sycl::access_mode::write>(CGH);
 
           CGH.single_task<TestSetAndGetOnDevice>([=](sycl::kernel_handler KH) {
             IntAcc[0] = KH.get_specialization_constant<IntId>();

--- a/sycl/test-e2e/Graph/Inputs/whole_update_host_task_accessor.cpp
+++ b/sycl/test-e2e/Graph/Inputs/whole_update_host_task_accessor.cpp
@@ -32,7 +32,7 @@ void add_nodes_to_graph(
   auto HostTaskOp = add_node(
       Graph, Queue,
       [&](handler &CGH) {
-        auto AccC = BufferC.get_access<access::mode::read_write,
+        auto AccC = BufferC.get_access<access_mode::read_write,
                                        access::target::host_task>(CGH);
         depends_on_helper(CGH, LastOperation);
         CGH.host_task([=]() {

--- a/sycl/test-e2e/Graph/Profiling/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/Profiling/event_profiling_info.cpp
@@ -48,9 +48,9 @@ int main() {
     CopyGraph.begin_recording(Queue);
 
     Queue.submit([&](sycl::handler &Cgh) {
-      accessor<int, 1, access::mode::read, access::target::device> AccessorFrom(
+      accessor<int, 1, access_mode::read, access::target::device> AccessorFrom(
           BufferFrom, Cgh, range<1>(Size));
-      accessor<int, 1, access::mode::write, access::target::device> AccessorTo(
+      accessor<int, 1, access_mode::write, access::target::device> AccessorTo(
           BufferTo, Cgh, range<1>(Size));
       Cgh.copy(AccessorFrom, AccessorTo);
     });

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_buffer_accessor.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/exception_buffer_accessor.cpp
@@ -30,7 +30,7 @@ int main() {
   if (!expectException(
           [&]() {
             Queue.submit([&](handler &CGH) {
-              auto Acc = Buf.get_access<sycl::access::mode::write>(CGH);
+              auto Acc = Buf.get_access<sycl::access_mode::write>(CGH);
               CGH.parallel_for(sycl::range<1>{N},
                                [=](sycl::id<1> Idx) { Acc[Idx] = 0; });
             });

--- a/sycl/test-e2e/Graph/Update/dyn_cgf_accessor_deps.cpp
+++ b/sycl/test-e2e/Graph/Update/dyn_cgf_accessor_deps.cpp
@@ -24,20 +24,20 @@ int main() {
       {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
   auto RootNode = Graph.add([&](handler &CGH) {
-    auto Acc = Buf.get_access<access::mode::write>(CGH);
+    auto Acc = Buf.get_access<access_mode::write>(CGH);
     CGH.parallel_for(Size, [=](item<1> Item) { Acc[Item.get_id()] = 1; });
   });
 
   int PatternA = 42;
   auto CGFA = [&](handler &CGH) {
-    auto Acc = Buf.get_access<access::mode::read_write>(CGH);
+    auto Acc = Buf.get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(Size,
                      [=](item<1> Item) { Acc[Item.get_id()] += PatternA; });
   };
 
   int PatternB = 0xA;
   auto CGFB = [&](handler &CGH) {
-    auto Acc = Buf.get_access<access::mode::read_write>(CGH);
+    auto Acc = Buf.get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(Size,
                      [=](item<1> Item) { Acc[Item.get_id()] += PatternB; });
   };
@@ -46,7 +46,7 @@ int main() {
   auto DynamicCGNode = Graph.add(DynamicCG);
 
   auto LeafNode = Graph.add([&](handler &CGH) {
-    auto Acc = Buf.get_access<access::mode::read>(CGH);
+    auto Acc = Buf.get_access<access_mode::read>(CGH);
     CGH.parallel_for(
         Size, [=](item<1> Item) { Ptr[Item.get_id()] = Acc[Item.get_id()]; });
   });

--- a/sycl/test-e2e/Graph/Update/dyn_cgf_accessor_deps2.cpp
+++ b/sycl/test-e2e/Graph/Update/dyn_cgf_accessor_deps2.cpp
@@ -29,8 +29,8 @@ int main() {
   int InitA = 4;
   int InitB = -4;
   auto RootNode = Graph.add([&](handler &CGH) {
-    auto AccA = BufA.get_access<access::mode::write>(CGH);
-    auto AccB = BufB.get_access<access::mode::write>(CGH);
+    auto AccA = BufA.get_access<access_mode::write>(CGH);
+    auto AccB = BufB.get_access<access_mode::write>(CGH);
     CGH.parallel_for(Size, [=](item<1> Item) {
       AccA[Item.get_id()] = InitA;
       AccB[Item.get_id()] = InitB;
@@ -39,14 +39,14 @@ int main() {
 
   int PatternA = 42;
   auto CGFA = [&](handler &CGH) {
-    auto AccA = BufA.get_access<access::mode::read_write>(CGH);
+    auto AccA = BufA.get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(Size,
                      [=](item<1> Item) { AccA[Item.get_id()] += PatternA; });
   };
 
   int PatternB = 0xA;
   auto CGFB = [&](handler &CGH) {
-    auto AccB = BufB.get_access<access::mode::read_write>(CGH);
+    auto AccB = BufB.get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(Size,
                      [=](item<1> Item) { AccB[Item.get_id()] += PatternB; });
   };
@@ -55,8 +55,8 @@ int main() {
   auto DynamicCGNode = Graph.add(DynamicCG);
 
   auto LeafNode = Graph.add([&](handler &CGH) {
-    auto AccA = BufA.get_access<access::mode::read>(CGH);
-    auto AccB = BufB.get_access<access::mode::read>(CGH);
+    auto AccA = BufA.get_access<access_mode::read>(CGH);
+    auto AccB = BufB.get_access<access_mode::read>(CGH);
     CGH.parallel_for(Size, [=](item<1> Item) {
       Ptr[Item.get_id()] = AccA[Item.get_id()] + AccB[Item.get_id()];
     });

--- a/sycl/test-e2e/Graph/Update/dyn_cgf_host_task_accessor.cpp
+++ b/sycl/test-e2e/Graph/Update/dyn_cgf_host_task_accessor.cpp
@@ -71,7 +71,7 @@ int main() {
 
     // Create two different command groups for the host task
     auto CGFA = [&](handler &CGH) {
-      auto AccC = BufferC.get_access<access::mode::read_write,
+      auto AccC = BufferC.get_access<access_mode::read_write,
                                      access::target::host_task>(CGH);
       CGH.host_task([=]() {
         for (size_t i = 0; i < Size; i++) {
@@ -80,7 +80,7 @@ int main() {
       });
     };
     auto CGFB = [&](handler &CGH) {
-      auto AccC = BufferC.get_access<access::mode::read_write,
+      auto AccC = BufferC.get_access<access_mode::read_write,
                                      access::target::host_task>(CGH);
       CGH.host_task([=]() {
         for (size_t i = 0; i < Size; i++) {

--- a/sycl/test-e2e/Graph/graph_common.hpp
+++ b/sycl/test-e2e/Graph/graph_common.hpp
@@ -100,15 +100,15 @@ event run_kernels(queue Q, const size_t Size, buffer<T> BufferA,
                   buffer<T> BufferB, buffer<T> BufferC) {
   // Read & write Buffer A.
   Q.submit([&](handler &CGH) {
-    auto DataA = BufferA.template get_access<access::mode::read_write>(CGH);
+    auto DataA = BufferA.template get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(range<1>(Size), [=](item<1> Id) { DataA[Id]++; });
   });
 
   // Reads Buffer A.
   // Read & Write Buffer B.
   Q.submit([&](handler &CGH) {
-    auto DataA = BufferA.template get_access<access::mode::read>(CGH);
-    auto DataB = BufferB.template get_access<access::mode::read_write>(CGH);
+    auto DataA = BufferA.template get_access<access_mode::read>(CGH);
+    auto DataB = BufferB.template get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(range<1>(Size),
                      [=](item<1> Id) { DataB[Id] += DataA[Id]; });
   });
@@ -116,16 +116,16 @@ event run_kernels(queue Q, const size_t Size, buffer<T> BufferA,
   // Reads Buffer A.
   // Read & writes Buffer C
   Q.submit([&](handler &CGH) {
-    auto DataA = BufferA.template get_access<access::mode::read>(CGH);
-    auto DataC = BufferC.template get_access<access::mode::read_write>(CGH);
+    auto DataA = BufferA.template get_access<access_mode::read>(CGH);
+    auto DataC = BufferC.template get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(range<1>(Size),
                      [=](item<1> Id) { DataC[Id] -= DataA[Id]; });
   });
 
   // Read & write Buffers B and C.
   auto ExitEvent = Q.submit([&](handler &CGH) {
-    auto DataB = BufferB.template get_access<access::mode::read_write>(CGH);
-    auto DataC = BufferC.template get_access<access::mode::read_write>(CGH);
+    auto DataB = BufferB.template get_access<access_mode::read_write>(CGH);
+    auto DataC = BufferC.template get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
       DataB[Id]--;
       DataC[Id]--;
@@ -151,15 +151,15 @@ add_kernels(exp_ext::command_graph<exp_ext::graph_state::modifiable> Graph,
             buffer<T> BufferC) {
   // Read & write Buffer A
   Graph.add([&](handler &CGH) {
-    auto DataA = BufferA.template get_access<access::mode::read_write>(CGH);
+    auto DataA = BufferA.template get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(range<1>(Size), [=](item<1> Id) { DataA[Id]++; });
   });
 
   // Reads Buffer A
   // Read & Write Buffer B
   Graph.add([&](handler &CGH) {
-    auto DataA = BufferA.template get_access<access::mode::read>(CGH);
-    auto DataB = BufferB.template get_access<access::mode::read_write>(CGH);
+    auto DataA = BufferA.template get_access<access_mode::read>(CGH);
+    auto DataB = BufferB.template get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(range<1>(Size),
                      [=](item<1> Id) { DataB[Id] += DataA[Id]; });
   });
@@ -167,16 +167,16 @@ add_kernels(exp_ext::command_graph<exp_ext::graph_state::modifiable> Graph,
   // Reads Buffer A
   // Read & writes Buffer C
   Graph.add([&](handler &CGH) {
-    auto DataA = BufferA.template get_access<access::mode::read>(CGH);
-    auto DataC = BufferC.template get_access<access::mode::read_write>(CGH);
+    auto DataA = BufferA.template get_access<access_mode::read>(CGH);
+    auto DataC = BufferC.template get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(range<1>(Size),
                      [=](item<1> Id) { DataC[Id] -= DataA[Id]; });
   });
 
   // Read & write Buffers B and C
   auto ExitNode = Graph.add([&](handler &CGH) {
-    auto DataB = BufferB.template get_access<access::mode::read_write>(CGH);
-    auto DataC = BufferC.template get_access<access::mode::read_write>(CGH);
+    auto DataB = BufferB.template get_access<access_mode::read_write>(CGH);
+    auto DataC = BufferC.template get_access<access_mode::read_write>(CGH);
     CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
       DataB[Id]--;
       DataC[Id]--;


### PR DESCRIPTION
access::mode is deprecated in favor of access_mode.
PR to add deprecations: https://github.com/intel/llvm/pull/22803