### PR TITLE
[sycl-jit] Fix missing build rule for resource-shard-*.cpp with Makefiles generator

### DIFF
--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -85,15 +85,13 @@ add_custom_target(rtc-prepare-resources
 )
 
 add_custom_command(
-  OUTPUT ${SYCL_JIT_RESOURCE_CPP}
+  OUTPUT ${SYCL_JIT_RESOURCE_CPP} ${SYCL_JIT_RESOURCE_SHARD_CPPS}
   COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/generate.py --toolchain-dir ${SYCL_JIT_RESOURCE_INSTALL_DIR} --output ${SYCL_JIT_RESOURCE_CPP} --prefix ${SYCL_JIT_VIRTUAL_TOOLCHAIN_ROOT} --shard-dir ${SYCL_JIT_RESOURCE_SHARD_DIR} --num-shards ${SYCL_JIT_RESOURCE_NUM_SHARDS}
   DEPENDS
   rtc-prepare-resources
   ${SYCL_JIT_RESOURCE_DEPS}
   ${SYCL_JIT_RESOURCE_FILES}
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/generate.py
-  BYPRODUCTS
-  ${SYCL_JIT_RESOURCE_SHARD_CPPS}
 )
 
 # We use C23/C++26's `#embed` to implement this resource creation, and "current"


### PR DESCRIPTION
The generated resource-shard-N.cpp files were declared as BYPRODUCTS of the generate.py custom command rather than OUTPUT. CMake's Unix/ NMake Makefiles generators don't emit build rules for BYPRODUCTS (unlike Ninja, which tracks byproducts as first-class outputs), so a fresh build fails with "No rule to make target
'resource-shard-0.cpp'". Moving the shard files into OUTPUT gives Make a proper rule to produce them alongside resource.cpp.