### PR TITLE
[SYCL] append to spirv extension list

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11288,7 +11288,11 @@ static void getTripleBasedSPIRVTransOpts(Compilation &C,
       ",+SPV_KHR_cooperative_matrix"
       ",+SPV_EXT_shader_atomic_float16_add"
       ",+SPV_INTEL_fp_max_error"
-      ",+SPV_INTEL_memory_access_aliasing";
+      ",+SPV_INTEL_memory_access_aliasing"
+      ",+SPV_INTEL_fp_conversions"
+      ",+SPV_EXT_float8"
+      ",+SPV_KHR_bfloat16"
+      ",+SPV_INTEL_float4";
 
   TranslatorArgs.push_back(TCArgs.MakeArgString(ExtArg));
 }

--- a/clang/test/Driver/sycl-spirv-ext-old-model.cpp
+++ b/clang/test/Driver/sycl-spirv-ext-old-model.cpp
@@ -50,3 +50,7 @@
 // CHECK-DEFAULT-SAME:,+SPV_EXT_shader_atomic_float16_add
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_fp_max_error
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_memory_access_aliasing
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_fp_conversions
+// CHECK-DEFAULT-SAME:,+SPV_EXT_float8
+// CHECK-DEFAULT-SAME:,+SPV_KHR_bfloat16
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_float4

--- a/clang/test/Driver/sycl-spirv-ext.cpp
+++ b/clang/test/Driver/sycl-spirv-ext.cpp
@@ -68,3 +68,7 @@
 // CHECK-DEFAULT-SAME:,+SPV_EXT_shader_atomic_float16_add
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_fp_max_error
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_memory_access_aliasing
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_fp_conversions
+// CHECK-DEFAULT-SAME:,+SPV_EXT_float8
+// CHECK-DEFAULT-SAME:,+SPV_KHR_bfloat16
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_float4

--- a/clang/test/Driver/sycl-spirv-metadata-old-model.cpp
+++ b/clang/test/Driver/sycl-spirv-metadata-old-model.cpp
@@ -9,7 +9,7 @@
 // RUN:  FileCheck -check-prefix CHECK-WITHOUT %s
 
 // CHECK-WITH: llvm-spirv{{.*}} "--spirv-preserve-auxdata"
-// CHECK-WITH-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_memory_access_aliasing"
+// CHECK-WITH-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_float4"
 
 // CHECK-WITHOUT: "{{.*}}llvm-spirv"
 // CHECK-WITHOUT-NOT: --spirv-preserve-auxdata

--- a/clang/test/Driver/sycl-spirv-obj-old-model.cpp
+++ b/clang/test/Driver/sycl-spirv-obj-old-model.cpp
@@ -11,7 +11,7 @@
 // SPIRV_DEVICE_OBJ-SAME: "-o" "[[DEVICE_BC:.+\.bc]]"
 // SPIRV_DEVICE_OBJ: llvm-spirv{{.*}} "-o" "[[DEVICE_SPV:.+\.spv]]"
 // SPIRV_DEVICE_OBJ-SAME: "--spirv-preserve-auxdata"
-// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_memory_access_aliasing"
+// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_float4"
 // SPIRV_DEVICE_OBJ-SAME: "[[DEVICE_BC]]"
 // SPIRV_DEVICE_OBJ: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu"
 // SPIRV_DEVICE_OBJ-SAME: "-fsycl-is-host"

--- a/clang/test/Driver/sycl-spirv-obj.cpp
+++ b/clang/test/Driver/sycl-spirv-obj.cpp
@@ -11,7 +11,7 @@
 // SPIRV_DEVICE_OBJ-SAME: "-o" "[[DEVICE_BC:.+\.bc]]"
 // SPIRV_DEVICE_OBJ: llvm-spirv{{.*}} "-o" "[[DEVICE_SPV:.+\.spv]]"
 // SPIRV_DEVICE_OBJ-SAME: "--spirv-preserve-auxdata"
-// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_memory_access_aliasing"
+// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_float4"
 // SPIRV_DEVICE_OBJ-SAME: "[[DEVICE_BC]]"
 // SPIRV_DEVICE_OBJ: llvm-offload-binary{{.*}} "--image=file=[[DEVICE_SPV]]{{.*}}"
 // SPIRV_DEVICE_OBJ: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu"

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -951,7 +951,11 @@ getTripleBasedSPIRVTransOpts(const ArgList &Args,
       ",+SPV_KHR_cooperative_matrix"
       ",+SPV_EXT_shader_atomic_float16_add"
       ",+SPV_INTEL_fp_max_error"
-      ",+SPV_INTEL_memory_access_aliasing";
+      ",+SPV_INTEL_memory_access_aliasing"
+      ",+SPV_INTEL_fp_conversions"
+      ",+SPV_EXT_float8"
+      ",+SPV_KHR_bfloat16"
+      ",+SPV_INTEL_float4";
   TranslatorArgs.push_back(Args.MakeArgString(ExtArg));
 }
 

--- a/sycl-jit/jit-compiler/lib/translation/SPIRVLLVMTranslation.cpp
+++ b/sycl-jit/jit-compiler/lib/translation/SPIRVLLVMTranslation.cpp
@@ -67,7 +67,12 @@ SPIRV::TranslatorOpts &SPIRVLLVMTranslator::translatorOpts() {
       SPIRV::ExtensionID::SPV_KHR_non_semantic_info,
       SPIRV::ExtensionID::SPV_KHR_cooperative_matrix,
       SPIRV::ExtensionID::SPV_EXT_shader_atomic_float16_add,
-      SPIRV::ExtensionID::SPV_INTEL_fp_max_error};
+      SPIRV::ExtensionID::SPV_INTEL_fp_max_error,
+      SPIRV::ExtensionID::SPV_INTEL_memory_access_aliasing,
+      SPIRV::ExtensionID::SPV_INTEL_fp_conversions,
+      SPIRV::ExtensionID::SPV_EXT_float8,
+      SPIRV::ExtensionID::SPV_KHR_bfloat16,
+      SPIRV::ExtensionID::SPV_INTEL_float4};
 
   static auto Opts = [&]() -> SPIRV::TranslatorOpts {
     // Options for translation between SPIR-V and LLVM IR.

--- a/sycl/test-e2e/Experimental/fp4/e2m1_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp4/e2m1_cri_conversion.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: arch-intel_gpu_cri
-// RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_INTEL_float4,+SPV_KHR_bfloat16 -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: target-nvidia, target-amd, spirv-backend

--- a/sycl/test-e2e/Experimental/fp4/e2m1_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp4/e2m1_x2_cri_conversion.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: arch-intel_gpu_cri
-// RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_INTEL_float4,+SPV_KHR_bfloat16 -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: target-nvidia, target-amd, spirv-backend

--- a/sycl/test-e2e/Experimental/fp8/e4m3_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e4m3_cri_conversion.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: arch-intel_gpu_cri
-// RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: target-nvidia, target-amd, spirv-backend

--- a/sycl/test-e2e/Experimental/fp8/e4m3_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e4m3_x2_cri_conversion.cpp
@@ -1,6 +1,6 @@
 
 // REQUIRES: arch-intel_gpu_cri
-// RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: target-nvidia, target-amd, spirv-backend

--- a/sycl/test-e2e/Experimental/fp8/e5m2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e5m2_cri_conversion.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: arch-intel_gpu_cri
-// RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: target-nvidia, target-amd, spirv-backend

--- a/sycl/test-e2e/Experimental/fp8/e5m2_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e5m2_x2_cri_conversion.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: arch-intel_gpu_cri
-// RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: target-nvidia, target-amd, spirv-backend

--- a/sycl/test-e2e/Experimental/fp8/e8m0_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e8m0_cri_conversion.cpp
@@ -1,6 +1,5 @@
-
 // REQUIRES: arch-intel_gpu_cri
-// RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: target-nvidia, target-amd, spirv-backend

--- a/sycl/test-e2e/Experimental/fp8/e8m0_x2_cri_conversion.cpp
+++ b/sycl/test-e2e/Experimental/fp8/e8m0_x2_cri_conversion.cpp
@@ -1,6 +1,6 @@
 
 // REQUIRES: arch-intel_gpu_cri
-// RUN: %{build} -Xclang -freg-struct-return -Xspirv-translator=spir64 --spirv-ext=+SPV_INTEL_fp_conversions,+SPV_EXT_float8,+SPV_KHR_bfloat16 -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: target-nvidia, target-amd, spirv-backend


### PR DESCRIPTION
This PR adds spirv extensions to default spirv list. This needs to avoid adding them with `--spirv-ext=+SomeExtension` by user.
All extensions added in PR are required to successfully compile and run sources with FP8 and FP4 data types.