### PR TITLE
[UR][CTS] Temporarily disable urDeviceGetInfoTest.SuccessFanSpeed on L0 V2 Arc B580

### DIFF
--- a/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
+++ b/unified-runtime/test/conformance/device/urDeviceGetInfo.cpp
@@ -2631,6 +2631,15 @@ TEST_P(urDeviceGetInfoTest, SuccessThrottleReasons) {
 
 // This test uses NVML which requires driver/library version match.
 TEST_P(urDeviceGetInfoTest, SuccessFanSpeed) {
+  // TODO: Re-enable once the XE Kernel Mode Driver supports the FAN APIs on
+  // this device (see KMD Jira VLK-92189). zesFanGetState
+  // (ZES_FAN_SPEED_UNITS_PERCENT) started to return
+  // ZE_RESULT_ERROR_UNSUPPORTED_FEATURE on Arc(TM) B580 after the User Mode
+  // Driver was updated to v26.27.39122.11 in commit
+  // 9b65cb732c7ead19408867357fd7224809396706.
+  // Issue tracker: https://github.com/intel/llvm/issues/22812
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{"Arc(TM) B580"});
+
   size_t property_size = 0;
   const ur_device_info_t property_name = UR_DEVICE_INFO_FAN_SPEED;
 


### PR DESCRIPTION
This test fails in CI on the Level Zero V2 adapter with the Intel(R)
Arc(TM) B580 Graphics device:

```
  Expected equality of these values:
    uur::Result(UR_RESULT_SUCCESS)
      Which is: UR_RESULT_SUCCESS
    uur::Result(urDeviceGetInfo(device, property_name, property_size,
                                &property_value, nullptr))
      Which is: UR_RESULT_ERROR_UNSUPPORTED_FEATURE
```

zesFanGetState(ZES_FAN_SPEED_UNITS_PERCENT) started to return
ZE_RESULT_ERROR_UNSUPPORTED_FEATURE on Arc(TM) B580 because the User
Mode Driver was updated to v26.27.39122.11 in commit
9b65cb7, but the XE Kernel Mode Driver doesn't have support
for the FAN APIs yet on this device (see KMD Jira VLK-92189).

Disable temporarily via UUR_KNOWN_FAILURE_ON, scoped to the Level Zero
V2 backend and the Arc B580 device name, until the KMD adds Fan API
support.

Fixes: #22812

Ref: KMD Jira VLK-92189
