### PR TITLE
[SYCL][E2E] Disable level_zero/interop-buffer.cpp on Win

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22347
 // UNSUPPORTED: windows && gpu-intel-gen12
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
-// UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
+// UNSUPPORTED: windows && run-mode
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22284
 // UNSUPPORTED: linux && run-mode
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405


### PR DESCRIPTION
Fails on Arc also, see [here](https://github.com/intel/llvm/issues/22284#issuecomment-5145672262).