### PR TITLE
[SYCL] Update dpcpp-tools tests

### DIFF
--- a/sycl/test-e2e/AOT/Inputs/aot.cpp
+++ b/sycl/test-e2e/AOT/Inputs/aot.cpp
@@ -11,8 +11,8 @@
 #include <array>
 #include <iostream>
 
-constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
-constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
+constexpr sycl::access_mode sycl_read = sycl::access_mode::read;
+constexpr sycl::access_mode sycl_write = sycl::access_mode::write;
 
 template <typename T> class SimpleVadd;
 

--- a/sycl/test-e2e/AOT/Inputs/simple.cpp
+++ b/sycl/test-e2e/AOT/Inputs/simple.cpp
@@ -8,7 +8,7 @@ int main() {
     sycl::buffer<int, 1> buf(&data, sycl::range<1>(1));
 
     q.submit([&](sycl::handler &h) {
-       auto acc = buf.get_access<sycl::access::mode::write>(h);
+       auto acc = buf.get_access<sycl::access_mode::write>(h);
        h.single_task([=]() { acc[0] = 42; });
      }).wait();
   }

--- a/sycl/test-e2e/BFloat16/bfloat16_conversions.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_conversions.cpp
@@ -85,7 +85,7 @@ int test_device_vector_conversions(queue Q) {
   std::cout << "float[4] -> bfloat16[4] conversion on device..." << std::flush;
   // Convert float array to bfloat16 array
   Q.submit([&](handler &CGH) {
-     accessor<int, 1, access::mode::write, target::device> ERR(err_buf, CGH);
+     accessor<int, 1, access_mode::write, target::device> ERR(err_buf, CGH);
      CGH.single_task([=]() {
        float FloatArray[4] = {1.0f, -1.0f, 0.0f, 2.0f};
        bfloat16 BF16Array[4];
@@ -106,7 +106,7 @@ int test_device_vector_conversions(queue Q) {
   std::cout << "bfloat16[4] -> float[4] conversion on device..." << std::flush;
   // Convert bfloat16 array back to float array
   Q.submit([&](handler &CGH) {
-     accessor<int, 1, access::mode::write, target::device> ERR(err_buf, CGH);
+     accessor<int, 1, access_mode::write, target::device> ERR(err_buf, CGH);
      CGH.single_task([=]() {
        bfloat16 BF16Array[3] = {1.0f, 0.0f, -1.0f};
        float FloatArray[3];

--- a/sycl/test-e2e/BFloat16/bfloat16_type.hpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_type.hpp
@@ -18,7 +18,7 @@ template <typename T> void assert_close(const T &C, const float ref) {
 void verify_conv_implicit(queue &q, buffer<float, 1> &a, range<1> &r,
                           const float ref) {
   q.submit([&](handler &cgh) {
-    auto A = a.get_access<access::mode::read_write>(cgh);
+    auto A = a.get_access<access_mode::read_write>(cgh);
     cgh.parallel_for<class calc_conv>(r, [=](id<1> index) {
       sycl::ext::oneapi::bfloat16 AVal{A[index]};
       A[index] = AVal;
@@ -31,7 +31,7 @@ void verify_conv_implicit(queue &q, buffer<float, 1> &a, range<1> &r,
 void verify_conv_explicit(queue &q, buffer<float, 1> &a, range<1> &r,
                           const float ref) {
   q.submit([&](handler &cgh) {
-    auto A = a.get_access<access::mode::read_write>(cgh);
+    auto A = a.get_access<access_mode::read_write>(cgh);
     cgh.parallel_for<class calc_conv_impl>(r, [=](id<1> index) {
       sycl::ext::oneapi::bfloat16 AVal = A[index];
       A[index] = float(AVal);
@@ -46,9 +46,9 @@ void verify_add(queue &q, buffer<float, 1> &a, buffer<float, 1> &b, range<1> &r,
   buffer<float, 1> c{r};
 
   q.submit([&](handler &cgh) {
-    auto A = a.get_access<access::mode::read>(cgh);
-    auto B = b.get_access<access::mode::read>(cgh);
-    auto C = c.get_access<access::mode::write>(cgh);
+    auto A = a.get_access<access_mode::read>(cgh);
+    auto B = b.get_access<access_mode::read>(cgh);
+    auto C = c.get_access<access_mode::write>(cgh);
     cgh.parallel_for<class calc_add_expl>(r, [=](id<1> index) {
       sycl::ext::oneapi::bfloat16 AVal{A[index]};
       sycl::ext::oneapi::bfloat16 BVal{B[index]};
@@ -65,9 +65,9 @@ void verify_sub(queue &q, buffer<float, 1> &a, buffer<float, 1> &b, range<1> &r,
   buffer<float, 1> c{r};
 
   q.submit([&](handler &cgh) {
-    auto A = a.get_access<access::mode::read>(cgh);
-    auto B = b.get_access<access::mode::read>(cgh);
-    auto C = c.get_access<access::mode::write>(cgh);
+    auto A = a.get_access<access_mode::read>(cgh);
+    auto B = b.get_access<access_mode::read>(cgh);
+    auto C = c.get_access<access_mode::write>(cgh);
     cgh.parallel_for<class calc_sub>(r, [=](id<1> index) {
       sycl::ext::oneapi::bfloat16 AVal{A[index]};
       sycl::ext::oneapi::bfloat16 BVal{B[index]};
@@ -83,8 +83,8 @@ void verify_minus(queue &q, buffer<float, 1> &a, range<1> &r, const float ref) {
   buffer<float, 1> c{r};
 
   q.submit([&](handler &cgh) {
-    auto A = a.get_access<access::mode::read>(cgh);
-    auto C = c.get_access<access::mode::write>(cgh);
+    auto A = a.get_access<access_mode::read>(cgh);
+    auto C = c.get_access<access_mode::write>(cgh);
     cgh.parallel_for<class calc_minus>(r, [=](id<1> index) {
       sycl::ext::oneapi::bfloat16 AVal{A[index]};
       sycl::ext::oneapi::bfloat16 CVal = -AVal;
@@ -100,9 +100,9 @@ void verify_mul(queue &q, buffer<float, 1> &a, buffer<float, 1> &b, range<1> &r,
   buffer<float, 1> c{r};
 
   q.submit([&](handler &cgh) {
-    auto A = a.get_access<access::mode::read>(cgh);
-    auto B = b.get_access<access::mode::read>(cgh);
-    auto C = c.get_access<access::mode::write>(cgh);
+    auto A = a.get_access<access_mode::read>(cgh);
+    auto B = b.get_access<access_mode::read>(cgh);
+    auto C = c.get_access<access_mode::write>(cgh);
     cgh.parallel_for<class calc_mul>(r, [=](id<1> index) {
       sycl::ext::oneapi::bfloat16 AVal{A[index]};
       sycl::ext::oneapi::bfloat16 BVal{B[index]};
@@ -119,9 +119,9 @@ void verify_div(queue &q, buffer<float, 1> &a, buffer<float, 1> &b, range<1> &r,
   buffer<float, 1> c{r};
 
   q.submit([&](handler &cgh) {
-    auto A = a.get_access<access::mode::read>(cgh);
-    auto B = b.get_access<access::mode::read>(cgh);
-    auto C = c.get_access<access::mode::write>(cgh);
+    auto A = a.get_access<access_mode::read>(cgh);
+    auto B = b.get_access<access_mode::read>(cgh);
+    auto C = c.get_access<access_mode::write>(cgh);
     cgh.parallel_for<class calc_div>(r, [=](id<1> index) {
       sycl::ext::oneapi::bfloat16 AVal{A[index]};
       sycl::ext::oneapi::bfloat16 BVal{B[index]};
@@ -138,9 +138,9 @@ void verify_logic(queue &q, buffer<float, 1> &a, buffer<float, 1> &b,
   buffer<float, 1> c{r};
 
   q.submit([&](handler &cgh) {
-    auto A = a.get_access<access::mode::read>(cgh);
-    auto B = b.get_access<access::mode::read>(cgh);
-    auto C = c.get_access<access::mode::write>(cgh);
+    auto A = a.get_access<access_mode::read>(cgh);
+    auto B = b.get_access<access_mode::read>(cgh);
+    auto C = c.get_access<access_mode::write>(cgh);
     cgh.parallel_for<class logic>(r, [=](id<1> index) {
       sycl::ext::oneapi::bfloat16 AVal{A[index]};
       sycl::ext::oneapi::bfloat16 BVal{B[index]};

--- a/sycl/test-e2e/BFloat16/bfloat16_vec_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_vec_builtins.cpp
@@ -81,8 +81,7 @@ bool check(bool a, bool b) { return (a != b); }
   { /* On Device */                                                            \
     buffer<int> err_buf(&err, 1);                                              \
     q.submit([&](handler &cgh) {                                               \
-       accessor<int, 1, access_mode::write, target::device> ERR(err_buf,      \
-                                                                 cgh);         \
+       accessor<int, 1, access_mode::write, target::device> ERR(err_buf, cgh); \
        cgh.single_task([=]() { OPTEST(NAME, SZ, RETTY, INPVAL) });             \
      }).wait();                                                                \
   }                                                                            \

--- a/sycl/test-e2e/BFloat16/bfloat16_vec_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_vec_builtins.cpp
@@ -81,7 +81,7 @@ bool check(bool a, bool b) { return (a != b); }
   { /* On Device */                                                            \
     buffer<int> err_buf(&err, 1);                                              \
     q.submit([&](handler &cgh) {                                               \
-       accessor<int, 1, access::mode::write, target::device> ERR(err_buf,      \
+       accessor<int, 1, access_mode::write, target::device> ERR(err_buf,      \
                                                                  cgh);         \
        cgh.single_task([=]() { OPTEST(NAME, SZ, RETTY, INPVAL) });             \
      }).wait();                                                                \
@@ -131,7 +131,7 @@ void test() {
   {
     buffer<int> err_buf(&err, 1);
     q.submit([&](handler &cgh) {
-       accessor<int, 1, access::mode::write, target::device> ERR(err_buf, cgh);
+       accessor<int, 1, access_mode::write, target::device> ERR(err_buf, cgh);
        cgh.single_task([=]() {
          vec<bfloat16, 3> arg{1.0f, nan, 2.0f};
          vec<int16_t, 3> res = sycl::ext::oneapi::experimental::isnan(arg);
@@ -220,7 +220,7 @@ void test() {
   {
     buffer<int> err_buf(&err, 1);
     q.submit([&](handler &cgh) {
-       accessor<int, 1, access::mode::write, target::device> ERR(err_buf, cgh);
+       accessor<int, 1, access_mode::write, target::device> ERR(err_buf, cgh);
        cgh.single_task([=]() {
          vec<bfloat16, 3> arg1, arg2, arg3;
          bfloat16 inpVal1 = 1.0f;

--- a/sycl/test-e2e/DeviceCodeSplit/Inputs/split-per-source-second-file.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/Inputs/split-per-source-second-file.cpp
@@ -15,7 +15,7 @@ void runKernelsFromFile2() {
     assert(KernelIDStorage[0] == KernelID1);
 
     Q.submit([&](sycl::handler &Cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(Cgh);
       Cgh.single_task<File2Kern1>([=]() { Acc[0] = 3; });
     });
   }

--- a/sycl/test-e2e/DeviceCodeSplit/grf.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/grf.cpp
@@ -85,7 +85,7 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class SYCLKernelSingleGRF>(Size,
                                                   [=](id<1> i) { PA[i] += 2; });
     });
@@ -116,7 +116,7 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class SYCLKernelSpecifiedGRF>(Size,
                                                      KernelFunctor(PA, prop));
     });

--- a/sycl/test-e2e/DeviceCodeSplit/grf_512.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/grf_512.cpp
@@ -63,7 +63,7 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class SYCLKernelSingleGRF>(Size,
                                                   [=](id<1> i) { PA[i] += 2; });
     });
@@ -90,7 +90,7 @@ int main(void) {
               << "\n";
 
     auto e = q.submit([&](handler &cgh) {
-      auto PA = bufa.get_access<access::mode::read_write>(cgh);
+      auto PA = bufa.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class SYCLKernelSpecifiedGRF>(Size,
                                                      KernelFunctor(PA, prop));
     });

--- a/sycl/test-e2e/DeviceCodeSplit/split-per-kernel.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/split-per-kernel.cpp
@@ -25,7 +25,7 @@ int main() {
     assert(!KB.has_kernel(KernelID3));
 
     Q.submit([&](sycl::handler &Cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(Cgh);
       Cgh.single_task<Kern1>([=]() { Acc[0] = 1; });
     });
   }
@@ -44,7 +44,7 @@ int main() {
     assert(!KB.has_kernel(KernelID3));
 
     Q.submit([&](sycl::handler &Cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(Cgh);
       Cgh.single_task<Kern2>([=]() { Acc[0] = 2; });
     });
   }
@@ -63,7 +63,7 @@ int main() {
     assert(!KB.has_kernel(KernelID2));
 
     Q.submit([&](sycl::handler &Cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(Cgh);
       Cgh.single_task<Kern3>([=]() { Acc[0] = 3; });
     });
   }

--- a/sycl/test-e2e/DeviceCodeSplit/split-per-source-main.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/split-per-source-main.cpp
@@ -31,7 +31,7 @@ int main() {
   {
     sycl::buffer<int, 1> Buf(&Data, sycl::range<1>(1));
     Q.submit([&](sycl::handler &Cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(Cgh);
       Cgh.single_task<File1Kern1>([=]() { Acc[0] = 1; });
     });
   }
@@ -40,7 +40,7 @@ int main() {
   {
     sycl::buffer<int, 1> Buf(&Data, sycl::range<1>(1));
     Q.submit([&](sycl::handler &Cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(Cgh);
       Cgh.single_task<File1Kern2>([=]() { Acc[0] = 2; });
     });
   }

--- a/sycl/test-e2e/NewOffloadDriver/Inputs/aot.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/Inputs/aot.cpp
@@ -11,8 +11,8 @@
 #include <array>
 #include <iostream>
 
-constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
-constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
+constexpr sycl::access_mode sycl_read = sycl::access_mode::read;
+constexpr sycl::access_mode sycl_write = sycl::access_mode::write;
 
 template <typename T> class Vadd;
 

--- a/sycl/test-e2e/NewOffloadDriver/Inputs/split-per-source-second-file.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/Inputs/split-per-source-second-file.cpp
@@ -15,7 +15,7 @@ void runKernelsFromFile2() {
     assert(KernelIDStorage[0] == KernelID1);
 
     Q.submit([&](sycl::handler &Cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(Cgh);
       Cgh.single_task<File2Kern1>([=]() { Acc[0] = 3; });
     });
   }

--- a/sycl/test-e2e/NewOffloadDriver/multisource.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/multisource.cpp
@@ -38,7 +38,7 @@ void init_buf(queue &q, buffer<int, 1> &b, range<1> &r, int i);
 #elif INIT_KERNEL
 void init_buf(queue &q, buffer<int, 1> &b, range<1> &r, int i) {
   q.submit([&](handler &cgh) {
-    auto B = b.get_access<access::mode::write>(cgh);
+    auto B = b.get_access<access_mode::write>(cgh);
     cgh.parallel_for<class init>(r, [=](id<1> index) { B[index] = i; });
   });
 }
@@ -51,9 +51,9 @@ void calc_buf(queue &q, buffer<int, 1> &a, buffer<int, 1> &b, buffer<int, 1> &c,
 void calc_buf(queue &q, buffer<int, 1> &a, buffer<int, 1> &b, buffer<int, 1> &c,
               range<1> &r) {
   q.submit([&](handler &cgh) {
-    auto A = a.get_access<access::mode::read>(cgh);
-    auto B = b.get_access<access::mode::read>(cgh);
-    auto C = c.get_access<access::mode::write>(cgh);
+    auto A = a.get_access<access_mode::read>(cgh);
+    auto B = b.get_access<access_mode::read>(cgh);
+    auto C = c.get_access<access_mode::write>(cgh);
     cgh.parallel_for<class calc>(
         r, [=](id<1> index) { C[index] = A[index] - B[index]; });
   });

--- a/sycl/test-e2e/NewOffloadDriver/separate_compile.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/separate_compile.cpp
@@ -37,7 +37,7 @@ int run_test_b(int v) {
     sycl::queue deviceQueue;
     sycl::buffer<int, 1> buf(arr, 1);
     deviceQueue.submit([&](sycl::handler &cgh) {
-      auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+      auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
       cgh.single_task<class kernel_b>([=]() { acc[0] *= 3; });
     });
   }
@@ -62,7 +62,7 @@ int run_test_a(int v) {
     sycl::queue deviceQueue;
     sycl::buffer<int, 1> buf(arr, 1);
     deviceQueue.submit([&](sycl::handler &cgh) {
-      auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+      auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
       cgh.single_task<class kernel_a>([=]() { acc[0] *= 2; });
     });
   }

--- a/sycl/test-e2e/NewOffloadDriver/split-per-source-main.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/split-per-source-main.cpp
@@ -31,7 +31,7 @@ int main() {
   {
     sycl::buffer<int, 1> Buf(&Data, sycl::range<1>(1));
     Q.submit([&](sycl::handler &Cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(Cgh);
       Cgh.single_task<File1Kern1>([=]() { Acc[0] = 1; });
     });
   }
@@ -40,7 +40,7 @@ int main() {
   {
     sycl::buffer<int, 1> Buf(&Data, sycl::range<1>(1));
     Q.submit([&](sycl::handler &Cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(Cgh);
       Cgh.single_task<File1Kern2>([=]() { Acc[0] = 2; });
     });
   }

--- a/sycl/test-e2e/SeparateCompile/same-kernel.cpp
+++ b/sycl/test-e2e/SeparateCompile/same-kernel.cpp
@@ -22,8 +22,8 @@ using namespace sycl;
 class TestFnObj {
 public:
   TestFnObj(buffer<int> &buf, handler &cgh)
-      : data(buf.get_access<access::mode::write>(cgh)) {}
-  accessor<int, 1, access::mode::write, access::target::device> data;
+      : data(buf.get_access<access_mode::write>(cgh)) {}
+  accessor<int, 1, access_mode::write, access::target::device> data;
   void operator()(id<1> item) const { data[item] = item[0]; }
 };
 

--- a/sycl/test-e2e/SeparateCompile/sycl-external-within-staticlib.cpp
+++ b/sycl/test-e2e/SeparateCompile/sycl-external-within-staticlib.cpp
@@ -36,9 +36,9 @@ void hostf(unsigned Size, sycl::buffer<int, 1> &bufA,
            sycl::buffer<int, 1> &bufB, sycl::buffer<int, 1> &bufC) {
   sycl::range<1> range{Size};
   sycl::queue().submit([&](sycl::handler &cgh) {
-    auto accA = bufA.get_access<sycl::access::mode::read>(cgh);
-    auto accB = bufB.get_access<sycl::access::mode::read>(cgh);
-    auto accC = bufC.get_access<sycl::access::mode::write>(cgh);
+    auto accA = bufA.get_access<sycl::access_mode::read>(cgh);
+    auto accB = bufB.get_access<sycl::access_mode::read>(cgh);
+    auto accC = bufC.get_access<sycl::access_mode::write>(cgh);
 
     cgh.parallel_for<class Test>(range, [=](sycl::id<1> ID) {
       accC[ID] = external_f1(accA[ID], accB[ID]);

--- a/sycl/test-e2e/SeparateCompile/sycl-external.cpp
+++ b/sycl/test-e2e/SeparateCompile/sycl-external.cpp
@@ -41,9 +41,9 @@ int main(void) {
     sycl::buffer<int, 1> bufC(C, range);
 
     sycl::queue().submit([&](sycl::handler &cgh) {
-      auto accA = bufA.get_access<sycl::access::mode::read>(cgh);
-      auto accB = bufB.get_access<sycl::access::mode::read>(cgh);
-      auto accC = bufC.get_access<sycl::access::mode::write>(cgh);
+      auto accA = bufA.get_access<sycl::access_mode::read>(cgh);
+      auto accB = bufB.get_access<sycl::access_mode::read>(cgh);
+      auto accC = bufC.get_access<sycl::access_mode::write>(cgh);
 
       cgh.parallel_for<class Test>(
           range, [=](sycl::id<1> ID) { accC[ID] = foo(accA[ID], accB[ID]); });

--- a/sycl/test-e2e/SeparateCompile/test.cpp
+++ b/sycl/test-e2e/SeparateCompile/test.cpp
@@ -74,7 +74,7 @@ int run_test_b(int v) {
     sycl::queue deviceQueue;
     sycl::buffer<int, 1> buf(arr, 1);
     deviceQueue.submit([&](sycl::handler &cgh) {
-      auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+      auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
       cgh.single_task<class kernel_b>([=]() { acc[0] *= 3; });
     });
   }
@@ -99,7 +99,7 @@ int run_test_a(int v) {
     sycl::queue deviceQueue;
     sycl::buffer<int, 1> buf(arr, 1);
     deviceQueue.submit([&](sycl::handler &cgh) {
-      auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+      auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
       cgh.single_task<class kernel_a>([=]() { acc[0] *= 2; });
     });
   }


### PR DESCRIPTION
access::mode is deprecated in favor of access_mode.
PR to add deprecations: https://github.com/intel/llvm/pull/22803