### PR TITLE
[SYCL] Update E2E to use access_mode [3/3]

### DIFF
--- a/sycl/test-e2e/AddressCast/khr_static_addrspace_cast.cpp
+++ b/sycl/test-e2e/AddressCast/khr_static_addrspace_cast.cpp
@@ -24,10 +24,10 @@ int main() {
   Queue
       .submit([&](sycl::handler &cgh) {
         auto GlobalAccessor =
-            GlobalBuffer.get_access<sycl::access::mode::read_write>(cgh);
+            GlobalBuffer.get_access<sycl::access_mode::read_write>(cgh);
         auto LocalAccessor = sycl::local_accessor<int>(1, cgh);
         auto ResultAccessor =
-            ResultBuffer.get_access<sycl::access::mode::write>(cgh);
+            ResultBuffer.get_access<sycl::access_mode::write>(cgh);
         cgh.parallel_for<class Kernel>(
             sycl::nd_range<1>(NItems, 1), [=](sycl::nd_item<1> Item) {
               bool Success = true;

--- a/sycl/test-e2e/Assert/assert_in_kernels.hpp
+++ b/sycl/test-e2e/Assert/assert_in_kernels.hpp
@@ -14,7 +14,7 @@ void kernelFunc1(int *Buf, int wiID) {
 
 void assertTest1(queue &Q, buffer<int, 1> &Buf) {
   Q.submit([&](handler &CGH) {
-    auto Acc = Buf.template get_access<mode::read_write>(CGH);
+    auto Acc = Buf.template get_access<sycl::access_mode::read_write>(CGH);
 
     CGH.parallel_for<class Kernel_1>(
         Buf.get_range(), [=](sycl::id<1> wiID) { kernelFunc1(&Acc[0], wiID); });
@@ -29,7 +29,7 @@ void kernelFunc2(int *Buf, int wiID) {
 
 void assertTest2(queue &Q, buffer<int, 1> &Buf) {
   Q.submit([&](handler &CGH) {
-    auto Acc = Buf.template get_access<mode::read_write>(CGH);
+    auto Acc = Buf.template get_access<sycl::access_mode::read_write>(CGH);
 
     CGH.parallel_for<class Kernel_2>(
         Buf.get_range(), [=](sycl::id<1> wiID) { kernelFunc2(&Acc[0], wiID); });
@@ -44,7 +44,7 @@ void kernelFunc3(int *Buf, int wiID) {
 
 void assertTest3(queue &Q, buffer<int, 1> &Buf) {
   Q.submit([&](handler &CGH) {
-    auto Acc = Buf.template get_access<mode::read_write>(CGH);
+    auto Acc = Buf.template get_access<sycl::access_mode::read_write>(CGH);
 
     CGH.parallel_for<class Kernel_3>(
         Buf.get_range(), [=](sycl::id<1> wiID) { kernelFunc3(&Acc[0], wiID); });

--- a/sycl/test-e2e/Assert/assert_in_kernels.hpp
+++ b/sycl/test-e2e/Assert/assert_in_kernels.hpp
@@ -14,7 +14,7 @@ void kernelFunc1(int *Buf, int wiID) {
 
 void assertTest1(queue &Q, buffer<int, 1> &Buf) {
   Q.submit([&](handler &CGH) {
-    auto Acc = Buf.template get_access<sycl::access_mode::read_write>(CGH);
+    auto Acc = Buf.template get_access<access_mode::read_write>(CGH);
 
     CGH.parallel_for<class Kernel_1>(
         Buf.get_range(), [=](sycl::id<1> wiID) { kernelFunc1(&Acc[0], wiID); });
@@ -29,7 +29,7 @@ void kernelFunc2(int *Buf, int wiID) {
 
 void assertTest2(queue &Q, buffer<int, 1> &Buf) {
   Q.submit([&](handler &CGH) {
-    auto Acc = Buf.template get_access<sycl::access_mode::read_write>(CGH);
+    auto Acc = Buf.template get_access<access_mode::read_write>(CGH);
 
     CGH.parallel_for<class Kernel_2>(
         Buf.get_range(), [=](sycl::id<1> wiID) { kernelFunc2(&Acc[0], wiID); });
@@ -44,7 +44,7 @@ void kernelFunc3(int *Buf, int wiID) {
 
 void assertTest3(queue &Q, buffer<int, 1> &Buf) {
   Q.submit([&](handler &CGH) {
-    auto Acc = Buf.template get_access<sycl::access_mode::read_write>(CGH);
+    auto Acc = Buf.template get_access<access_mode::read_write>(CGH);
 
     CGH.parallel_for<class Kernel_3>(
         Buf.get_range(), [=](sycl::id<1> wiID) { kernelFunc3(&Acc[0], wiID); });

--- a/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
@@ -52,7 +52,7 @@ template <class kernel_name> void enqueueKernel(queue *Q) {
   sycl::buffer<int, 1> Buf(numOfItems);
 
   Q->submit([&](handler &CGH) {
-    auto Acc = Buf.template get_access<sycl::access_mode::read_write>(CGH);
+    auto Acc = Buf.template get_access<access_mode::read_write>(CGH);
 
     CGH.parallel_for<kernel_name>(numOfItems, [=](sycl::id<1> wiID) {
       Acc[wiID] = 0;

--- a/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
@@ -52,7 +52,7 @@ template <class kernel_name> void enqueueKernel(queue *Q) {
   sycl::buffer<int, 1> Buf(numOfItems);
 
   Q->submit([&](handler &CGH) {
-    auto Acc = Buf.template get_access<mode::read_write>(CGH);
+    auto Acc = Buf.template get_access<sycl::access_mode::read_write>(CGH);
 
     CGH.parallel_for<kernel_name>(numOfItems, [=](sycl::id<1> wiID) {
       Acc[wiID] = 0;

--- a/sycl/test-e2e/AtomicRef/assignment.h
+++ b/sycl/test-e2e/AtomicRef/assignment.h
@@ -27,7 +27,7 @@ void assignment_test(queue q, size_t N) {
     buffer<T> assignment_buf(&assignment, 1);
     q.submit([&](handler &cgh) {
       auto st =
-          assignment_buf.template get_access<access::mode::read_write>(cgh);
+          assignment_buf.template get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<assignment_kernel<AtomicRef, address_space, T>>(
           range<1>(N), [=](item<1> it) {
             size_t gid = it.get_id(0);

--- a/sycl/test-e2e/AtomicRef/compare_exchange.h
+++ b/sycl/test-e2e/AtomicRef/compare_exchange.h
@@ -33,10 +33,10 @@ void compare_exchange_local_test(queue q, size_t N) {
     buffer<T> output_buf(output.data(), output.size());
     q.submit([&](handler &cgh) {
        auto compare_exchange =
-           compare_exchange_buf.template get_access<access::mode::read_write>(
+           compare_exchange_buf.template get_access<access_mode::read_write>(
                cgh);
        auto out =
-           output_buf.template get_access<access::mode::discard_write>(cgh);
+           output_buf.template get_access<access_mode::discard_write>(cgh);
        local_accessor<T, 1> loc(1, cgh);
 
        cgh.parallel_for(nd_range<1>(N, N), [=](nd_item<1> it) {
@@ -88,10 +88,10 @@ void compare_exchange_global_test(queue q, size_t N) {
 
     q.submit([&](handler &cgh) {
        auto exc =
-           compare_exchange_buf.template get_access<access::mode::read_write>(
+           compare_exchange_buf.template get_access<access_mode::read_write>(
                cgh);
        auto out =
-           output_buf.template get_access<access::mode::discard_write>(cgh);
+           output_buf.template get_access<access_mode::discard_write>(cgh);
        cgh.parallel_for(range<1>(N), [=](item<1> it) {
          size_t gid = it.get_id(0);
          auto atm = AtomicRef < T,

--- a/sycl/test-e2e/AtomicRef/max.h
+++ b/sycl/test-e2e/AtomicRef/max.h
@@ -32,9 +32,9 @@ void max_local_test(queue q, size_t N) {
     buffer<T> cum_buf(&cum, 1);
     buffer<T> output_buf(output.data(), output.size());
     q.submit([&](handler &cgh) {
-       auto cum = cum_buf.template get_access<access::mode::read_write>(cgh);
+       auto cum = cum_buf.template get_access<access_mode::read_write>(cgh);
        auto out =
-           output_buf.template get_access<access::mode::discard_write>(cgh);
+           output_buf.template get_access<access_mode::discard_write>(cgh);
        local_accessor<T, 1> loc(1, cgh);
 
        cgh.parallel_for(nd_range<1>(N, N), [=](nd_item<1> it) {
@@ -83,9 +83,9 @@ void max_global_test(queue q, size_t N) {
     buffer<T> output_buf(output.data(), output.size());
 
     q.submit([&](handler &cgh) {
-      auto val = val_buf.template get_access<access::mode::read_write>(cgh);
+      auto val = val_buf.template get_access<access_mode::read_write>(cgh);
       auto out =
-          output_buf.template get_access<access::mode::discard_write>(cgh);
+          output_buf.template get_access<access_mode::discard_write>(cgh);
       cgh.parallel_for(range<1>(N), [=](item<1> it) {
         int gid = it.get_id(0);
         auto atm = AtomicRef < T,

--- a/sycl/test-e2e/AtomicRef/store.h
+++ b/sycl/test-e2e/AtomicRef/store.h
@@ -29,7 +29,7 @@ void store_global_test(queue q, size_t N) {
   {
     buffer<T> store_buf(&store, 1);
     q.submit([&](handler &cgh) {
-      auto st = store_buf.template get_access<access::mode::read_write>(cgh);
+      auto st = store_buf.template get_access<access_mode::read_write>(cgh);
       cgh.parallel_for(range<1>(N), [=](item<1> it) {
         size_t gid = it.get_id(0);
         auto atm = AtomicRef<T, memory_order::relaxed, scope, space>(st[0]);
@@ -82,7 +82,7 @@ void store_local_test(queue q, size_t N) {
   {
     buffer<T> store_buf(&store, 1);
     q.submit([&](handler &cgh) {
-      auto st = store_buf.template get_access<access::mode::read_write>(cgh);
+      auto st = store_buf.template get_access<access_mode::read_write>(cgh);
       local_accessor<T, 1> loc(1, cgh);
       cgh.parallel_for(nd_range<1>(N, N), [=](nd_item<1> it) {
         size_t gid = it.get_global_id(0);

--- a/sycl/test-e2e/Basic/access_to_subset.cpp
+++ b/sycl/test-e2e/Basic/access_to_subset.cpp
@@ -12,7 +12,7 @@
 #include <sycl/detail/core.hpp>
 
 using namespace sycl;
-using acc_w = accessor<int, 2, access::mode::write, access::target::device>;
+using acc_w = accessor<int, 2, access_mode::write, access::target::device>;
 
 int main() {
 

--- a/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
@@ -10,7 +10,7 @@
 #include <math.h>
 #include <type_traits>
 
-constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
+constexpr sycl::access_mode sycl_write = sycl::access_mode::write;
 
 template <typename To, typename From> class BitCastKernel;
 

--- a/sycl/test-e2e/Basic/buffer/buffer_full_copy.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_full_copy.cpp
@@ -22,7 +22,7 @@ void check_copy_device_to_host(sycl::queue &Queue) {
 
   // Submit kernel where you'll fill the buffer
   Queue.submit([&](sycl::handler &cgh) {
-    auto acc = simple_buffer.get_access<sycl::access::mode::write>(cgh);
+    auto acc = simple_buffer.get_access<sycl::access_mode::write>(cgh);
     cgh.fill(acc, 13);
   });
 
@@ -69,7 +69,7 @@ void check_fill(sycl::queue &Queue) {
   }
 
   auto e = Queue.submit([&](sycl::handler &cgh) {
-    auto a = buf_1.template get_access<sycl::access::mode::write>(cgh, size / 2,
+    auto a = buf_1.template get_access<sycl::access_mode::write>(cgh, size / 2,
                                                                   offset);
     cgh.fill(a, (float)1337.0);
   });
@@ -102,8 +102,8 @@ void check_copy_host_to_device(sycl::queue &Queue) {
     expected_res_2[i] = expected_res_1[offset + i];
 
   auto e = Queue.submit([&](sycl::handler &cgh) {
-    auto a = buf_1.get_access<sycl::access::mode::read>(cgh, size / 2, offset);
-    auto b = buf_2.get_access<sycl::access::mode::write>(cgh, size / 2);
+    auto a = buf_1.get_access<sycl::access_mode::read>(cgh, size / 2, offset);
+    auto b = buf_2.get_access<sycl::access_mode::write>(cgh, size / 2);
     cgh.copy(a, b);
   });
   e.wait();
@@ -141,10 +141,10 @@ void check_copy_host_to_device(sycl::queue &Queue) {
       expected_res_4[i][j] = expected_res_3[i + offset][j + offset];
 
   e = Queue.submit([&](sycl::handler &cgh) {
-    auto a = buf_3.get_access<sycl::access::mode::read>(
+    auto a = buf_3.get_access<sycl::access_mode::read>(
         cgh, {size / 2, size / 2}, {offset, offset});
     auto b =
-        buf_4.get_access<sycl::access::mode::write>(cgh, {size / 2, size / 2});
+        buf_4.get_access<sycl::access_mode::write>(cgh, {size / 2, size / 2});
     cgh.copy(a, b);
   });
   e.wait();
@@ -190,9 +190,9 @@ void check_copy_host_to_device(sycl::queue &Queue) {
             expected_res_5[i + offset][j + offset][k + offset];
 
   e = Queue.submit([&](sycl::handler &cgh) {
-    auto a = buf_5.get_access<sycl::access::mode::read>(
+    auto a = buf_5.get_access<sycl::access_mode::read>(
         cgh, {size / 2, size / 2, size / 2}, {offset, offset, offset});
-    auto b = buf_6.get_access<sycl::access::mode::write>(
+    auto b = buf_6.get_access<sycl::access_mode::write>(
         cgh, {size / 2, size / 2, size / 2});
     cgh.copy(a, b);
   });

--- a/sycl/test-e2e/Basic/buffer/buffer_full_copy.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_full_copy.cpp
@@ -70,7 +70,7 @@ void check_fill(sycl::queue &Queue) {
 
   auto e = Queue.submit([&](sycl::handler &cgh) {
     auto a = buf_1.template get_access<sycl::access_mode::write>(cgh, size / 2,
-                                                                  offset);
+                                                                 offset);
     cgh.fill(a, (float)1337.0);
   });
   e.wait();

--- a/sycl/test-e2e/Basic/buffer/reinterpret.cpp
+++ b/sycl/test-e2e/Basic/buffer/reinterpret.cpp
@@ -39,7 +39,7 @@ void execute_kernel(sycl::queue &cmd_queue, std::vector<OldType> &data,
 
   cmd_queue.submit([&](sycl::handler &cgh) {
     auto rb_acc =
-        reinterpret_subbuf.template get_access<sycl::access::mode::write>(cgh);
+        reinterpret_subbuf.template get_access<sycl::access_mode::write>(cgh);
     cgh.parallel_for<KernelName>(
         reinterpret_subbuf.get_range(),
         [=](sycl::id<dim> index) { rb_acc[index] = val; });
@@ -61,7 +61,7 @@ int main() {
   sycl::buffer<unsigned int, 1> buf_i(r1);
   auto buf_char = buf_i.reinterpret<unsigned char>(r2);
   cmd_queue.submit([&](sycl::handler &cgh) {
-    auto acc = buf_char.get_access<sycl::access::mode::read_write>(cgh);
+    auto acc = buf_char.get_access<sycl::access_mode::read_write>(cgh);
     cgh.parallel_for<class chars>(r2,
                                   [=](sycl::id<1> i) { acc[i] = UCHAR_MAX; });
   });
@@ -81,7 +81,7 @@ int main() {
   sycl::buffer<unsigned int, 1> buf_1d(r1d);
   auto buf_2d = buf_1d.reinterpret<unsigned int>(r2d);
   cmd_queue.submit([&](sycl::handler &cgh) {
-    auto acc2d = buf_2d.get_access<sycl::access::mode::read_write>(cgh);
+    auto acc2d = buf_2d.get_access<sycl::access_mode::read_write>(cgh);
     cgh.parallel_for<class ones>(r2d, [=](sycl::item<2> itemID) {
       size_t i = itemID.get_id(0);
       size_t j = itemID.get_id(1);
@@ -194,7 +194,7 @@ int main() {
 
       cmd_queue.submit([&](sycl::handler &cgh) {
         auto rb_acc =
-            reinterpret_subbuf.get_access<sycl::access::mode::write>(cgh);
+            reinterpret_subbuf.get_access<sycl::access_mode::write>(cgh);
         cgh.parallel_for<class foo_3>(
             reinterpret_subbuf.get_range(),
             [=](sycl::id<1> index) { rb_acc[index] = 13; });

--- a/sycl/test-e2e/Basic/char_builtins.cpp
+++ b/sycl/test-e2e/Basic/char_builtins.cpp
@@ -46,9 +46,9 @@ template <typename T> int doCharTest(const T *A, const T *B, T *C) {
     buffer<T> BBuf(B, BufferSize);
     buffer<T> CBuf(C, BufferSize);
     Q.submit([&](handler &CGH) {
-      auto AAcc = ABuf.template get_access<access::mode::read>(CGH);
-      auto BAcc = BBuf.template get_access<access::mode::read>(CGH);
-      auto CAcc = CBuf.template get_access<access::mode::write>(CGH);
+      auto AAcc = ABuf.template get_access<access_mode::read>(CGH);
+      auto BAcc = BBuf.template get_access<access_mode::read>(CGH);
+      auto CAcc = CBuf.template get_access<access_mode::write>(CGH);
       CGH.single_task<>([=]() {
         CAcc[0] = clz(AAcc[0]);
         CAcc[1] = ctz(AAcc[1]);
@@ -69,7 +69,7 @@ template <typename T> int doCharTest(const T *A, const T *B, T *C) {
   {
     buffer<T> ABuf(A, BufferSize);
     Q.submit([&](handler &CGH) {
-      auto AAcc = ABuf.template get_access<access::mode::read_write>(CGH);
+      auto AAcc = ABuf.template get_access<access_mode::read_write>(CGH);
       local_accessor<T, 1> Local(range<1>{WorkGroupSize}, CGH);
 
       nd_range<1> NDR{range<1>(NElems), range<1>(WorkGroupSize)};

--- a/sycl/test-e2e/Basic/event.cpp
+++ b/sycl/test-e2e/Basic/event.cpp
@@ -70,7 +70,7 @@ int main() {
     float Scalar = 2.0;
     sycl::buffer<float, 1> Buf(&Data, sycl::range<1>(1));
     auto Event = Queue.submit([&](sycl::handler &cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(cgh);
 
       cgh.single_task<class test_event>([=]() { Acc[0] = Scalar; });
     });

--- a/sycl/test-e2e/Basic/fill_accessor.cpp
+++ b/sycl/test-e2e/Basic/fill_accessor.cpp
@@ -52,7 +52,7 @@ void CheckFillZeroDimAccessor(queue &Q, T Init, T Expected) {
   {
     buffer<T, Dims> Buffer(Data.data(), Range);
     Q.submit([&](handler &CGH) {
-       accessor<T, 0, sycl::access::mode::write> Accessor(Buffer, CGH);
+       accessor<T, 0, sycl::access_mode::write> Accessor(Buffer, CGH);
        CGH.fill(Accessor, Expected);
      }).wait_and_throw();
   }

--- a/sycl/test-e2e/Basic/free_function_queries/free_function_queries_sub_group.cpp
+++ b/sycl/test-e2e/Basic/free_function_queries/free_function_queries_sub_group.cpp
@@ -30,12 +30,12 @@ int main() {
       sycl::queue q;
       sycl::nd_range<1> NDR(sycl::range<1>{n}, sycl::range<1>{2});
       q.submit([&](sycl::handler &cgh) {
-        sycl::accessor<int, 1, sycl::access::mode::write,
+        sycl::accessor<int, 1, sycl::access_mode::write,
                        sycl::access::target::device>
-            acc(buf.get_access<sycl::access::mode::write>(cgh));
-        sycl::accessor<int, 1, sycl::access::mode::write,
+            acc(buf.get_access<sycl::access_mode::write>(cgh));
+        sycl::accessor<int, 1, sycl::access_mode::write,
                        sycl::access::target::device>
-            results_acc(results_buf.get_access<sycl::access::mode::write>(cgh));
+            results_acc(results_buf.get_access<sycl::access_mode::write>(cgh));
         cgh.parallel_for<class NdItemTest>(NDR, [=](auto nd_i) {
           static_assert(std::is_same<decltype(nd_i), sycl::nd_item<1>>::value,
                         "lambda arg type is unexpected");

--- a/sycl/test-e2e/Basic/group_async_copy_legacy.cpp
+++ b/sycl/test-e2e/Basic/group_async_copy_legacy.cpp
@@ -114,8 +114,8 @@ template <typename T> int test(size_t Stride) {
      // In must be read_write for legacy multi_ptr as it would otherwise produce
      // a const multi_ptr which was not a valid source argument to
      // async_work_group_copy in SYCL 1.2.1.
-     auto In = InBuf.template get_access<access::mode::read_write>(CGH);
-     auto Out = OutBuf.template get_access<access::mode::write>(CGH);
+     auto In = InBuf.template get_access<access_mode::read_write>(CGH);
+     auto Out = OutBuf.template get_access<access_mode::write>(CGH);
      local_accessor<T, 1> Local(range<1>{WorkGroupSize}, CGH);
 
      nd_range<1> NDR{range<1>(NElems), range<1>(WorkGroupSize)};

--- a/sycl/test-e2e/Basic/handler/handler_copy_with_offset.cpp
+++ b/sycl/test-e2e/Basic/handler/handler_copy_with_offset.cpp
@@ -19,8 +19,8 @@
 #include <vector>
 
 using namespace sycl;
-constexpr access::mode read = access::mode::read;
-constexpr access::mode write = access::mode::write;
+constexpr access_mode read = access_mode::read;
+constexpr access_mode write = access_mode::write;
 constexpr access::target ondevice = access::target::device;
 
 int main() {

--- a/sycl/test-e2e/Basic/host-task-dependency.cpp
+++ b/sycl/test-e2e/Basic/host-task-dependency.cpp
@@ -27,10 +27,9 @@ struct Context {
 
 S::event HostTask_CopyBuf1ToBuf2(Context *Ctx) {
   S::event Event = Ctx->Queue.submit([&](S::handler &CGH) {
-    S::host_accessor<int, 1, S::access_mode::read> CopierSrcAcc(Ctx->Buf1,
-                                                                 CGH);
+    S::host_accessor<int, 1, S::access_mode::read> CopierSrcAcc(Ctx->Buf1, CGH);
     S::host_accessor<int, 1, S::access_mode::write> CopierDstAcc(Ctx->Buf2,
-                                                                  CGH);
+                                                                 CGH);
 
     auto CopierHostTask = [=] {
       for (size_t Idx = 0; Idx < CopierDstAcc.size(); ++Idx)
@@ -92,8 +91,8 @@ void Thread1Fn(Context *Ctx) {
 
   // 3. submit simple task to move data between two buffers
   Ctx->Queue.submit([&](S::handler &CGH) {
-    S::accessor<int, 1, S::access_mode::read, S::access::target::device>
-        SrcAcc(Ctx->Buf2, CGH);
+    S::accessor<int, 1, S::access_mode::read, S::access::target::device> SrcAcc(
+        Ctx->Buf2, CGH);
     S::accessor<int, 1, S::access_mode::write, S::access::target::device>
         DstAcc(Ctx->Buf3, CGH);
 

--- a/sycl/test-e2e/Basic/host-task-dependency.cpp
+++ b/sycl/test-e2e/Basic/host-task-dependency.cpp
@@ -27,9 +27,9 @@ struct Context {
 
 S::event HostTask_CopyBuf1ToBuf2(Context *Ctx) {
   S::event Event = Ctx->Queue.submit([&](S::handler &CGH) {
-    S::host_accessor<int, 1, S::access::mode::read> CopierSrcAcc(Ctx->Buf1,
+    S::host_accessor<int, 1, S::access_mode::read> CopierSrcAcc(Ctx->Buf1,
                                                                  CGH);
-    S::host_accessor<int, 1, S::access::mode::write> CopierDstAcc(Ctx->Buf2,
+    S::host_accessor<int, 1, S::access_mode::write> CopierDstAcc(Ctx->Buf2,
                                                                   CGH);
 
     auto CopierHostTask = [=] {
@@ -54,21 +54,21 @@ S::event HostTask_CopyBuf1ToBuf2(Context *Ctx) {
 void Thread1Fn(Context *Ctx) {
   // 0. initialize resulting buffer with apriori wrong result
   {
-    S::host_accessor<int, 1, S::access::mode::write> Acc(Ctx->Buf1);
+    S::host_accessor<int, 1, S::access_mode::write> Acc(Ctx->Buf1);
 
     for (size_t Idx = 0; Idx < Acc.size(); ++Idx)
       Acc[Idx] = -1;
   }
 
   {
-    S::host_accessor<int, 1, S::access::mode::write> Acc(Ctx->Buf2);
+    S::host_accessor<int, 1, S::access_mode::write> Acc(Ctx->Buf2);
 
     for (size_t Idx = 0; Idx < Acc.size(); ++Idx)
       Acc[Idx] = -2;
   }
 
   {
-    S::host_accessor<int, 1, S::access::mode::write> Acc(Ctx->Buf3);
+    S::host_accessor<int, 1, S::access_mode::write> Acc(Ctx->Buf3);
 
     for (size_t Idx = 0; Idx < Acc.size(); ++Idx)
       Acc[Idx] = -3;
@@ -76,7 +76,7 @@ void Thread1Fn(Context *Ctx) {
 
   // 1. submit task writing to buffer 1
   Ctx->Queue.submit([&](S::handler &CGH) {
-    S::accessor<int, 1, S::access::mode::write, S::access::target::device>
+    S::accessor<int, 1, S::access_mode::write, S::access::target::device>
         GeneratorAcc(Ctx->Buf1, CGH);
 
     auto GeneratorKernel = [GeneratorAcc] {
@@ -92,9 +92,9 @@ void Thread1Fn(Context *Ctx) {
 
   // 3. submit simple task to move data between two buffers
   Ctx->Queue.submit([&](S::handler &CGH) {
-    S::accessor<int, 1, S::access::mode::read, S::access::target::device>
+    S::accessor<int, 1, S::access_mode::read, S::access::target::device>
         SrcAcc(Ctx->Buf2, CGH);
-    S::accessor<int, 1, S::access::mode::write, S::access::target::device>
+    S::accessor<int, 1, S::access_mode::write, S::access::target::device>
         DstAcc(Ctx->Buf3, CGH);
 
     CGH.depends_on(HostTaskEvent);
@@ -109,7 +109,7 @@ void Thread1Fn(Context *Ctx) {
 
   // 4. check data in buffer #3
   {
-    S::host_accessor<int, 1, S::access::mode::read> Acc(Ctx->Buf3);
+    S::host_accessor<int, 1, S::access_mode::read> Acc(Ctx->Buf3);
 
     bool Failure = false;
 
@@ -154,7 +154,7 @@ void test() {
 
   // 3. check via host accessor that buf 2 contains valid data
   {
-    S::host_accessor<int, 1, S::access::mode::read> ResultAcc(Ctx.Buf2);
+    S::host_accessor<int, 1, S::access_mode::read> ResultAcc(Ctx.Buf2);
 
     bool Failure = false;
     for (size_t Idx = 0; Idx < ResultAcc.size(); ++Idx) {

--- a/sycl/test-e2e/Basic/image/image_accessor_readsampler.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_readsampler.cpp
@@ -67,8 +67,8 @@ void checkReadSampler(char *host_ptr, s::sampler Sampler, s::float4 Coord,
     s::queue myQueue;
     s::buffer<s::float4, 1> ReadDataBuf(&ReadData, s::range<1>(1));
     myQueue.submit([&](s::handler &cgh) {
-      auto ReadAcc = Img.get_access<s::float4, s::access::mode::read>(cgh);
-      s::accessor<s::float4, 1, s::access::mode::write> ReadDataBufAcc(
+      auto ReadAcc = Img.get_access<s::float4, s::access_mode::read>(cgh);
+      s::accessor<s::float4, 1, s::access_mode::write> ReadDataBufAcc(
           ReadDataBuf, cgh);
 
       cgh.single_task<class kernel_class<i>>([=]() {

--- a/sycl/test-e2e/Basic/image/image_array.cpp
+++ b/sycl/test-e2e/Basic/image/image_array.cpp
@@ -57,9 +57,9 @@ int main() {
 
     TestQueue Q{sycl::default_selector_v};
 
-    constexpr auto SYCLRead = sycl::access::mode::read;
-    constexpr auto SYCLWrite = sycl::access::mode::write;
-    constexpr auto SYCLReadWrite = sycl::access::mode::read_write;
+    constexpr auto SYCLRead = sycl::access_mode::read;
+    constexpr auto SYCLWrite = sycl::access_mode::write;
+    constexpr auto SYCLReadWrite = sycl::access_mode::read_write;
 
     Q.submit([&](sycl::handler &CGH) {
       auto ImgAcc = Img.get_access<sycl::float4, SYCLRead>(CGH);

--- a/sycl/test-e2e/Basic/image/image_sample.cpp
+++ b/sycl/test-e2e/Basic/image/image_sample.cpp
@@ -51,8 +51,8 @@ bool test1d_coord(dataT *hostPtr, coordT coord, dataT expectedColour) {
     // Do the test by reading a single pixel from the image
     s::queue myQueue(s::default_selector_v);
     myQueue.submit([&](s::handler &cgh) {
-      auto imageAcc = image.get_access<dataT, s::access::mode::read>(cgh);
-      s::accessor<dataT, 1, s::access::mode::write> resultDataAcc(resultDataBuf,
+      auto imageAcc = image.get_access<dataT, s::access_mode::read>(cgh);
+      s::accessor<dataT, 1, s::access_mode::write> resultDataAcc(resultDataBuf,
                                                                   cgh);
 
       cgh.single_task<test_1d_class>([=]() {
@@ -86,8 +86,8 @@ bool test2d_coord(dataT *hostPtr, coordT coord, dataT expectedColour) {
     // Do the test by reading a single pixel from the image
     s::queue myQueue(s::default_selector_v);
     myQueue.submit([&](s::handler &cgh) {
-      auto imageAcc = image.get_access<dataT, s::access::mode::read>(cgh);
-      s::accessor<dataT, 1, s::access::mode::write> resultDataAcc(resultDataBuf,
+      auto imageAcc = image.get_access<dataT, s::access_mode::read>(cgh);
+      s::accessor<dataT, 1, s::access_mode::write> resultDataAcc(resultDataBuf,
                                                                   cgh);
 
       cgh.single_task<test_2d_class>([=]() {
@@ -121,8 +121,8 @@ bool test3d_coord(dataT *hostPtr, coordT coord, dataT expectedColour) {
     // Do the test by reading a single pixel from the image
     s::queue myQueue(s::default_selector_v);
     myQueue.submit([&](s::handler &cgh) {
-      auto imageAcc = image.get_access<dataT, s::access::mode::read>(cgh);
-      s::accessor<dataT, 1, s::access::mode::write> resultDataAcc(resultDataBuf,
+      auto imageAcc = image.get_access<dataT, s::access_mode::read>(cgh);
+      s::accessor<dataT, 1, s::access_mode::write> resultDataAcc(resultDataBuf,
                                                                   cgh);
 
       cgh.single_task<test_3d_class>([=]() {

--- a/sycl/test-e2e/Basic/image/image_sample.cpp
+++ b/sycl/test-e2e/Basic/image/image_sample.cpp
@@ -53,7 +53,7 @@ bool test1d_coord(dataT *hostPtr, coordT coord, dataT expectedColour) {
     myQueue.submit([&](s::handler &cgh) {
       auto imageAcc = image.get_access<dataT, s::access_mode::read>(cgh);
       s::accessor<dataT, 1, s::access_mode::write> resultDataAcc(resultDataBuf,
-                                                                  cgh);
+                                                                 cgh);
 
       cgh.single_task<test_1d_class>([=]() {
         dataT RetColor = imageAcc.read(coord, testSampler);
@@ -88,7 +88,7 @@ bool test2d_coord(dataT *hostPtr, coordT coord, dataT expectedColour) {
     myQueue.submit([&](s::handler &cgh) {
       auto imageAcc = image.get_access<dataT, s::access_mode::read>(cgh);
       s::accessor<dataT, 1, s::access_mode::write> resultDataAcc(resultDataBuf,
-                                                                  cgh);
+                                                                 cgh);
 
       cgh.single_task<test_2d_class>([=]() {
         dataT RetColor = imageAcc.read(coord, testSampler);
@@ -123,7 +123,7 @@ bool test3d_coord(dataT *hostPtr, coordT coord, dataT expectedColour) {
     myQueue.submit([&](s::handler &cgh) {
       auto imageAcc = image.get_access<dataT, s::access_mode::read>(cgh);
       s::accessor<dataT, 1, s::access_mode::write> resultDataAcc(resultDataBuf,
-                                                                  cgh);
+                                                                 cgh);
 
       cgh.single_task<test_3d_class>([=]() {
         dataT RetColor = imageAcc.read(coord, testSampler);

--- a/sycl/test-e2e/Basic/image/srgba-read.cpp
+++ b/sycl/test-e2e/Basic/image/srgba-read.cpp
@@ -53,8 +53,8 @@ void test_rd(image_channel_order ChanOrder, image_channel_type ChanType) {
 
     Q.submit([&](handler &cgh) {
       auto image_acc =
-          image_2D.get_access<accessorPixelT, access::mode::read>(cgh);
-      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+          image_2D.get_access<accessorPixelT, access_mode::read>(cgh);
+      auto test_acc = testResults.get_access<access_mode::write>(cgh);
 
       cgh.single_task<class im2D_rw>([=]() {
         int i = 0; // the index for writing into the testResult buffer.

--- a/sycl/test-e2e/Basic/kernel_bundle/kernel_bundle_api_hip.cpp
+++ b/sycl/test-e2e/Basic/kernel_bundle/kernel_bundle_api_hip.cpp
@@ -147,7 +147,7 @@ int main() {
     // The error handling tests rely on Kernel3Name binary existing.
     sycl::buffer<int, 1> Buf(sycl::range<1>{1});
     Q.submit([&](sycl::handler &CGH) {
-      auto Acc = Buf.get_access<sycl::access::mode::write>(CGH);
+      auto Acc = Buf.get_access<sycl::access_mode::write>(CGH);
       CGH.single_task<Kernel3Name>([=]() { Acc[0] = 42; });
     });
 

--- a/sycl/test-e2e/Basic/linear-sub_group.cpp
+++ b/sycl/test-e2e/Basic/linear-sub_group.cpp
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]) {
   {
     buffer<int, 2> output_buf(output.data(), range<2>(outer, inner));
     q.submit([&](handler &cgh) {
-      auto output = output_buf.get_access<access::mode::read_write>(cgh);
+      auto output = output_buf.get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<class linear_id>(
           nd_range<2>(range<2>(outer, inner), range<2>(outer, inner)),
           [=](nd_item<2> it) {

--- a/sycl/test-e2e/Basic/multi_ptr_null_relational_operators.cpp
+++ b/sycl/test-e2e/Basic/multi_ptr_null_relational_operators.cpp
@@ -33,7 +33,7 @@ void nullptrRelationalOperatorTest() {
     sycl::buffer<int, 1> buf(1);
     queue
         .submit([&](sycl::handler &cgh) {
-          auto dev_acc = buf.get_access<sycl::access::mode::write>(cgh);
+          auto dev_acc = buf.get_access<sycl::access_mode::write>(cgh);
           if constexpr (address_space ==
                         sycl::access::address_space::local_space) {
             sycl::local_accessor<int, 1> locAcc(1, cgh);

--- a/sycl/test-e2e/Basic/nested_queue_submit.cpp
+++ b/sycl/test-e2e/Basic/nested_queue_submit.cpp
@@ -20,7 +20,7 @@ void nestedSubmitParallelFor(sycl::queue &q) {
   {
     sycl::buffer<float> buf(array.data(), sycl::range<1>{n});
     q.submit([&](sycl::handler &h) {
-      auto acc = buf.get_access<sycl::access::mode::write>(h);
+      auto acc = buf.get_access<sycl::access_mode::write>(h);
       q.parallel_for<class zero>(sycl::range<1>{n},
                                  [=](sycl::id<1> i) { acc[i] = float(0.0); });
     });

--- a/sycl/test-e2e/Basic/parallel_for_user_types.cpp
+++ b/sycl/test-e2e/Basic/parallel_for_user_types.cpp
@@ -40,7 +40,7 @@ int main() {
   // Check user defined sycl::item wrapper
   sycl::buffer<int> data_buf(data, sz);
   q.submit([&](sycl::handler &h) {
-    auto buf_acc = data_buf.get_access<sycl::access::mode::read_write>(h);
+    auto buf_acc = data_buf.get_access<sycl::access_mode::read_write>(h);
     h.parallel_for(sycl::range<1>{sz},
                    [=](item_wrapper<1> item) { buf_acc[item.get()] += 1; });
   });
@@ -60,7 +60,7 @@ int main() {
 
   // Check user defined sycl::nd_item wrapper
   q.submit([&](sycl::handler &h) {
-    auto buf_acc = data_buf.get_access<sycl::access::mode::read_write>(h);
+    auto buf_acc = data_buf.get_access<sycl::access_mode::read_write>(h);
     h.parallel_for(sycl::nd_range<1>{sz, 2},
                    [=](nd_item_wrapper<1> item) { buf_acc[item.get()] += 1; });
   });

--- a/sycl/test-e2e/Basic/span.cpp
+++ b/sycl/test-e2e/Basic/span.cpp
@@ -41,7 +41,7 @@ void testSpanCapture() {
   usm_span[0] += 100; // 101 modify first value using span affordance.
 
   event E = Q.submit([&](handler &cgh) {
-    auto can_read_from_span_acc = SpanRead.get_access<access::mode::write>(cgh);
+    auto can_read_from_span_acc = SpanRead.get_access<access_mode::write>(cgh);
     cgh.single_task<class hi>([=] {
       // read from the spans.
       can_read_from_span_acc[0] = vecUSM_span[0];
@@ -84,7 +84,7 @@ void testSpanOnDevice() {
   buffer<int, 1> SpanRead(NumberOfReadTestsRange);
 
   event E = Q.submit([&](handler &cgh) {
-    auto can_read_from_span_acc = SpanRead.get_access<access::mode::write>(cgh);
+    auto can_read_from_span_acc = SpanRead.get_access<access_mode::write>(cgh);
     cgh.single_task<class ha>([=] {
       // create a span on device, pass it to function that modifies it
       // read values back out.

--- a/sycl/test-e2e/Basic/sycl-namespace.cpp
+++ b/sycl/test-e2e/Basic/sycl-namespace.cpp
@@ -9,7 +9,7 @@ int main() {
   {
     sycl::buffer<int, 1> b(&r, 1);
     q.submit([&](sycl::handler &h) {
-      auto a = b.get_access<sycl::access::mode::write>(h);
+      auto a = b.get_access<sycl::access_mode::write>(h);
       h.single_task<class T>([=]() { a[0] = 42; });
     });
   }

--- a/sycl/test-e2e/Basic/vector/byte.cpp
+++ b/sycl/test-e2e/Basic/vector/byte.cpp
@@ -72,7 +72,7 @@ int main() {
     sycl::queue Queue;
     Queue
         .submit([&](sycl::handler &cgh) {
-          auto Acc = Buf.get_access<sycl::access::mode::read_write>(cgh);
+          auto Acc = Buf.get_access<sycl::access_mode::read_write>(cgh);
           cgh.single_task<class st>([=]() {
             // load
             sycl::multi_ptr<std::byte,

--- a/sycl/test-e2e/Config/env_vars.cpp
+++ b/sycl/test-e2e/Config/env_vars.cpp
@@ -26,7 +26,7 @@ int main() {
   bool shouldCrash = env::isDefined("SHOULD_CRASH");
   try {
     myQueue.submit([&](handler &cgh) {
-      auto B = buf.get_access<access::mode::read_write>(cgh);
+      auto B = buf.get_access<access_mode::read_write>(cgh);
       cgh.single_task<class kernel_name1>([=]() { B[0] = 0; });
     });
     assert(!shouldCrash);

--- a/sycl/test-e2e/DeprecatedFeatures/set_arg_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/set_arg_interop.cpp
@@ -58,8 +58,8 @@ int main() {
     buffer<float, 1> FirstBuffer(Array, range<1>(1));
     buffer<int, 1> SecondBuffer(&Value, range<1>(1));
     Queue.submit([&](handler &CGH) {
-      CGH.set_arg(0, FirstBuffer.get_access<access::mode::write>(CGH));
-      CGH.set_arg(1, SecondBuffer.get_access<access::mode::write>(CGH));
+      CGH.set_arg(0, FirstBuffer.get_access<access_mode::write>(CGH));
+      CGH.set_arg(1, SecondBuffer.get_access<access_mode::write>(CGH));
       CGH.single_task(FirstKernel);
     });
   }
@@ -71,8 +71,8 @@ int main() {
   {
     buffer<float, 1> FirstBuffer(Array, range<1>(Count));
     Queue.submit([&](handler &CGH) {
-      auto Acc = FirstBuffer.get_access<access::mode::read_write>(CGH);
-      CGH.set_arg(0, FirstBuffer.get_access<access::mode::read_write>(CGH));
+      auto Acc = FirstBuffer.get_access<access_mode::read_write>(CGH);
+      CGH.set_arg(0, FirstBuffer.get_access<access_mode::read_write>(CGH));
       CGH.parallel_for(range<1>{Count}, SecondKernel);
     });
   }
@@ -105,9 +105,9 @@ int main() {
   {
     buffer<float, 1> FirstBuffer(Array, range<1>(Count));
     Queue.submit([&](handler &CGH) {
-      auto Acc = FirstBuffer.get_access<access::mode::read_write>(CGH);
-      CGH.set_arg(0, FirstBuffer.get_access<access::mode::read_write>(CGH));
-      CGH.set_arg(1, sycl::accessor<float, 1, sycl::access::mode::read_write,
+      auto Acc = FirstBuffer.get_access<access_mode::read_write>(CGH);
+      CGH.set_arg(0, FirstBuffer.get_access<access_mode::read_write>(CGH));
+      CGH.set_arg(1, sycl::accessor<float, 1, sycl::access_mode::read_write,
                                     sycl::access::target::local>(
                          sycl::range<1>(Count), CGH));
       CGH.parallel_for(range<1>{Count}, ThirdKernel);

--- a/sycl/test-e2e/DeviceGlobal/device_global_arrow.hpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_arrow.hpp
@@ -32,7 +32,7 @@ int test() {
   {
     buffer<int, 1> OutBuf{Out, 2};
     Q.submit([&](handler &CGH) {
-      auto OutAcc = OutBuf.get_access<access::mode::write>(CGH);
+      auto OutAcc = OutBuf.get_access<access_mode::write>(CGH);
       CGH.single_task([=]() {
         OutAcc[0] = DeviceGlobalVar1->getX();
         OutAcc[1] = DeviceGlobalVar2->getX();

--- a/sycl/test-e2e/DeviceGlobal/device_global_static.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_static.cpp
@@ -27,7 +27,7 @@ int main() {
   {
     buffer<int, 1> OutBuf(&OutVal, 1);
     Q.submit([&](handler &CGH) {
-      auto OutAcc = OutBuf.get_access<access::mode::write>(CGH);
+      auto OutAcc = OutBuf.get_access<access_mode::write>(CGH);
       CGH.single_task([=]() { OutAcc[0] = DeviceGlobalVar.get()[0]; });
     });
   }

--- a/sycl/test-e2e/DeviceLib/ITTAnnotations/barrier.cpp
+++ b/sycl/test-e2e/DeviceLib/ITTAnnotations/barrier.cpp
@@ -19,7 +19,7 @@ int main() {
     // Ensure that a simple kernel gets run when instrumented with
     // ITT start/finish annotations and ITT wg_barrier/wi_resume annotations.
     q.submit([&](handler &cgh) {
-      auto acc = buf.get_access<access::mode::read_write>(cgh);
+      auto acc = buf.get_access<access_mode::read_write>(cgh);
       local_accessor<int, 1> local_acc(local_range, cgh);
       cgh.parallel_for<class simple_barrier_kernel>(
           nd_range<1>(num_items, local_range), [=](nd_item<1> item) {

--- a/sycl/test-e2e/DeviceLib/built-ins/ext_native_math_common.hpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/ext_native_math_common.hpp
@@ -33,7 +33,7 @@ void native_tanh_tester(sycl::queue q, T val, T up, T lo) {
   {
     sycl::buffer<T, 1> BufR(&r, sycl::range<1>(1));
     q.submit([&](sycl::handler &cgh) {
-      auto AccR = BufR.template get_access<sycl::access::mode::read_write>(cgh);
+      auto AccR = BufR.template get_access<sycl::access_mode::read_write>(cgh);
       cgh.single_task([=]() {
         AccR[0] = sycl::ext::oneapi::experimental::native::tanh(AccR[0]);
       });
@@ -54,7 +54,7 @@ void native_exp2_tester(sycl::queue q, T val, T up, T lo) {
   {
     sycl::buffer<T, 1> BufR(&r, sycl::range<1>(1));
     q.submit([&](sycl::handler &cgh) {
-      auto AccR = BufR.template get_access<sycl::access::mode::read_write>(cgh);
+      auto AccR = BufR.template get_access<sycl::access_mode::read_write>(cgh);
       cgh.single_task([=]() {
         AccR[0] = sycl::ext::oneapi::experimental::native::exp2(AccR[0]);
       });

--- a/sycl/test-e2e/DeviceLib/built-ins/scalar_common.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/scalar_common.cpp
@@ -17,7 +17,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class maxF1F1>(
             [=]() { AccR[0] = s::max(float{0.5f}, float{2.3f}); });
       });

--- a/sycl/test-e2e/DeviceLib/built-ins/scalar_math.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/scalar_math.cpp
@@ -21,7 +21,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class acosF1>([=]() { AccR[0] = s::acos(float{0.5}); });
       });
     }
@@ -35,7 +35,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class acoshF1>(
             [=]() { AccR[0] = s::acosh(float{2.4}); });
       });
@@ -50,7 +50,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class asinF1>([=]() { AccR[0] = s::asin(float{0.5}); });
       });
     }
@@ -64,7 +64,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class asinhF1>(
             [=]() { AccR[0] = s::asinh(float{0.5}); });
       });
@@ -79,7 +79,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class atanF1>([=]() { AccR[0] = s::atan(float{0.5}); });
       });
     }
@@ -93,7 +93,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class atanhF1>(
             [=]() { AccR[0] = s::atanh(float{0.5}); });
       });
@@ -108,7 +108,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class cbrtF1>(
             [=]() { AccR[0] = s::cbrt(float{27.0}); });
       });
@@ -123,7 +123,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class ceilF1>([=]() { AccR[0] = s::ceil(float{0.5}); });
       });
     }
@@ -137,7 +137,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class cosF1>([=]() { AccR[0] = s::cos(float{0.5}); });
       });
     }
@@ -151,7 +151,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class coshF1>([=]() { AccR[0] = s::cosh(float{0.5}); });
       });
     }
@@ -165,7 +165,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class cospiF1>(
             [=]() { AccR[0] = s::cospi(float{0.1}); });
       });
@@ -180,7 +180,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class erfcF1>([=]() { AccR[0] = s::erfc(float{0.5}); });
       });
     }
@@ -194,7 +194,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class erfF1>([=]() { AccR[0] = s::erf(float{0.5}); });
       });
     }
@@ -208,7 +208,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class expF1>([=]() { AccR[0] = s::exp(float{0.5}); });
       });
     }
@@ -222,7 +222,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class exp2F1>([=]() { AccR[0] = s::exp2(float{8.0}); });
       });
     }
@@ -236,7 +236,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class exp10F1>([=]() { AccR[0] = s::exp10(float{2}); });
       });
     }
@@ -250,7 +250,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class expm1F1>(
             [=]() { AccR[0] = s::expm1(float{0.5}); });
       });
@@ -265,7 +265,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class fabsF1>(
             [=]() { AccR[0] = s::fabs(float{-0.5}); });
       });
@@ -280,7 +280,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class floorF1>(
             [=]() { AccR[0] = s::floor(float{0.5}); });
       });
@@ -295,7 +295,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class fmaxF1F1>(
             [=]() { AccR[0] = s::fmax(float{0.5}, float{0.8}); });
       });
@@ -310,7 +310,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class fminF1F1>(
             [=]() { AccR[0] = s::fmin(float{0.5}, float{0.8}); });
       });
@@ -325,7 +325,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class fmodF1F1>(
             [=]() { AccR[0] = s::fmod(float{5.1}, float{3.0}); });
       });
@@ -340,7 +340,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::read_write>(cgh);
         cgh.single_task<class lgammaF1>(
             [=]() { AccR[0] = s::lgamma(float{10.f}); });
       });
@@ -355,7 +355,7 @@ int main() {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::read_write>(cgh);
         cgh.single_task<class lgammaF1_neg>(
             [=]() { AccR[0] = s::lgamma(float{-2.4f}); });
       });

--- a/sycl/test-e2e/DeviceLib/built-ins/vector_common.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/vector_common.cpp
@@ -17,7 +17,7 @@ int main() {
       s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class maxF2F2>([=]() {
           AccR[0] = s::max(s::float2{0.5f, 3.4f}, s::float2{2.3f, 0.4f});
         });
@@ -36,7 +36,7 @@ int main() {
       s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class maxF2F1>([=]() {
           AccR[0] = s::max(s::float2{0.5f, 3.4f}, float{3.0f});
         });

--- a/sycl/test-e2e/DeviceLib/built-ins/vector_math.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/vector_math.cpp
@@ -20,7 +20,7 @@ int main() {
       s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class fminF2F2>([=]() {
           AccR[0] = s::fmin(s::float2{0.5f, 3.4f}, s::float2{2.3f, 0.4f});
         });
@@ -39,7 +39,7 @@ int main() {
       s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class fabsF2>([=]() {
           AccR[0] = s::fabs(s::float2{-1.0f, 2.0f});
         });
@@ -58,7 +58,7 @@ int main() {
       s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class floorF2>([=]() {
           AccR[0] = s::floor(s::float2{1.4f, 2.8f});
         });
@@ -77,7 +77,7 @@ int main() {
       s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::write>(cgh);
         cgh.single_task<class ceilF2>([=]() {
           AccR[0] = s::ceil(s::float2{1.4f, 2.8f});
         });
@@ -99,8 +99,8 @@ int main() {
 
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
-        auto AccI = BufI.get_access<s::access::mode::read_write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::read_write>(cgh);
+        auto AccI = BufI.get_access<s::access_mode::read_write>(cgh);
         cgh.single_task<class fractF2GF2>([=]() {
           s::global_ptr<s::float2> Iptr(AccI);
           AccR[0] = s::fract(s::float2{1.5f, 2.5f}, Iptr);
@@ -128,8 +128,8 @@ int main() {
       s::buffer<s::float2, 1> BufI(&i, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
-        auto AccI = BufI.get_access<s::access::mode::read_write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::read_write>(cgh);
+        auto AccI = BufI.get_access<s::access_mode::read_write>(cgh);
         cgh.single_task<class fractF2PF2>([=]() {
           s::float2 temp(0.0);
           s::private_ptr<s::float2> Iptr(&temp);
@@ -157,7 +157,7 @@ int main() {
       s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::read_write>(cgh);
         cgh.single_task<class lgamma_rF2>([=]() {
           AccR[0] = s::lgamma(s::float2{10.f, -2.4f});
         });
@@ -180,8 +180,8 @@ int main() {
       s::buffer<s::int2, 1> BufI(&i, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
-        auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
-        auto AccI = BufI.get_access<s::access::mode::read_write>(cgh);
+        auto AccR = BufR.get_access<s::access_mode::read_write>(cgh);
+        auto AccI = BufI.get_access<s::access_mode::read_write>(cgh);
         cgh.single_task<class lgamma_rF2PF2>([=]() {
           s::int2 temp(0.0);
           s::private_ptr<s::int2> Iptr(&temp);

--- a/sycl/test-e2e/DeviceLib/c99_complex_math_test.cpp
+++ b/sycl/test-e2e/DeviceLib/c99_complex_math_test.cpp
@@ -58,7 +58,7 @@ float _Complex catanhf(float _Complex z);
 }
 
 namespace s = sycl;
-constexpr s::access::mode sycl_write = s::access::mode::write;
+constexpr s::access_mode sycl_write = s::access_mode::write;
 
 bool approx_equal_cmplx_f(float _Complex x, float _Complex y) {
   return approx_equal_fp(__real__ x, __real__ y) &&

--- a/sycl/test-e2e/DeviceLib/complex_utils.hpp
+++ b/sycl/test-e2e/DeviceLib/complex_utils.hpp
@@ -309,9 +309,9 @@ int device_complex_test_mul(sycl::queue &deviceQueue,
         complex_mul_result.data(), numOfMulOutput);
     deviceQueue.submit([&](sycl::handler &cgh) {
       auto complex_mul_access =
-          buffer_complex_mul.template get_access<sycl::access::mode::read>(cgh);
+          buffer_complex_mul.template get_access<sycl::access_mode::read>(cgh);
       auto complex_mul_res_access =
-          buffer_complex_mul_res.template get_access<sycl::access::mode::write>(
+          buffer_complex_mul_res.template get_access<sycl::access_mode::write>(
               cgh);
       cgh.single_task<class DeviceComplexMulTest>([=]() {
         size_t i, j;
@@ -349,9 +349,9 @@ int device_complex_test_div(sycl::queue &deviceQueue,
         complex_div_result.data(), numOfDivOutput);
     deviceQueue.submit([&](sycl::handler &cgh) {
       auto complex_div_access =
-          buffer_complex_div.template get_access<sycl::access::mode::read>(cgh);
+          buffer_complex_div.template get_access<sycl::access_mode::read>(cgh);
       auto complex_div_res_access =
-          buffer_complex_div_res.template get_access<sycl::access::mode::write>(
+          buffer_complex_div_res.template get_access<sycl::access_mode::write>(
               cgh);
       cgh.single_task<class DeviceComplexDivTest>([=]() {
         size_t i, j;

--- a/sycl/test-e2e/DeviceLib/imf/simd_emulate_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf/simd_emulate_test.cpp
@@ -7,8 +7,8 @@
 #include <sycl/ext/intel/math.hpp>
 
 namespace s = sycl;
-constexpr s::access::mode sycl_read = s::access::mode::read;
-constexpr s::access::mode sycl_write = s::access::mode::write;
+constexpr s::access_mode sycl_read = s::access_mode::read;
+constexpr s::access_mode sycl_write = s::access_mode::write;
 
 void run_vabs2_4_test(s::queue &queue) {
   bool pass = true;

--- a/sycl/test-e2e/DeviceLib/math_override_test.cpp
+++ b/sycl/test-e2e/DeviceLib/math_override_test.cpp
@@ -5,8 +5,8 @@
 
 #include "math_utils.hpp"
 namespace s = sycl;
-constexpr s::access::mode sycl_read = s::access::mode::read;
-constexpr s::access::mode sycl_write = s::access::mode::write;
+constexpr s::access_mode sycl_read = s::access_mode::read;
+constexpr s::access_mode sycl_write = s::access_mode::write;
 
 // Dummy function provided by user to override device library
 // version.

--- a/sycl/test-e2e/DeviceLib/math_windows_test.cpp
+++ b/sycl/test-e2e/DeviceLib/math_windows_test.cpp
@@ -13,8 +13,8 @@
 #include <sycl/detail/core.hpp>
 
 namespace s = sycl;
-constexpr s::access::mode sycl_read = s::access::mode::read;
-constexpr s::access::mode sycl_write = s::access::mode::write;
+constexpr s::access_mode sycl_read = s::access_mode::read;
+constexpr s::access_mode sycl_write = s::access_mode::write;
 
 #define TEST_NUM 35
 

--- a/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
@@ -10,8 +10,8 @@
 
 using std::complex;
 namespace s = sycl;
-constexpr s::access::mode sycl_read = s::access::mode::read;
-constexpr s::access::mode sycl_write = s::access::mode::write;
+constexpr s::access_mode sycl_read = s::access_mode::read;
+constexpr s::access_mode sycl_write = s::access_mode::write;
 
 template <typename T> bool approx_equal_cmplx(complex<T> x, complex<T> y) {
   return approx_equal_fp(x.real(), y.real()) &&

--- a/sycl/test-e2e/DotProduct/dot_product_vec_test.cpp
+++ b/sycl/test-e2e/DotProduct/dot_product_vec_test.cpp
@@ -66,10 +66,10 @@ static bool testss(queue &Q) {
   buffer<int32_t, 1> Dbuf(D, range<1>(RangeLength));
 
   Q.submit([&](handler &cgh) {
-    auto Ap = Abuf.get_access<access::mode::read>(cgh);
-    auto Bp = Bbuf.get_access<access::mode::read>(cgh);
-    auto Cp = Cbuf.get_access<access::mode::read>(cgh);
-    auto Dp = Dbuf.get_access<access::mode::write>(cgh);
+    auto Ap = Abuf.get_access<access_mode::read>(cgh);
+    auto Bp = Bbuf.get_access<access_mode::read>(cgh);
+    auto Cp = Cbuf.get_access<access_mode::read>(cgh);
+    auto Dp = Dbuf.get_access<access_mode::write>(cgh);
 
     cgh.parallel_for<class tss>(range<1>(RangeLength), [=](id<1> I) {
       Dp[I] = dot_acc(Ap[I], Bp[I], Cp[I]);
@@ -105,10 +105,10 @@ static bool testuu(queue &Q) {
   buffer<int32_t, 1> Dbuf(D, range<1>(RangeLength));
 
   Q.submit([&](handler &cgh) {
-    auto Ap = Abuf.get_access<access::mode::read>(cgh);
-    auto Bp = Bbuf.get_access<access::mode::read>(cgh);
-    auto Cp = Cbuf.get_access<access::mode::read>(cgh);
-    auto Dp = Dbuf.get_access<access::mode::write>(cgh);
+    auto Ap = Abuf.get_access<access_mode::read>(cgh);
+    auto Bp = Bbuf.get_access<access_mode::read>(cgh);
+    auto Cp = Cbuf.get_access<access_mode::read>(cgh);
+    auto Dp = Dbuf.get_access<access_mode::write>(cgh);
 
     cgh.parallel_for<class tuu>(range<1>(RangeLength), [=](id<1> I) {
       Dp[I] = dot_acc(Ap[I], Bp[I], Cp[I]);
@@ -144,10 +144,10 @@ static bool testsu(queue &Q) {
   buffer<int32_t, 1> Dbuf(D, range<1>(RangeLength));
 
   Q.submit([&](handler &cgh) {
-    auto Ap = Abuf.get_access<access::mode::read>(cgh);
-    auto Bp = Bbuf.get_access<access::mode::read>(cgh);
-    auto Cp = Cbuf.get_access<access::mode::read>(cgh);
-    auto Dp = Dbuf.get_access<access::mode::write>(cgh);
+    auto Ap = Abuf.get_access<access_mode::read>(cgh);
+    auto Bp = Bbuf.get_access<access_mode::read>(cgh);
+    auto Cp = Cbuf.get_access<access_mode::read>(cgh);
+    auto Dp = Dbuf.get_access<access_mode::write>(cgh);
 
     cgh.parallel_for<class tsu>(range<1>(RangeLength), [=](id<1> I) {
       Dp[I] = dot_acc(Ap[I], Bp[I], Cp[I]);
@@ -183,10 +183,10 @@ static bool testus(queue &Q) {
   buffer<int32_t, 1> Dbuf(D, range<1>(RangeLength));
 
   Q.submit([&](handler &cgh) {
-    auto Ap = Abuf.get_access<access::mode::read>(cgh);
-    auto Bp = Bbuf.get_access<access::mode::read>(cgh);
-    auto Cp = Cbuf.get_access<access::mode::read>(cgh);
-    auto Dp = Dbuf.get_access<access::mode::write>(cgh);
+    auto Ap = Abuf.get_access<access_mode::read>(cgh);
+    auto Bp = Bbuf.get_access<access_mode::read>(cgh);
+    auto Cp = Cbuf.get_access<access_mode::read>(cgh);
+    auto Dp = Dbuf.get_access<access_mode::write>(cgh);
 
     cgh.parallel_for<class tus>(range<1>(RangeLength), [=](id<1> I) {
       Dp[I] = dot_acc(Ap[I], Bp[I], Cp[I]);

--- a/sycl/test-e2e/Experimental/launch_queries/max_num_work_groups.cpp
+++ b/sycl/test-e2e/Experimental/launch_queries/max_num_work_groups.cpp
@@ -20,7 +20,7 @@ namespace kernels {
 
 template <class T, size_t Dim>
 using sycl_global_accessor =
-    sycl::accessor<T, Dim, sycl::access::mode::read_write,
+    sycl::accessor<T, Dim, sycl::access_mode::read_write,
                    sycl::access::target::global_buffer>;
 
 class TestKernel {
@@ -110,7 +110,7 @@ int test_max_num_work_groups(sycl::queue &q, const sycl::device &dev) {
   auto launch_range = sycl::nd_range<1>{sycl::range<1>{NumWorkItems},
                                         sycl::range<1>{workGroupSize}};
   q.submit([&](sycl::handler &cgh) {
-     auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+     auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
      if constexpr (KernelName::HasLocalMemory) {
        sycl::local_accessor<value_type, 1> loc_acc{
            sycl::range<1>{workGroupSize}, cgh};
@@ -142,7 +142,7 @@ int test_max_num_work_groups(sycl::queue &q, const sycl::device &dev) {
                                    sycl::range<1>{workGroupSize}};
 
   q.submit([&](sycl::handler &cgh) {
-     auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+     auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
      if constexpr (KernelName::HasLocalMemory) {
        sycl::local_accessor<value_type, 1> loc_acc{sycl::range<1>{localSize},
                                                    cgh};
@@ -179,7 +179,7 @@ int test_max_num_work_groups(sycl::queue &q, const sycl::device &dev) {
                                      sycl::range<1>{workGroupSize}};
 
     q.submit([&](sycl::handler &cgh) {
-       auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+       auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
        if constexpr (KernelName::HasLocalMemory) {
          sycl::local_accessor<value_type, 1> loc_acc{sycl::range<1>{localSize},
                                                      cgh};

--- a/sycl/test-e2e/Experimental/launch_queries/max_work_group_size.cpp
+++ b/sycl/test-e2e/Experimental/launch_queries/max_work_group_size.cpp
@@ -15,7 +15,7 @@ namespace kernels {
 
 template <class T, size_t Dim>
 using sycl_global_accessor =
-    sycl::accessor<T, Dim, sycl::access::mode::read_write,
+    sycl::accessor<T, Dim, sycl::access_mode::read_write,
                    sycl::access::target::global_buffer>;
 class TestKernel {
 public:
@@ -54,7 +54,7 @@ int main() {
   auto launch_range =
       sycl::nd_range<1>{sycl::range<1>{numWorkItems}, sycl::range<1>{1}};
   q.submit([&](sycl::handler &cgh) {
-     auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+     auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
      cgh.parallel_for<class kernels::TestKernel>(launch_range,
                                                  kernels::TestKernel{acc});
    }).wait();

--- a/sycl/test-e2e/Experimental/reusable_events/event_as_dependency.cpp
+++ b/sycl/test-e2e/Experimental/reusable_events/event_as_dependency.cpp
@@ -23,7 +23,7 @@ int main() {
 
   // First kernel
   q.submit([&](sycl::handler &cgh) {
-    auto acc = buf.get_access<sycl::access::mode::write>(cgh);
+    auto acc = buf.get_access<sycl::access_mode::write>(cgh);
     cgh.parallel_for<class DepKernel1>(sycl::range<1>(N),
                                        [=](sycl::id<1> idx) { acc[idx] = 10; });
   });
@@ -32,7 +32,7 @@ int main() {
   // Second kernel depends on event
   q.submit([&](sycl::handler &cgh) {
     cgh.depends_on(event);
-    auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+    auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
     cgh.parallel_for<class DepKernel2>(
         sycl::range<1>(N), [=](sycl::id<1> idx) { acc[idx] = acc[idx] + 7; });
   });

--- a/sycl/test-e2e/Experimental/reusable_events/in_order_queue_signal.cpp
+++ b/sycl/test-e2e/Experimental/reusable_events/in_order_queue_signal.cpp
@@ -23,13 +23,13 @@ int main() {
 
   // Submit multiple operations
   q.submit([&](sycl::handler &cgh) {
-    auto acc = buf.get_access<sycl::access::mode::write>(cgh);
+    auto acc = buf.get_access<sycl::access_mode::write>(cgh);
     cgh.parallel_for<class InOrderOp1>(sycl::range<1>(N),
                                        [=](sycl::id<1> idx) { acc[idx] = 1; });
   });
 
   q.submit([&](sycl::handler &cgh) {
-    auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+    auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
     cgh.parallel_for<class InOrderOp2>(
         sycl::range<1>(N), [=](sycl::id<1> idx) { acc[idx] = acc[idx] + 2; });
   });

--- a/sycl/test-e2e/Experimental/reusable_events/queue_returned_events.cpp
+++ b/sycl/test-e2e/Experimental/reusable_events/queue_returned_events.cpp
@@ -19,7 +19,7 @@ int main() {
   sycl::buffer<int> buf(data.data(), sycl::range<1>(N));
 
   auto event = q.submit([&](sycl::handler &cgh) {
-    auto acc = buf.get_access<sycl::access::mode::write>(cgh);
+    auto acc = buf.get_access<sycl::access_mode::write>(cgh);
     cgh.parallel_for<class QueueEvent>(sycl::range<1>(N),
                                        [=](sycl::id<1> idx) { acc[idx] = 42; });
   });

--- a/sycl/test-e2e/FreeFunctionKernels/enum_parameter.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/enum_parameter.cpp
@@ -9,20 +9,20 @@
 #include <sycl/ext/oneapi/free_function_queries.hpp>
 
 using namespace sycl;
-using rAccType = sycl::accessor<int, 1, sycl::access::mode::read>;
-using wAccType = sycl::accessor<int, 1, sycl::access::mode::write>;
-using rwAccType = sycl::accessor<int, 1, sycl::access::mode::read_write>;
+using rAccType = sycl::accessor<int, 1, sycl::access_mode::read>;
+using wAccType = sycl::accessor<int, 1, sycl::access_mode::write>;
+using rwAccType = sycl::accessor<int, 1, sycl::access_mode::read_write>;
 
 using flagType = sycl::accessor<bool, 1>;
 
-template <typename T, int Dims, access::mode modeT>
-bool hasAccessorMode(sycl::accessor<T, Dims, modeT> acc, access::mode mode) {
+template <typename T, int Dims, access_mode modeT>
+bool hasAccessorMode(sycl::accessor<T, Dims, modeT> acc, access_mode mode) {
   return modeT == mode;
 }
 
 template <typename AccType>
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::single_task_kernel))
-void verifyAccessorMode(AccType acc, access::mode accMode, flagType flagAcc) {
+void verifyAccessorMode(AccType acc, access_mode accMode, flagType flagAcc) {
   flagAcc[0] = hasAccessorMode(acc, accMode);
 }
 
@@ -33,9 +33,9 @@ int main() {
   sycl::kernel Kernel2 = getKernel<verifyAccessorMode<wAccType>>(Context);
   sycl::kernel Kernel3 = getKernel<verifyAccessorMode<rwAccType>>(Context);
 
-  const auto rMode = sycl::access::mode::read;
-  const auto wMode = sycl::access::mode::write;
-  const auto rwMode = sycl::access::mode::read_write;
+  const auto rMode = sycl::access_mode::read;
+  const auto wMode = sycl::access_mode::write;
+  const auto rwMode = sycl::access_mode::read_write;
 
   bool flag1, flag2, flag3;
   flag1 = (flag2 = (flag3 = false));

--- a/sycl/test-e2e/Functor/kernel_functor.cpp
+++ b/sycl/test-e2e/Functor/kernel_functor.cpp
@@ -14,7 +14,7 @@
 
 #include <cassert>
 
-constexpr auto sycl_read_write = sycl::access::mode::read_write;
+constexpr auto sycl_read_write = sycl::access_mode::read_write;
 constexpr auto sycl_device = sycl::access::target::device;
 
 // Case 1:

--- a/sycl/test-e2e/GroupAlgorithm/leader.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/leader.cpp
@@ -17,7 +17,7 @@ void test(queue q) {
     buffer<int> out_buf(&out, 1);
 
     q.submit([&](handler &cgh) {
-      auto out = out_buf.template get_access<access::mode::read_write>(cgh);
+      auto out = out_buf.template get_access<access_mode::read_write>(cgh);
       cgh.parallel_for(nd_range<2>(R, R), [=](nd_item<2> it) {
         group<2> g = it.get_group();
         if (g.leader()) {

--- a/sycl/test-e2e/GroupLocalMemory/no_early_opt.cpp
+++ b/sycl/test-e2e/GroupLocalMemory/no_early_opt.cpp
@@ -30,8 +30,8 @@ int main() {
     buffer<int *, 1> BufB{VecB.data(), range<1>(Size)};
 
     Q.submit([&](handler &Cgh) {
-      auto AccA = BufA.get_access<access::mode::read_write>(Cgh);
-      auto AccB = BufB.get_access<access::mode::read_write>(Cgh);
+      auto AccA = BufA.get_access<access_mode::read_write>(Cgh);
+      auto AccB = BufB.get_access<access_mode::read_write>(Cgh);
       Cgh.parallel_for<KernelA>(
           nd_range<1>(range<1>(Size), range<1>(WgSize)), [=](nd_item<1> Item) {
             multi_ptr<int, access::address_space::local_space,

--- a/sycl/test-e2e/HostInteropTask/host-task-dependency3.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-dependency3.cpp
@@ -57,7 +57,7 @@ void test(size_t Count) {
     Q.submit([&](handler &CGH) {
       std::cout << "Submit Kernel-1" << std::endl;
 
-      auto Acc0 = B0.get_access<mode::read_write>(CGH);
+      auto Acc0 = B0.get_access<sycl::access_mode::read_write>(CGH);
 
       CGH.single_task<class Test5_Kernel1>([=] { Acc0[1] = 1 * Idx; });
     });
@@ -65,7 +65,7 @@ void test(size_t Count) {
     Q.submit([&](handler &CGH) {
       std::cout << "Submit Kernel-2" << std::endl;
 
-      auto Acc1 = B1.get_access<mode::read_write>(CGH);
+      auto Acc1 = B1.get_access<sycl::access_mode::read_write>(CGH);
 
       CGH.single_task<class Test5_Kernel2>([=] { Acc1[2] = 1 * Idx; });
     });

--- a/sycl/test-e2e/HostInteropTask/host-task-dependency3.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-dependency3.cpp
@@ -57,7 +57,7 @@ void test(size_t Count) {
     Q.submit([&](handler &CGH) {
       std::cout << "Submit Kernel-1" << std::endl;
 
-      auto Acc0 = B0.get_access<sycl::access_mode::read_write>(CGH);
+      auto Acc0 = B0.get_access<access_mode::read_write>(CGH);
 
       CGH.single_task<class Test5_Kernel1>([=] { Acc0[1] = 1 * Idx; });
     });
@@ -65,7 +65,7 @@ void test(size_t Count) {
     Q.submit([&](handler &CGH) {
       std::cout << "Submit Kernel-2" << std::endl;
 
-      auto Acc1 = B1.get_access<sycl::access_mode::read_write>(CGH);
+      auto Acc1 = B1.get_access<access_mode::read_write>(CGH);
 
       CGH.single_task<class Test5_Kernel2>([=] { Acc1[2] = 1 * Idx; });
     });

--- a/sycl/test-e2e/HostInteropTask/host-task.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task.cpp
@@ -28,7 +28,7 @@ void test1(queue &Q) {
   buffer<int, 1> Buffer{BUFFER_SIZE};
 
   Q.submit([&](handler &CGH) {
-    auto Acc = Buffer.get_access<mode::write>(CGH);
+    auto Acc = Buffer.get_access<sycl::access_mode::write>(CGH);
     CGH.host_task([=] { /* A no-op */ });
   });
 
@@ -41,15 +41,15 @@ void test2(queue &Q) {
   buffer<int, 1> Buffer2{BUFFER_SIZE};
 
   Q.submit([&](handler &CGH) {
-    auto Acc = Buffer1.template get_access<mode::write>(CGH);
+    auto Acc = Buffer1.template get_access<sycl::access_mode::write>(CGH);
 
     auto Kernel = [=](item<1> Id) { Acc[Id] = 123; };
     CGH.parallel_for<NameGen<class Test6Init, true>>(Acc.size(), Kernel);
   });
 
   Q.submit([&](handler &CGH) {
-    auto AccSrc = Buffer1.template get_access<mode::read>(CGH);
-    auto AccDst = Buffer2.template get_access<mode::write>(CGH);
+    auto AccSrc = Buffer1.template get_access<sycl::access_mode::read>(CGH);
+    auto AccDst = Buffer2.template get_access<sycl::access_mode::write>(CGH);
 
     auto Func = [=] {
       for (size_t Idx = 0; Idx < AccDst.size(); ++Idx)

--- a/sycl/test-e2e/HostInteropTask/host-task.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task.cpp
@@ -28,7 +28,7 @@ void test1(queue &Q) {
   buffer<int, 1> Buffer{BUFFER_SIZE};
 
   Q.submit([&](handler &CGH) {
-    auto Acc = Buffer.get_access<sycl::access_mode::write>(CGH);
+    auto Acc = Buffer.get_access<access_mode::write>(CGH);
     CGH.host_task([=] { /* A no-op */ });
   });
 
@@ -41,15 +41,15 @@ void test2(queue &Q) {
   buffer<int, 1> Buffer2{BUFFER_SIZE};
 
   Q.submit([&](handler &CGH) {
-    auto Acc = Buffer1.template get_access<sycl::access_mode::write>(CGH);
+    auto Acc = Buffer1.template get_access<access_mode::write>(CGH);
 
     auto Kernel = [=](item<1> Id) { Acc[Id] = 123; };
     CGH.parallel_for<NameGen<class Test6Init, true>>(Acc.size(), Kernel);
   });
 
   Q.submit([&](handler &CGH) {
-    auto AccSrc = Buffer1.template get_access<sycl::access_mode::read>(CGH);
-    auto AccDst = Buffer2.template get_access<sycl::access_mode::write>(CGH);
+    auto AccSrc = Buffer1.template get_access<access_mode::read>(CGH);
+    auto AccDst = Buffer2.template get_access<access_mode::write>(CGH);
 
     auto Func = [=] {
       for (size_t Idx = 0; Idx < AccDst.size(); ++Idx)

--- a/sycl/test-e2e/HostInteropTask/interop-task.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task.cpp
@@ -34,8 +34,8 @@ void checkBufferValues(BufferT Buffer, ValueT Value) {
 template <typename DataT>
 void copy(buffer<DataT, 1> &Src, buffer<DataT, 1> &Dst, queue &Q) {
   Q.submit([&](handler &CGH) {
-    auto SrcA = Src.template get_access<mode::read>(CGH);
-    auto DstA = Dst.template get_access<mode::write>(CGH);
+    auto SrcA = Src.template get_access<sycl::access_mode::read>(CGH);
+    auto DstA = Dst.template get_access<sycl::access_mode::write>(CGH);
 
     auto Func = [=](interop_handle IH) {
       auto NativeQ = IH.get_native_queue<backend::opencl>();
@@ -60,7 +60,7 @@ void copy(buffer<DataT, 1> &Src, buffer<DataT, 1> &Dst, queue &Q) {
 
 template <typename DataT> void modify(buffer<DataT, 1> &B, queue &Q) {
   Q.submit([&](handler &CGH) {
-    auto Acc = B.template get_access<mode::read_write>(CGH);
+    auto Acc = B.template get_access<sycl::access_mode::read_write>(CGH);
 
     auto Kernel = [=](item<1> Id) { Acc[Id] += 1; };
 
@@ -71,8 +71,8 @@ template <typename DataT> void modify(buffer<DataT, 1> &B, queue &Q) {
 template <typename DataT, DataT B1Init, DataT B2Init>
 void init(buffer<DataT, 1> &B1, buffer<DataT, 1> &B2, queue &Q) {
   Q.submit([&](handler &CGH) {
-    auto Acc1 = B1.template get_access<mode::write>(CGH);
-    auto Acc2 = B2.template get_access<mode::write>(CGH);
+    auto Acc1 = B1.template get_access<sycl::access_mode::write>(CGH);
+    auto Acc2 = B2.template get_access<sycl::access_mode::write>(CGH);
 
     CGH.parallel_for<Init<DataT>>(BUFFER_SIZE, [=](item<1> Id) {
       Acc1[Id] = -1;
@@ -156,7 +156,7 @@ void test3(queue &Q) {
   buffer<int, 1> Buffer{BUFFER_SIZE * 128};
 
   event Event = Q.submit([&](handler &CGH) {
-    auto Acc1 = Buffer.get_access<mode::write>(CGH);
+    auto Acc1 = Buffer.get_access<sycl::access_mode::write>(CGH);
 
     CGH.parallel_for<class Init3>(BUFFER_SIZE,
                                   [=](item<1> Id) { Acc1[Id] = 123; });
@@ -178,7 +178,7 @@ void test4(queue &Q) {
   buffer<int, 1> Buffer{BUFFER_SIZE};
 
   Q.submit([&](handler &CGH) {
-    auto Acc = Buffer.get_access<mode::write>(CGH);
+    auto Acc = Buffer.get_access<sycl::access_mode::write>(CGH);
     auto Func = [=](interop_handle IH) { /*A no-op */ };
     CGH.host_task(Func);
   });
@@ -189,7 +189,7 @@ void test5(queue &Q) {
   buffer<int, 1> Buffer2{BUFFER_SIZE};
 
   Q.submit([&](handler &CGH) {
-    auto Acc = Buffer1.template get_access<mode::write>(CGH);
+    auto Acc = Buffer1.template get_access<sycl::access_mode::write>(CGH);
 
     auto Kernel = [=](item<1> Id) { Acc[Id] = 123; };
     CGH.parallel_for<class Test5Init>(Acc.get_count(), Kernel);

--- a/sycl/test-e2e/HostInteropTask/interop-task.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task.cpp
@@ -34,8 +34,8 @@ void checkBufferValues(BufferT Buffer, ValueT Value) {
 template <typename DataT>
 void copy(buffer<DataT, 1> &Src, buffer<DataT, 1> &Dst, queue &Q) {
   Q.submit([&](handler &CGH) {
-    auto SrcA = Src.template get_access<sycl::access_mode::read>(CGH);
-    auto DstA = Dst.template get_access<sycl::access_mode::write>(CGH);
+    auto SrcA = Src.template get_access<access_mode::read>(CGH);
+    auto DstA = Dst.template get_access<access_mode::write>(CGH);
 
     auto Func = [=](interop_handle IH) {
       auto NativeQ = IH.get_native_queue<backend::opencl>();
@@ -60,7 +60,7 @@ void copy(buffer<DataT, 1> &Src, buffer<DataT, 1> &Dst, queue &Q) {
 
 template <typename DataT> void modify(buffer<DataT, 1> &B, queue &Q) {
   Q.submit([&](handler &CGH) {
-    auto Acc = B.template get_access<sycl::access_mode::read_write>(CGH);
+    auto Acc = B.template get_access<access_mode::read_write>(CGH);
 
     auto Kernel = [=](item<1> Id) { Acc[Id] += 1; };
 
@@ -71,8 +71,8 @@ template <typename DataT> void modify(buffer<DataT, 1> &B, queue &Q) {
 template <typename DataT, DataT B1Init, DataT B2Init>
 void init(buffer<DataT, 1> &B1, buffer<DataT, 1> &B2, queue &Q) {
   Q.submit([&](handler &CGH) {
-    auto Acc1 = B1.template get_access<sycl::access_mode::write>(CGH);
-    auto Acc2 = B2.template get_access<sycl::access_mode::write>(CGH);
+    auto Acc1 = B1.template get_access<access_mode::write>(CGH);
+    auto Acc2 = B2.template get_access<access_mode::write>(CGH);
 
     CGH.parallel_for<Init<DataT>>(BUFFER_SIZE, [=](item<1> Id) {
       Acc1[Id] = -1;
@@ -156,7 +156,7 @@ void test3(queue &Q) {
   buffer<int, 1> Buffer{BUFFER_SIZE * 128};
 
   event Event = Q.submit([&](handler &CGH) {
-    auto Acc1 = Buffer.get_access<sycl::access_mode::write>(CGH);
+    auto Acc1 = Buffer.get_access<access_mode::write>(CGH);
 
     CGH.parallel_for<class Init3>(BUFFER_SIZE,
                                   [=](item<1> Id) { Acc1[Id] = 123; });
@@ -178,7 +178,7 @@ void test4(queue &Q) {
   buffer<int, 1> Buffer{BUFFER_SIZE};
 
   Q.submit([&](handler &CGH) {
-    auto Acc = Buffer.get_access<sycl::access_mode::write>(CGH);
+    auto Acc = Buffer.get_access<access_mode::write>(CGH);
     auto Func = [=](interop_handle IH) { /*A no-op */ };
     CGH.host_task(Func);
   });
@@ -189,7 +189,7 @@ void test5(queue &Q) {
   buffer<int, 1> Buffer2{BUFFER_SIZE};
 
   Q.submit([&](handler &CGH) {
-    auto Acc = Buffer1.template get_access<sycl::access_mode::write>(CGH);
+    auto Acc = Buffer1.template get_access<access_mode::write>(CGH);
 
     auto Kernel = [=](item<1> Id) { Acc[Id] = 123; };
     CGH.parallel_for<class Test5Init>(Acc.get_count(), Kernel);

--- a/sycl/test-e2e/InlineAsm/asm_16_no_input_int.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_16_no_input_int.cpp
@@ -15,7 +15,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
 
   void operator()(sycl::handler &cgh) {
     auto C =
-        this->getOutputBuffer().template get_access<sycl::access::mode::write>(
+        this->getOutputBuffer().template get_access<sycl::access_mode::write>(
             cgh);
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},

--- a/sycl/test-e2e/InlineAsm/asm_8_no_input_int.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_8_no_input_int.cpp
@@ -13,7 +13,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
 
   void operator()(sycl::handler &cgh) {
     auto C =
-        this->getOutputBuffer().template get_access<sycl::access::mode::write>(
+        this->getOutputBuffer().template get_access<sycl::access_mode::write>(
             cgh);
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},

--- a/sycl/test-e2e/InlineAsm/asm_float_add.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_float_add.cpp
@@ -19,13 +19,13 @@ struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
 
   void operator()(sycl::handler &cgh) {
     auto A =
-        this->getInputBuffer(0).template get_access<sycl::access::mode::read>(
+        this->getInputBuffer(0).template get_access<sycl::access_mode::read>(
             cgh);
     auto B =
-        this->getInputBuffer(1).template get_access<sycl::access::mode::read>(
+        this->getInputBuffer(1).template get_access<sycl::access_mode::read>(
             cgh);
     auto C =
-        this->getOutputBuffer().template get_access<sycl::access::mode::write>(
+        this->getOutputBuffer().template get_access<sycl::access_mode::write>(
             cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(

--- a/sycl/test-e2e/InlineAsm/asm_if.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_if.cpp
@@ -13,7 +13,7 @@ template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
 
   void operator()(sycl::handler &CGH) {
     auto C =
-        this->getOutputBuffer().template get_access<sycl::access::mode::write>(
+        this->getOutputBuffer().template get_access<sycl::access_mode::write>(
             CGH);
     bool switchField = false;
     CGH.parallel_for<KernelFunctor<T>>(

--- a/sycl/test-e2e/InlineAsm/asm_mul.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_mul.cpp
@@ -17,13 +17,13 @@ struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
                                                     input1.size()) {}
   void operator()(sycl::handler &cgh) {
     auto A =
-        this->getInputBuffer(0).template get_access<sycl::access::mode::read>(
+        this->getInputBuffer(0).template get_access<sycl::access_mode::read>(
             cgh);
     auto B =
-        this->getInputBuffer(1).template get_access<sycl::access::mode::read>(
+        this->getInputBuffer(1).template get_access<sycl::access_mode::read>(
             cgh);
     auto C =
-        this->getOutputBuffer().template get_access<sycl::access::mode::write>(
+        this->getOutputBuffer().template get_access<sycl::access_mode::write>(
             cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(

--- a/sycl/test-e2e/InlineAsm/asm_plus_mod.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_plus_mod.cpp
@@ -17,10 +17,10 @@ struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
 
   void operator()(sycl::handler &cgh) {
     auto A =
-        this->getInputBuffer(0).template get_access<sycl::access::mode::read>(
+        this->getInputBuffer(0).template get_access<sycl::access_mode::read>(
             cgh);
     auto B =
-        this->getOutputBuffer().template get_access<sycl::access::mode::write>(
+        this->getOutputBuffer().template get_access<sycl::access_mode::write>(
             cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(

--- a/sycl/test-e2e/IntermediateLib/Inputs/incrementing_lib.cpp
+++ b/sycl/test-e2e/IntermediateLib/Inputs/incrementing_lib.cpp
@@ -31,7 +31,7 @@ extern "C" API_EXPORT void performIncrementation(sycl::queue &q,
                                                  sycl::buffer<int, 1> &buf) {
   sycl::range<1> r = buf.get_range();
   q.submit([&](sycl::handler &cgh) {
-    auto acc = buf.get_access<sycl::access::mode::write>(cgh);
+    auto acc = buf.get_access<sycl::access_mode::write>(cgh);
     cgh.parallel_for<class CLASSNAME>(
         r, [=](sycl::id<1> idx) { acc[idx] += INC; });
   });

--- a/sycl/test-e2e/KernelCompiler/opencl_cache.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_cache.cpp
@@ -53,8 +53,8 @@ void testSyclKernel(sycl::queue &Q, sycl::kernel Kernel, int multiplier,
   sycl::buffer OutputBuf(OutputArray, sycl::range<1>(N));
 
   Q.submit([&](sycl::handler &CGH) {
-    CGH.set_arg(0, InputBuf.get_access<sycl::access::mode::read>(CGH));
-    CGH.set_arg(1, OutputBuf.get_access<sycl::access::mode::write>(CGH));
+    CGH.set_arg(0, InputBuf.get_access<sycl::access_mode::read>(CGH));
+    CGH.set_arg(1, OutputBuf.get_access<sycl::access_mode::write>(CGH));
     CGH.parallel_for(sycl::range<1>{N}, Kernel);
   });
 

--- a/sycl/test-e2e/KernelParams/array-kernel-param-nested-run.cpp
+++ b/sycl/test-e2e/KernelParams/array-kernel-param-nested-run.cpp
@@ -58,7 +58,7 @@ bool test_accessor_array_in_struct(queue &myQueue) {
 
   myQueue.submit([&](handler &cgh) {
     using Accessor =
-        accessor<int, 1, access::mode::read_write, access::target::device>;
+        accessor<int, 1, access_mode::read_write, access::target::device>;
 
     struct S {
       int w;
@@ -68,11 +68,11 @@ bool test_accessor_array_in_struct(queue &myQueue) {
       int z;
     } S = {3,
            3,
-           {in_buffer1.get_access<access::mode::read_write>(cgh),
-            in_buffer2.get_access<access::mode::read_write>(cgh)},
+           {in_buffer1.get_access<access_mode::read_write>(cgh),
+            in_buffer2.get_access<access_mode::read_write>(cgh)},
            7,
            7};
-    auto output_accessor = out_buffer.get_access<access::mode::write>(cgh);
+    auto output_accessor = out_buffer.get_access<access_mode::write>(cgh);
 
     cgh.parallel_for<class accessor_array_in_struct>(
         num_items, [=](sycl::id<1> index) {
@@ -103,8 +103,8 @@ bool test_templated_array_in_struct(queue &myQueue) {
 
   myQueue.submit([&](handler &cgh) {
     using Accessor =
-        accessor<int, 1, access::mode::read_write, access::target::device>;
-    auto output_accessor = out_buffer.get_access<access::mode::write>(cgh);
+        accessor<int, 1, access_mode::read_write, access::target::device>;
+    auto output_accessor = out_buffer.get_access<access_mode::write>(cgh);
 
     cgh.parallel_for<class templated_array_in_struct>(
         num_items, [=](sycl::id<1> index) {

--- a/sycl/test-e2e/KernelParams/struct_kernel_param.cpp
+++ b/sycl/test-e2e/KernelParams/struct_kernel_param.cpp
@@ -60,7 +60,7 @@ bool test0() {
     buffer<MyStruct, 1> Buf(&S0, range<1>(1));
     queue myQueue;
     myQueue.submit([&](handler &cgh) {
-      auto B = Buf.get_access<access::mode::write>(cgh);
+      auto B = Buf.get_access<access_mode::write>(cgh);
       cgh.single_task<class MyKernel>([=] { B[0] = S; });
     });
   }
@@ -87,7 +87,7 @@ bool test1() {
     buffer<unsigned int, 1> Buffer((unsigned int *)result, range<1>(4));
     queue myQueue;
     myQueue.submit([&](handler &cgh) {
-      auto B = Buffer.get_access<access::mode::write>(cgh);
+      auto B = Buffer.get_access<access_mode::write>(cgh);
       cgh.parallel_for<class bufferByRange_cap>(range<1>{4}, [=](id<1> index) {
         B[index.get(0)] = index.get(0) > 2 ? ice2 : ice.get(index.get(0));
       });

--- a/sycl/test-e2e/Reduction/reduction_big_data.cpp
+++ b/sycl/test-e2e/Reduction/reduction_big_data.cpp
@@ -52,7 +52,7 @@ int test(queue &Q, T Identity) {
 
   // Compute.
   Q.submit([&](handler &CGH) {
-    auto In = InBuf.template get_access<access::mode::read>(CGH);
+    auto In = InBuf.template get_access<access_mode::read>(CGH);
     CGH.parallel_for<Name>(NDRange, sycl::reduction(OutBuf, CGH, Identity, BOp),
                            [=](nd_item<1> NDIt, auto &Sum) {
                              if (NDIt.get_global_linear_id() < NWorkItems)

--- a/sycl/test-e2e/Reduction/reduction_nd_conditional.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_conditional.cpp
@@ -41,7 +41,7 @@ int test(queue &Q, T Identity, size_t WGSize, size_t NWItems) {
 
   // Compute.
   Q.submit([&](handler &CGH) {
-    auto In = InBuf.template get_access<access::mode::read>(CGH);
+    auto In = InBuf.template get_access<access_mode::read>(CGH);
     auto Redu = sycl::reduction(OutBuf, CGH, Identity, BOp);
     CGH.parallel_for<Name>(NDRange, Redu, [=](nd_item<1> NDIt, auto &Sum) {
       size_t I = NDIt.get_global_linear_id();

--- a/sycl/test-e2e/Reduction/reduction_range_1d_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_reducer_skip.cpp
@@ -31,7 +31,7 @@ int main() {
   size_t MaxWGSize =
       Q.get_device().get_info<info::device::max_work_group_size>();
 
-  constexpr access::mode RW = access::mode::read_write;
+  constexpr access_mode RW = access_mode::read_write;
   // Fast-reduce and Fast-atomics. Try various range types/sizes.
   tests<class A1, int>(Q, 0, 99, std::plus<int>{}, range<1>(1));
   tests<class A2, int>(Q, 0, 99, std::plus<>{}, range<1>(2));

--- a/sycl/test-e2e/Reduction/reduction_usm.cpp
+++ b/sycl/test-e2e/Reduction/reduction_usm.cpp
@@ -52,7 +52,7 @@ int test(queue &Q, OptionalIdentity<T, HasIdentity> Identity, T Init,
        }
      };
 
-     auto In = InBuf.template get_access<access::mode::read>(CGH);
+     auto In = InBuf.template get_access<access_mode::read>(CGH);
      auto Redu = CreateReduction();
      CGH.parallel_for<USMKName<Name, class Test>>(
          NDRange, Redu, [=](nd_item<1> NDIt, auto &Sum) {
@@ -65,7 +65,7 @@ int test(queue &Q, OptionalIdentity<T, HasIdentity> Identity, T Init,
   if (AllocType == usm::alloc::device) {
     buffer<T, 1> Buf(&ComputedOut, range<1>(1));
     Q.submit([&](handler &CGH) {
-       auto OutAcc = Buf.template get_access<access::mode::discard_write>(CGH);
+       auto OutAcc = Buf.template get_access<access_mode::discard_write>(CGH);
        CGH.single_task<USMKName<Name, class Check>>(
            [=]() { OutAcc[0] = *ReduVarPtr; });
      }).wait();

--- a/sycl/test-e2e/Regression/2020-spec-constants-debug-info.cpp
+++ b/sycl/test-e2e/Regression/2020-spec-constants-debug-info.cpp
@@ -19,7 +19,7 @@ int main() {
   {
     sycl::buffer<double, 1> Buf{sycl::range{1}};
     q.submit([&](sycl::handler &cgh) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(cgh);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(cgh);
       cgh.set_specialization_constant<test_id_1>(1);
       cgh.single_task<class Kernel1>([=](sycl::kernel_handler kh) {
         Acc[0] = kh.get_specialization_constant<test_id_1>();

--- a/sycl/test-e2e/Regression/commandlist/Inputs/FindPrimesSYCL.cpp
+++ b/sycl/test-e2e/Regression/commandlist/Inputs/FindPrimesSYCL.cpp
@@ -9,8 +9,8 @@
 #include <vector>
 
 #include <string>
-constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
-constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
+constexpr sycl::access_mode sycl_read = sycl::access_mode::read;
+constexpr sycl::access_mode sycl_write = sycl::access_mode::write;
 
 using namespace std;
 

--- a/sycl/test-e2e/Regression/fp16-with-unnamed-lambda.cpp
+++ b/sycl/test-e2e/Regression/fp16-with-unnamed-lambda.cpp
@@ -24,7 +24,7 @@ int main() {
   sycl::buffer<sycl::half> Buf(1);
 
   Q.submit([&](sycl::handler &CGH) {
-    auto Acc = Buf.get_access<sycl::access::mode::write>(CGH);
+    auto Acc = Buf.get_access<sycl::access_mode::write>(CGH);
     CGH.single_task([=]() { Acc[0] = 1; });
   });
 

--- a/sycl/test-e2e/Regression/group.cpp
+++ b/sycl/test-e2e/Regression/group.cpp
@@ -40,7 +40,7 @@ bool group__get_group_range() {
     queue Q(AsyncHandler{});
 
     Q.submit([&](handler &cgh) {
-      auto Ptr = Buf.get_access<access::mode::write>(cgh);
+      auto Ptr = Buf.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<class group__get_group_range>(
           nd_range<3>{GlobalRange, LocalRange}, [=](nd_item<DIMS> I) {
@@ -106,7 +106,7 @@ bool group__get_linear_id() {
     queue Q(AsyncHandler{});
 
     Q.submit([&](handler &cgh) {
-      auto Ptr = Buf.get_access<access::mode::write>(cgh);
+      auto Ptr = Buf.get_access<access_mode::write>(cgh);
 
       cgh.parallel_for<class group__get_linear_id>(
           nd_range<3>{GlobalRange, LocalRange}, [=](nd_item<DIMS> I) {
@@ -184,7 +184,7 @@ bool group__async_work_group_copy() {
       queue Q(AsyncHandler{});
 
       Q.submit([&](handler &cgh) {
-        auto AccGlobal = Buf.get_access<access::mode::read_write>(cgh);
+        auto AccGlobal = Buf.get_access<access_mode::read_write>(cgh);
         local_accessor<DataType, DIMS> AccLocal(LocalRange, cgh);
 
         cgh.parallel_for<class group__async_work_group_copy>(

--- a/sycl/test-e2e/Regression/implicit_kernel_bundle_image_filtering.cpp
+++ b/sycl/test-e2e/Regression/implicit_kernel_bundle_image_filtering.cpp
@@ -23,7 +23,7 @@ int main() {
   {
     sycl::buffer<int, 1> Buf(&Ret, 1);
     Q.submit([&](sycl::handler &CGH) {
-      auto Acc = Buf.template get_access<sycl::access::mode::write>(CGH);
+      auto Acc = Buf.template get_access<sycl::access_mode::write>(CGH);
       CGH.set_specialization_constant<SpecConst>(42);
       CGH.single_task<class Kernel1>([=](sycl::kernel_handler H) {
         Acc[0] = H.get_specialization_constant<SpecConst>();

--- a/sycl/test-e2e/Regression/kernel_bundle_ignore_sycl_external.cpp
+++ b/sycl/test-e2e/Regression/kernel_bundle_ignore_sycl_external.cpp
@@ -35,7 +35,7 @@ int main() {
 
   sycl::buffer<int, 1> Buf(sycl::range<1>{1});
   Q.submit([&](sycl::handler &CGH) {
-    auto Acc = Buf.get_access<sycl::access::mode::write>(CGH);
+    auto Acc = Buf.get_access<sycl::access_mode::write>(CGH);
     CGH.use_kernel_bundle(KernelBundle);
     CGH.single_task<KernelName>([=]() { Acc[0] = 42; });
   });

--- a/sycl/test-e2e/Regression/local-arg-align.cpp
+++ b/sycl/test-e2e/Regression/local-arg-align.cpp
@@ -32,7 +32,7 @@ int main(int argc, char *argv[]) {
      local_accessor<cl_int, 1> a(1, h);
      local_accessor<float4, 1> b(1, h);
 
-     auto ares = res.get_access<access::mode::read_write>(h);
+     auto ares = res.get_access<access_mode::read_write>(h);
 
      // Manually capture kernel arguments to ensure an order with the int
      // argument first and the float4 argument second. If the two arguments are

--- a/sycl/test-e2e/Regression/multiple-targets.cpp
+++ b/sycl/test-e2e/Regression/multiple-targets.cpp
@@ -27,7 +27,7 @@ int main() {
     sycl::buffer<int, 1> A_Buf(A_Data, sycl::range<1>(10));
 
     Q.submit([&](sycl::handler &Cgh) {
-      auto A_Acc = A_Buf.get_access<sycl::access::mode::write>(Cgh);
+      auto A_Acc = A_Buf.get_access<sycl::access_mode::write>(Cgh);
       Cgh.parallel_for(sycl::range<1>{5},
                        [=](sycl::id<1> index) { A_Acc[index] = 5; });
     });
@@ -40,8 +40,8 @@ int main() {
     sycl::buffer<int, 1> C_Buf(C_Data, sycl::range<1>(10));
 
     Q.submit([&](sycl::handler &Cgh) {
-      auto B_Acc = B_Buf.get_access<sycl::access::mode::read_write>(Cgh);
-      auto C_Acc = C_Buf.get_access<sycl::access::mode::read>(Cgh);
+      auto B_Acc = B_Buf.get_access<sycl::access_mode::read_write>(Cgh);
+      auto C_Acc = C_Buf.get_access<sycl::access_mode::read>(Cgh);
       Cgh.parallel_for(sycl::range<1>{5}, [=](sycl::id<1> index) {
         B_Acc[index] += C_Acc[index];
       });
@@ -55,8 +55,8 @@ int main() {
     sycl::buffer<int, 1> C_Buf(C_Data, sycl::range<1>(10));
 
     Q.submit([&](sycl::handler &Cgh) {
-      auto B_Acc = B_Buf.get_access<sycl::access::mode::read>(Cgh);
-      auto C_Acc = C_Buf.get_access<sycl::access::mode::write>(Cgh);
+      auto B_Acc = B_Buf.get_access<sycl::access_mode::read>(Cgh);
+      auto C_Acc = C_Buf.get_access<sycl::access_mode::write>(Cgh);
       Cgh.parallel_for(sycl::range<1>{5},
                        [=](sycl::id<1> index) { C_Acc[index] = B_Acc[index]; });
     });

--- a/sycl/test-e2e/Regression/private_array_init_test.cpp
+++ b/sycl/test-e2e/Regression/private_array_init_test.cpp
@@ -30,7 +30,7 @@ int main() {
   {
     s::buffer<size_t, 1> buf(&data, s::range<1>(1));
     q.submit([&](s::handler &cgh) {
-      auto acc = buf.get_access<s::access::mode::read_write>(cgh);
+      auto acc = buf.get_access<s::access_mode::read_write>(cgh);
       cgh.single_task<class test>([=]() {
         // Test that SYCL program is not crashed if it contains a class/struct
         // that has private array member which is initialized by zeroes.

--- a/sycl/test-e2e/Regression/same_unnamed_kernels.cpp
+++ b/sycl/test-e2e/Regression/same_unnamed_kernels.cpp
@@ -14,7 +14,7 @@
 template <typename F, typename B>
 void run(sycl::queue &q, B &buf, const F &func) {
   auto e = q.submit([&](sycl::handler &cgh) {
-    auto acc = buf.template get_access<sycl::access::mode::write>(cgh);
+    auto acc = buf.template get_access<sycl::access_mode::write>(cgh);
     cgh.single_task([=]() { func(acc); });
   });
   e.wait();
@@ -29,11 +29,11 @@ int main() {
   sycl::buffer<int, 1> bufB(B, 1);
 
   run(q, bufA,
-      [&](const sycl::accessor<int, 1, sycl::access::mode::write> &acc) {
+      [&](const sycl::accessor<int, 1, sycl::access_mode::write> &acc) {
         acc[0] = 0;
       });
   run(q, bufB,
-      [&](const sycl::accessor<int, 1, sycl::access::mode::write> &acc) {
+      [&](const sycl::accessor<int, 1, sycl::access_mode::write> &acc) {
         acc[0] *= 2;
       });
 

--- a/sycl/test-e2e/Sampler/basic-rw-float.cpp
+++ b/sycl/test-e2e/Sampler/basic-rw-float.cpp
@@ -37,7 +37,7 @@ void test_rw(image_channel_order ChanOrder, image_channel_type ChanType) {
     // - create an image
     image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
     event E_Setup = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::write>(cgh);
       cgh.single_task<class setupUnormLinear>([=]() {
         image_acc.write(0, leftEdge);
         image_acc.write(1, body);
@@ -51,8 +51,8 @@ void test_rw(image_channel_order ChanOrder, image_channel_type ChanType) {
     buffer<pixelT, 1> testResults((range<1>(numTests)));
 
     event E_Test = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
-      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::read>(cgh);
+      auto test_acc = testResults.get_access<access_mode::write>(cgh);
 
       cgh.single_task<class im1D_Unorm_Linear>([=]() {
         int i = 0; // the index for writing into the testResult buffer.

--- a/sycl/test-e2e/Sampler/normalized-clamp-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clamp-nearest.cpp
@@ -48,7 +48,7 @@ void test_normalized_clamp_nearest_sampler(image_channel_order ChanOrder,
     // - create an image
     image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
     event E_Setup = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::write>(cgh);
       cgh.single_task<class setupUnormLinear>([=]() {
         image_acc.write(0, leftEdge);
         image_acc.write(1, body);
@@ -66,8 +66,8 @@ void test_normalized_clamp_nearest_sampler(image_channel_order ChanOrder,
         sampler(normalized, addressing_mode::clamp, nearest);
 
     event E_Test = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
-      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::read>(cgh);
+      auto test_acc = testResults.get_access<access_mode::write>(cgh);
 
       cgh.single_task<class im1D_norm_nearest>([=]() {
         int i = 0; // the index for writing into the testResult buffer.

--- a/sycl/test-e2e/Sampler/normalized-mirror-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-mirror-linear-float.cpp
@@ -65,7 +65,7 @@ void test_normalized_mirrored_linear_sampler(image_channel_order ChanOrder,
     // - create an image
     image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
     event E_Setup = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::write>(cgh);
       cgh.single_task<class setupUnormLinear>([=]() {
         image_acc.write(0, leftEdge);
         image_acc.write(1, body);
@@ -82,8 +82,8 @@ void test_normalized_mirrored_linear_sampler(image_channel_order ChanOrder,
     auto Norm_Mirror_Linear_sampler = sampler(normalized, mirrored, linear);
 
     event E_Test = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
-      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::read>(cgh);
+      auto test_acc = testResults.get_access<access_mode::write>(cgh);
 
       cgh.single_task<class im1D_norm_linear>([=]() {
         int i = 0; // the index for writing into the testResult buffer.

--- a/sycl/test-e2e/Sampler/normalized-none-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-none-nearest.cpp
@@ -52,7 +52,7 @@ void test_normalized_none_nearest_sampler(image_channel_order ChanOrder,
     // - create an image
     image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
     event E_Setup = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::write>(cgh);
       cgh.single_task<class setupUnormLinear>([=]() {
         image_acc.write(0, leftEdge);
         image_acc.write(1, body);
@@ -69,8 +69,8 @@ void test_normalized_none_nearest_sampler(image_channel_order ChanOrder,
     auto Norm_None_Nearest_sampler = sampler(normalized, none, nearest);
 
     event E_Test = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
-      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::read>(cgh);
+      auto test_acc = testResults.get_access<access_mode::write>(cgh);
 
       cgh.single_task<class im1D_norm_nearest>([=]() {
         int i = 0; // the index for writing into the testResult buffer.

--- a/sycl/test-e2e/Sampler/unnormalized-clamp-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clamp-linear-float.cpp
@@ -56,7 +56,7 @@ void test_unnormalized_clamp_linear_sampler(image_channel_order ChanOrder,
     // - create an image
     image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
     event E_Setup = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::write>(cgh);
       cgh.single_task<class setupUnormLinear>([=]() {
         image_acc.write(0, leftEdge);
         image_acc.write(1, body);
@@ -74,8 +74,8 @@ void test_unnormalized_clamp_linear_sampler(image_channel_order ChanOrder,
         sampler(unnormalized, addressing_mode::clamp, linear);
 
     event E_Test = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
-      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::read>(cgh);
+      auto test_acc = testResults.get_access<access_mode::write>(cgh);
 
       cgh.single_task<class im1D_Unorm_Linear>([=]() {
         int i = 0; // the index for writing into the testResult buffer.

--- a/sycl/test-e2e/Sampler/unnormalized-clampedge-nearest.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clampedge-nearest.cpp
@@ -48,7 +48,7 @@ void test_unnormalized_clampedge_nearest_sampler(image_channel_order ChanOrder,
     // - create an image
     image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
     event E_Setup = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::write>(cgh);
       cgh.single_task<class setupUnormLinear>([=]() {
         image_acc.write(0, leftEdge);
         image_acc.write(1, body);
@@ -66,8 +66,8 @@ void test_unnormalized_clampedge_nearest_sampler(image_channel_order ChanOrder,
         sampler(unnormalized, clamp_edge, nearest);
 
     event E_Test = Q.submit([&](handler &cgh) {
-      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
-      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+      auto image_acc = image_1D.get_access<pixelT, access_mode::read>(cgh);
+      auto test_acc = testResults.get_access<access_mode::write>(cgh);
 
       cgh.single_task<class im1D_Unorm_Linear>([=]() {
         int i = 0; // the index for writing into the testResult buffer.

--- a/sycl/test-e2e/Scheduler/BasicSchedulerTests.cpp
+++ b/sycl/test-e2e/Scheduler/BasicSchedulerTests.cpp
@@ -12,7 +12,7 @@
 
 #include <iostream>
 
-using sycl_access_mode = sycl::access::mode;
+using sycl_access_mode = sycl::access_mode;
 
 // Execute functor provided passing a queue created with default device selector
 // and async handler then waits for the tasks submitted to queue to finish. If

--- a/sycl/test-e2e/Scheduler/DeleteCmdException.cpp
+++ b/sycl/test-e2e/Scheduler/DeleteCmdException.cpp
@@ -27,7 +27,7 @@ void test_exception(sycl::queue &q, sycl::buffer<int, 1> &buf,
 
     // Will throw when submitted
     q.submit([&](sycl::handler &cgh) {
-       auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+       auto acc = buf.get_access<sycl::access_mode::read_write>(cgh);
        cgh.parallel_for(illegal_range, [=](sycl::nd_item<1> nd_item) {
          acc[nd_item.get_global_linear_id()] = 42; // will not be reached
        });

--- a/sycl/test-e2e/Scheduler/MemObjRemapping.cpp
+++ b/sycl/test-e2e/Scheduler/MemObjRemapping.cpp
@@ -21,7 +21,7 @@ int main() {
   buffer<int, 1> BufA{Range};
 
   Q.submit([&](handler &Cgh) {
-    auto AccA = BufA.get_access<access::mode::read_write>(Cgh);
+    auto AccA = BufA.get_access<access_mode::read_write>(Cgh);
     Cgh.parallel_for<Foo>(Range, [=](id<1> Idx) { AccA[Idx] = Idx[0]; });
   });
 
@@ -29,7 +29,7 @@ int main() {
     // Check access mode flags
     // CHECK: <--- urEnqueueMemBufferMap
     // CHECK: .mapFlags = UR_MAP_FLAG_READ
-    auto AccA = BufA.get_access<access::mode::read>();
+    auto AccA = BufA.get_access<access_mode::read>();
     for (std::size_t I = 0; I < Size; ++I) {
       assert(AccA[I] == I);
     }
@@ -38,13 +38,13 @@ int main() {
     // CHECK: <--- urEnqueueMemUnmap
     // CHECK: <--- urEnqueueMemBufferMap
     // CHECK: .mapFlags = UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE
-    auto AccA = BufA.get_access<access::mode::write>();
+    auto AccA = BufA.get_access<access_mode::write>();
     for (std::size_t I = 0; I < Size; ++I)
       AccA[I] = 2 * I;
   }
 
   // CHECK-NOT: <--- urEnqueueMemBufferMap
-  auto AccA = BufA.get_access<access::mode::read>();
+  auto AccA = BufA.get_access<access_mode::read>();
   for (std::size_t I = 0; I < Size; ++I) {
     assert(AccA[I] == 2 * I);
   }

--- a/sycl/test-e2e/SpecConstants/2020/handler-api.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/handler-api.cpp
@@ -73,11 +73,11 @@ bool test_default_values(sycl::queue q) {
   sycl::buffer<custom_type> custom_type_buffer(1);
 
   q.submit([&](sycl::handler &cgh) {
-    auto int_acc = int_buffer.get_access<sycl::access::mode::write>(cgh);
-    auto int_acc2 = int_buffer2.get_access<sycl::access::mode::write>(cgh);
-    auto float_acc = float_buffer.get_access<sycl::access::mode::write>(cgh);
+    auto int_acc = int_buffer.get_access<sycl::access_mode::write>(cgh);
+    auto int_acc2 = int_buffer2.get_access<sycl::access_mode::write>(cgh);
+    auto float_acc = float_buffer.get_access<sycl::access_mode::write>(cgh);
     auto custom_type_acc =
-        custom_type_buffer.get_access<sycl::access::mode::write>(cgh);
+        custom_type_buffer.get_access<sycl::access_mode::write>(cgh);
     cgh.single_task<TestDefaultValuesKernel>([=](sycl::kernel_handler kh) {
       int_acc[0] = kh.get_specialization_constant<int_id>();
       int_acc2[0] = kh.get_specialization_constant<int_id2>();
@@ -168,11 +168,11 @@ bool test_set_and_get_on_device(sycl::queue q) {
   custom_type new_custom_type_value('b', 1.0f, 12);
 
   q.submit([&](sycl::handler &cgh) {
-    auto int_acc = int_buffer.get_access<sycl::access::mode::write>(cgh);
-    auto int_acc2 = int_buffer2.get_access<sycl::access::mode::write>(cgh);
-    auto float_acc = float_buffer.get_access<sycl::access::mode::write>(cgh);
+    auto int_acc = int_buffer.get_access<sycl::access_mode::write>(cgh);
+    auto int_acc2 = int_buffer2.get_access<sycl::access_mode::write>(cgh);
+    auto float_acc = float_buffer.get_access<sycl::access_mode::write>(cgh);
     auto custom_type_acc =
-        custom_type_buffer.get_access<sycl::access::mode::write>(cgh);
+        custom_type_buffer.get_access<sycl::access_mode::write>(cgh);
 
     cgh.set_specialization_constant<int_id>(new_int_value);
     cgh.set_specialization_constant<int_id2>(new_int_value2);

--- a/sycl/test-e2e/SpecConstants/2020/non_native/Inputs/common.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/non_native/Inputs/common.cpp
@@ -25,7 +25,7 @@ int main() {
     sycl::buffer<int, 1> Buf{sycl::range{1}};
     Q.submit([&](sycl::handler &CGH) {
       CGH.set_specialization_constant<SpecConst2>(1);
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(CGH);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(CGH);
       CGH.single_task<class Kernel1Name>([=](sycl::kernel_handler KH) {
         Acc[0] = KH.get_specialization_constant<SpecConst2>();
       });
@@ -37,7 +37,7 @@ int main() {
   {
     sycl::buffer<TestStruct, 1> Buf{sycl::range{1}};
     Q.submit([&](sycl::handler &CGH) {
-      auto Acc = Buf.get_access<sycl::access::mode::read_write>(CGH);
+      auto Acc = Buf.get_access<sycl::access_mode::read_write>(CGH);
       CGH.set_specialization_constant<SpecConst3>(TestStruct{1, 2});
       const auto SC = CGH.get_specialization_constant<SpecConst4>();
       assert(SC == 42);

--- a/sycl/test-e2e/SubGroup/barrier.cpp
+++ b/sycl/test-e2e/SubGroup/barrier.cpp
@@ -28,8 +28,8 @@ template <typename T> void check(queue &Queue, size_t G = 240, size_t L = 60) {
     buffer<T> addbuf(data.data(), range<1>(G));
     buffer<size_t> sgsizebuf(1);
     Queue.submit([&](handler &cgh) {
-      auto addacc = addbuf.template get_access<access::mode::read_write>(cgh);
-      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
+      auto addacc = addbuf.template get_access<access_mode::read_write>(cgh);
+      auto sgsizeacc = sgsizebuf.get_access<access_mode::read_write>(cgh);
 
       cgh.parallel_for<sycl_subgr<T>>(NdRange, [=](nd_item<1> NdItem) {
         sycl::sub_group SG = NdItem.get_sub_group();

--- a/sycl/test-e2e/SubGroup/generic_reduce.cpp
+++ b/sycl/test-e2e/SubGroup/generic_reduce.cpp
@@ -27,8 +27,8 @@ void check_op(queue &Queue, T init, BinaryOperation op, bool skip_init = false,
     buffer<T> buf(G);
     buffer<size_t> sgsizebuf(1);
     Queue.submit([&](handler &cgh) {
-      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
-      auto acc = buf.template get_access<access::mode::read_write>(cgh);
+      auto sgsizeacc = sgsizebuf.get_access<access_mode::read_write>(cgh);
+      auto acc = buf.template get_access<access_mode::read_write>(cgh);
       cgh.parallel_for(NdRange, [=](nd_item<1> NdItem) {
         auto sg = NdItem.get_sub_group();
         if (skip_init) {

--- a/sycl/test-e2e/SubGroup/scan.hpp
+++ b/sycl/test-e2e/SubGroup/scan.hpp
@@ -22,9 +22,9 @@ void check_op(queue &Queue, T init, BinaryOperation op, bool skip_init = false,
     buffer<T> exbuf(G), inbuf(G);
     buffer<size_t> sgsizebuf(1);
     Queue.submit([&](handler &cgh) {
-      auto sgsizeacc = sgsizebuf.get_access<access::mode::read_write>(cgh);
-      auto exacc = exbuf.template get_access<access::mode::read_write>(cgh);
-      auto inacc = inbuf.template get_access<access::mode::read_write>(cgh);
+      auto sgsizeacc = sgsizebuf.get_access<access_mode::read_write>(cgh);
+      auto exacc = exbuf.template get_access<access_mode::read_write>(cgh);
+      auto inacc = inbuf.template get_access<access_mode::read_write>(cgh);
       cgh.parallel_for<SpecializationKernelName>(
           NdRange, [=](nd_item<1> NdItem) {
             sycl::sub_group sg = NdItem.get_sub_group();

--- a/sycl/test-e2e/SubGroupMask/GroupSize.cpp
+++ b/sycl/test-e2e/SubGroupMask/GroupSize.cpp
@@ -38,7 +38,7 @@ template <size_t SGSize> void test(queue Queue) {
       buffer resbuf(Res, range<1>(32 / SGSize));
 
       Queue.submit([&](handler &cgh) {
-        auto resacc = resbuf.template get_access<access::mode::read_write>(cgh);
+        auto resacc = resbuf.template get_access<access_mode::read_write>(cgh);
 
         cgh.parallel_for<sycl_subgr<SGSize>>(
             NdRange,

--- a/sycl/test-e2e/USM/fill.cpp
+++ b/sycl/test-e2e/USM/fill.cpp
@@ -113,7 +113,7 @@ void runDeviceTests(device dev, context ctxt, queue q, T val) {
   {
     buffer<T, 1> buf{&out[0], range<1>{N}};
     q.submit([&](handler &h) {
-       auto acc = buf.template get_access<access::mode::write>(h);
+       auto acc = buf.template get_access<access_mode::write>(h);
        h.parallel_for<usm_device_transfer<T>>(
            range<1>(N), [=](id<1> item) { acc[item] = array[item]; });
      }).wait();
@@ -134,7 +134,7 @@ void runDeviceTests(device dev, context ctxt, queue q, T val) {
   {
     buffer<T, 1> buf{&out[0], range<1>{N}};
     q.submit([&](handler &h) {
-       auto acc = buf.template get_access<access::mode::write>(h);
+       auto acc = buf.template get_access<access_mode::write>(h);
        h.parallel_for<usm_aligned_device_transfer<T>>(
            range<1>(N), [=](id<1> item) { acc[item] = array[item]; });
      }).wait();

--- a/sycl/test-e2e/USM/memcpy.cpp
+++ b/sycl/test-e2e/USM/memcpy.cpp
@@ -43,7 +43,7 @@ void check_on_device(queue q, int *arr) {
   {
     buffer<int, 1> buf{&out[0], range<1>{N}};
     q.submit([&](handler &h) {
-       auto acc = buf.template get_access<access::mode::write>(h);
+       auto acc = buf.template get_access<access_mode::write>(h);
        h.parallel_for<class usm_device_transfer>(
            range<1>(N), [=](id<1> item) { acc[item] = arr[item]; });
      }).wait();

--- a/sycl/test-e2e/WorkGroupScratchMemory/dynamic_alloc_local_accessor.cpp
+++ b/sycl/test-e2e/WorkGroupScratchMemory/dynamic_alloc_local_accessor.cpp
@@ -69,7 +69,7 @@ int main() {
   buffer<int, 1> Buf{Vec.data(), range<1>(Size)};
 
   Q.submit([&](handler &Cgh) {
-    auto Acc = Buf.get_access<access::mode::read_write>(Cgh);
+    auto Acc = Buf.get_access<access_mode::read_write>(Cgh);
     sycl_ext::work_group_scratch_size static_size(WgSize * RepeatWG *
                                                   sizeof(int));
     sycl_ext::properties properties{static_size};

--- a/sycl/test-e2e/WorkGroupStatic/work_group_static_memory_block_scope.cpp
+++ b/sycl/test-e2e/WorkGroupStatic/work_group_static_memory_block_scope.cpp
@@ -42,7 +42,7 @@ int main() {
     buffer<int, 1> Buf{Vec.data(), range<1>(Size)};
 
     Q.submit([&](handler &Cgh) {
-      auto Acc = Buf.get_access<access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<access_mode::read_write>(Cgh);
       Cgh.parallel_for<KernelA>(
           nd_range<1>(range<1>(Size), range<1>(WgSize)), [=](nd_item<1> Item) {
             sycl::ext::oneapi::experimental::work_group_static<int[WgSize]>
@@ -68,7 +68,7 @@ int main() {
     buffer<int, 1> Buf{Vec.data(), range<1>(Size)};
 
     Q.submit([&](handler &Cgh) {
-      auto Acc = Buf.get_access<access::mode::read_write>(Cgh);
+      auto Acc = Buf.get_access<access_mode::read_write>(Cgh);
       Cgh.parallel_for<KernelB>(
           nd_range<1>(range<1>(Size), range<1>(WgSize)), [=](nd_item<1> Item) {
             sycl::ext::oneapi::experimental::work_group_static<int> localIDBuff;

--- a/sycl/test-e2e/XPTI/buffer/accessors.cpp
+++ b/sycl/test-e2e/XPTI/buffer/accessors.cpp
@@ -26,17 +26,17 @@ int main() {
 
   Queue.submit([&](sycl::handler &cgh) {
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID1:.+]]|2015|1024|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-    auto A1 = Buf.get_access<mode::read, target::constant_buffer>(cgh);
+    auto A1 = Buf.get_access<sycl::access_mode::read, target::constant_buffer>(cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID2:.*]]|2014|1025|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-    auto A2 = Buf.get_access<mode::write>(cgh);
+    auto A2 = Buf.get_access<sycl::access_mode::write>(cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|0x0|[[ACCID3:.*]]|2016|1026|{{.*}}accessors.cpp:[[# @LINE + 1]]:34
     sycl::local_accessor<int, 1> A3(Range, cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID4:.*]]|2014|1027|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-    auto A4 = Buf.get_access<mode::discard_write>(cgh);
+    auto A4 = Buf.get_access<sycl::access_mode::discard_write>(cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID5:.*]]|2014|1028|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-    auto A5 = Buf.get_access<mode::discard_read_write, target::device>(cgh);
+    auto A5 = Buf.get_access<sycl::access_mode::discard_read_write, target::device>(cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID6:.*]]|2014|1029|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-    auto A6 = Buf.get_access<mode::atomic>(cgh);
+    auto A6 = Buf.get_access<sycl::access_mode::atomic>(cgh);
     cgh.parallel_for<class FillBuffer>(NDRange, [=](sycl::nd_item<1>) {
       (void)A1;
       (void)A2;
@@ -53,11 +53,11 @@ int main() {
   // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID9:.*]]|2018|1026|{{.*}}accessors.cpp:[[# @LINE + 1]]:25
   { sycl::host_accessor HA(Buf, sycl::read_write); }
   // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID10:.*]]|2018|1027|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-  { auto HA = Buf.get_access<mode::discard_write>(); }
+  { auto HA = Buf.get_access<sycl::access_mode::discard_write>(); }
   // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID11:.*]]|2018|1028|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-  { auto HA = Buf.get_access<mode::discard_read_write>(); }
+  { auto HA = Buf.get_access<sycl::access_mode::discard_read_write>(); }
   // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID12:.*]]|2018|1029|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-  { auto HA = Buf.get_access<mode::atomic>(); }
+  { auto HA = Buf.get_access<sycl::access_mode::atomic>(); }
 
   return 0;
 }

--- a/sycl/test-e2e/XPTI/buffer/accessors.cpp
+++ b/sycl/test-e2e/XPTI/buffer/accessors.cpp
@@ -25,7 +25,7 @@ int main() {
   sycl::nd_range<1> NDRange(Buf.size(), Buf.size());
 
   Queue.submit([&](sycl::handler &cgh) {
-    // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID1:.+]]|2015|1024|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
+    // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID1:.+]]|2015|1024|{{.*}}accessors.cpp:[[# @LINE + 2]]:13
     auto A1 =
         Buf.get_access<sycl::access_mode::read, target::constant_buffer>(cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID2:.*]]|2014|1025|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
@@ -34,7 +34,7 @@ int main() {
     sycl::local_accessor<int, 1> A3(Range, cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID4:.*]]|2014|1027|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
     auto A4 = Buf.get_access<sycl::access_mode::discard_write>(cgh);
-    // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID5:.*]]|2014|1028|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
+    // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID5:.*]]|2014|1028|{{.*}}accessors.cpp:[[# @LINE + 2]]:13
     auto A5 =
         Buf.get_access<sycl::access_mode::discard_read_write, target::device>(
             cgh);
@@ -55,15 +55,15 @@ int main() {
   { sycl::host_accessor HA(Buf, sycl::write_only); }
   // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID9:.*]]|2018|1026|{{.*}}accessors.cpp:[[# @LINE + 1]]:25
   { sycl::host_accessor HA(Buf, sycl::read_write); }
-  // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID10:.*]]|2018|1027|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
+  // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID10:.*]]|2018|1027|{{.*}}accessors.cpp:[[# @LINE + 2]]:19
   {
     auto HA = Buf.get_access<sycl::access_mode::discard_write>();
   }
-  // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID11:.*]]|2018|1028|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
+  // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID11:.*]]|2018|1028|{{.*}}accessors.cpp:[[# @LINE + 2]]:19
   {
     auto HA = Buf.get_access<sycl::access_mode::discard_read_write>();
   }
-  // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID12:.*]]|2018|1029|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
+  // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID12:.*]]|2018|1029|{{.*}}accessors.cpp:[[# @LINE + 2]]:19
   {
     auto HA = Buf.get_access<sycl::access_mode::atomic>();
   }

--- a/sycl/test-e2e/XPTI/buffer/accessors.cpp
+++ b/sycl/test-e2e/XPTI/buffer/accessors.cpp
@@ -26,7 +26,8 @@ int main() {
 
   Queue.submit([&](sycl::handler &cgh) {
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID1:.+]]|2015|1024|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-    auto A1 = Buf.get_access<sycl::access_mode::read, target::constant_buffer>(cgh);
+    auto A1 =
+        Buf.get_access<sycl::access_mode::read, target::constant_buffer>(cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID2:.*]]|2014|1025|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
     auto A2 = Buf.get_access<sycl::access_mode::write>(cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|0x0|[[ACCID3:.*]]|2016|1026|{{.*}}accessors.cpp:[[# @LINE + 1]]:34
@@ -34,7 +35,9 @@ int main() {
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID4:.*]]|2014|1027|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
     auto A4 = Buf.get_access<sycl::access_mode::discard_write>(cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID5:.*]]|2014|1028|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-    auto A5 = Buf.get_access<sycl::access_mode::discard_read_write, target::device>(cgh);
+    auto A5 =
+        Buf.get_access<sycl::access_mode::discard_read_write, target::device>(
+            cgh);
     // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID6:.*]]|2014|1029|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
     auto A6 = Buf.get_access<sycl::access_mode::atomic>(cgh);
     cgh.parallel_for<class FillBuffer>(NDRange, [=](sycl::nd_item<1>) {
@@ -53,11 +56,17 @@ int main() {
   // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID9:.*]]|2018|1026|{{.*}}accessors.cpp:[[# @LINE + 1]]:25
   { sycl::host_accessor HA(Buf, sycl::read_write); }
   // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID10:.*]]|2018|1027|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-  { auto HA = Buf.get_access<sycl::access_mode::discard_write>(); }
+  {
+    auto HA = Buf.get_access<sycl::access_mode::discard_write>();
+  }
   // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID11:.*]]|2018|1028|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-  { auto HA = Buf.get_access<sycl::access_mode::discard_read_write>(); }
+  {
+    auto HA = Buf.get_access<sycl::access_mode::discard_read_write>();
+  }
   // CHECK: {{[0-9]+}}|Construct accessor|[[BUFFERID]]|[[ACCID12:.*]]|2018|1029|{{.*}}accessors.cpp:[[# @LINE + 1]]:19
-  { auto HA = Buf.get_access<sycl::access_mode::atomic>(); }
+  {
+    auto HA = Buf.get_access<sycl::access_mode::atomic>();
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/XPTI/buffer/multiple_buffers.cpp
+++ b/sycl/test-e2e/XPTI/buffer/multiple_buffers.cpp
@@ -26,8 +26,8 @@ int main() {
   // CHECK:{{[0-9]+}}|Associate buffer|[[USERID2]]|[[BEID2:.*]]
   Queue.submit([&](sycl::handler &cgh) {
     // Get write only access to the buffer on a device.
-    auto Accessor1 = Buffer1.get_access<sycl::access::mode::write>(cgh);
-    auto Accessor2 = Buffer2.get_access<sycl::access::mode::write>(cgh);
+    auto Accessor1 = Buffer1.get_access<sycl::access_mode::write>(cgh);
+    auto Accessor2 = Buffer2.get_access<sycl::access_mode::write>(cgh);
     // Execute kernel.
     cgh.parallel_for<class FillBuffer>(NumOfWorkItems, [=](sycl::id<1> WIid) {
       Accessor1[WIid] = static_cast<short>(WIid.get(0));

--- a/sycl/test-e2e/XPTI/buffer/sub_buffer.cpp
+++ b/sycl/test-e2e/XPTI/buffer/sub_buffer.cpp
@@ -25,7 +25,7 @@ int main() {
 
     Queue.submit([&](sycl::handler &cgh) {
       // CHECK: {{[0-9]+}}|Construct accessor|[[USERID1]]|[[ACCID1:.*]]|2014|1025|{{.*}}sub_buffer.cpp:[[# @LINE + 1]]:34
-      auto Accessor1 = SubBuffer.get_access<sycl::access::mode::write>(cgh);
+      auto Accessor1 = SubBuffer.get_access<sycl::access_mode::write>(cgh);
       // CHECK:{{[0-9]+}}|Associate buffer|[[USERID1]]|[[BEID1:.*]]
       // CHECK:{{[0-9]+}}|Associate buffer|[[USERID1]]|[[BEID2:.*]]
       cgh.parallel_for<class FillBuffer>(

--- a/sycl/test-e2e/XPTI/kernel/content.cpp
+++ b/sycl/test-e2e/XPTI/kernel/content.cpp
@@ -46,8 +46,8 @@ int main() {
     buffer<int> in_buf(input.data(), input.size());
     buffer<int> out_buf(input.size());
     myQueue.submit([&](handler &cgh) {
-      auto in = in_buf.template get_access<access::mode::read>(cgh);
-      auto out = out_buf.template get_access<access::mode::read_write>(cgh);
+      auto in = in_buf.template get_access<access_mode::read>(cgh);
+      auto out = out_buf.template get_access<access_mode::read_write>(cgh);
       // CHECK-OPT:Node create|{{.*}}test2{{.*}}|{{.*}}.cpp:[[# @LINE - 3 ]]:13|{128, 4, 2}, {32, 2, 1}, {16, 1, 0}, 2
       // CHECK-NOOPT:Node create|{{.*}}test2{{.*}}|{{.*}}.cpp:[[# @LINE - 4 ]]:13|{128, 4, 2}, {32, 2, 1}, {16, 1, 0}, 8
       cgh.parallel_for<class test2>(


### PR DESCRIPTION
access::mode is deprecated in favor of access_mode.
PR to add deprecations: https://github.com/intel/llvm/pull/22803
1st - https://github.com/intel/llvm/pull/22842
2nd - https://github.com/intel/llvm/pull/22843