### PR TITLE
[SYCL] Fix g++ host-compiler build after 31945d82be43

### DIFF
--- a/sycl/include/sycl/access/access.hpp
+++ b/sycl/include/sycl/access/access.hpp
@@ -23,10 +23,10 @@ enum class target {
   global_buffer __SYCL2020_DEPRECATED("use 'target::device' instead") = device,
   constant_buffer __SYCL2020_DEPRECATED("use 'target::device' instead") = 2015,
   local __SYCL2020_DEPRECATED("use `local_accessor` instead") = 2016,
-  image __SYCL_DEPRECATED("removed in SYCL 2020") = 2017,
+  image __SYCL2020_DEPRECATED("removed in SYCL 2020") = 2017,
   host_buffer __SYCL2020_DEPRECATED("use 'host_accessor' instead") = 2018,
-  host_image __SYCL_DEPRECATED("removed in SYCL 2020") = 2019,
-  image_array __SYCL_DEPRECATED("removed in SYCL 2020") = 2020,
+  host_image __SYCL2020_DEPRECATED("removed in SYCL 2020") = 2019,
+  image_array __SYCL2020_DEPRECATED("removed in SYCL 2020") = 2020,
   host_task = 2021,
 };
 
@@ -40,7 +40,7 @@ enum class mode {
 };
 
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-enum class __SYCL_DEPRECATED("Removed in SYCL 2020") fence_space {
+enum class __SYCL2020_DEPRECATED("Removed in SYCL 2020") fence_space {
   local_space = 0,
   global_space = 1,
   global_and_local = 2

--- a/sycl/include/sycl/sampler.hpp
+++ b/sycl/include/sycl/sampler.hpp
@@ -63,7 +63,7 @@ class sampler_impl;
 ///
 /// \ingroup sycl_api
 class __SYCL_EXPORT __SYCL_SPECIAL_CLASS __SYCL_TYPE(sampler)
-    __SYCL_DEPRECATED("sampler has been removed in SYCL 2020") sampler {
+    __SYCL2020_DEPRECATED("sampler has been removed in SYCL 2020") sampler {
   friend sycl::detail::ImplUtils;
 
 public:


### PR DESCRIPTION
Fix sycl-in-tree::Complex~sycl_complex_include_order.cpp and sycl-in-tree::Regression~fsycl-host-compiler.cpp tests that broke after commit 31945d82be43 which deprecated the sampler class and access targets.

The commit used __SYCL_DEPRECATED which unconditionally expands to [[deprecated(...)]] on all compilers. When compiled with g++ (via -fsycl-host-compiler=g++) versions prior to GCC 13, mixing __attribute__((visibility("default"))) with [[deprecated(...)]] on a class declaration causes a parse error. Use __SYCL2020_DEPRECATED instead, which is gated on SYCL_LANGUAGE_VERSION == 202012L and matches the pattern used by other SYCL 2020 deprecations in the same files.

Fixes: CMPLRLLVM-77354