### PR TITLE
[SYCL] Remove sycl_ext_oneapi_discard_queue_events in preview-breaking mode

### DIFF
--- a/sycl/doc/extensions/deprecated/sycl_ext_oneapi_discard_queue_events.asciidoc
+++ b/sycl/doc/extensions/deprecated/sycl_ext_oneapi_discard_queue_events.asciidoc
@@ -47,6 +47,9 @@ replaced by the sycl_ext_oneapi_enqueue_functions extension: see link:../experim
 *Shipping software products should stop using APIs defined in this
 specification and use this alternative instead.*
 
+// __INTEL_PREVIEW_BREAKING_CHANGES: Move this specification to the "removed"
+// folder when the feature is removed at the next breaking changes window.
+
 == Version
 
 Revision: 1

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_discard_queue_events.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_discard_queue_events.asciidoc
@@ -1,3 +1,6 @@
+// __INTEL_PREVIEW_BREAKING_CHANGES: Remove this specification when the feature
+// is removed at the next breaking changes window.
+
 :dpcpp: pass:[DPC++]
 
 This extension has been deprecated, but the specification is still available

--- a/sycl/include/sycl/properties/queue_properties.def
+++ b/sycl/include/sycl/properties/queue_properties.def
@@ -32,9 +32,15 @@ __SYCL_MANUALLY_DEFINED_PROP(property::queue::cuda, use_default_stream)
 // Contains data field, defined explicitly.
 __SYCL_MANUALLY_DEFINED_PROP(ext::intel::property::queue, compute_index)
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+/// Inform the implementation that the application will not use events returned
+/// by queue member functions.
+///
+/// This property is incompatible with `enable_profiling`.
 __SYCL_DATA_LESS_PROP_DEPRECATED_ALIAS(
     ext::oneapi::property::queue, discard_events, DiscardEvents,
     __SYCL2020_DEPRECATED("use sycl_ext_oneapi_enqueue_functions instead"))
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 #undef __SYCL_DATA_LESS_PROP
 #undef __SYCL_MANUALLY_DEFINED_PROP

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -212,12 +212,15 @@ public:
         MQueueID{
             MNextAvailableQueueID.fetch_add(1, std::memory_order_relaxed)} {
     verifyProps(PropList);
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+    // The discard_events property is incompatible with enable_profiling.
     if (has_property<ext::oneapi::property::queue::discard_events>() &&
         has_property<property::queue::enable_profiling>()) {
       throw sycl::exception(make_error_code(errc::invalid),
                             "Queue cannot be constructed with both of "
                             "discard_events and enable_profiling.");
     }
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
     // The following commented section provides a guideline on how to use the
     // TLS enabled mechanism to create a tracepoint and notify using XPTI. This

--- a/sycl/source/feature_test.hpp.in
+++ b/sycl/source/feature_test.hpp.in
@@ -36,7 +36,11 @@ inline namespace _V1 {
 #define SYCL_EXT_ONEAPI_MATRIX 1
 #define SYCL_EXT_ONEAPI_ASSERT 1
 #define SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS 1
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+// Advertise the deprecated discard queue events extension in non-preview
+// builds.
 #define SYCL_EXT_ONEAPI_DISCARD_QUEUE_EVENTS 1
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 #define SYCL_EXT_ONEAPI_QUEUE_PRIORITY 1
 #define SYCL_EXT_ONEAPI_ENQUEUE_BARRIER 1
 #define SYCL_EXT_ONEAPI_FREE_FUNCTION_QUERIES 1

--- a/sycl/test-e2e/DeprecatedFeatures/DiscardEvents/lit.local.cfg
+++ b/sycl/test-e2e/DeprecatedFeatures/DiscardEvents/lit.local.cfg
@@ -1,0 +1,3 @@
+# __INTEL_PREVIEW_BREAKING_CHANGES: remove the folder along with all its
+# contents when the sycl_ext_oneapi_discard_queue_events feature is removed.
+config.unsupported_features += ['preview-mode']

--- a/sycl/unittests/queue/Properties.cpp
+++ b/sycl/unittests/queue/Properties.cpp
@@ -26,8 +26,11 @@ TEST(QueueProperties, ValidDatalessProperties) {
   sycl::unittest::UrMock<> Mock;
   DatalessQueuePropertyCheck<sycl::property::queue::in_order>();
   DatalessQueuePropertyCheck<sycl::property::queue::enable_profiling>();
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+  // Check the deprecated discard_events property in non-preview builds.
   DatalessQueuePropertyCheck<
       sycl::ext::oneapi::property::queue::discard_events>();
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
   DatalessQueuePropertyCheck<
       sycl::ext::oneapi::property::queue::priority_normal>();
   DatalessQueuePropertyCheck<


### PR DESCRIPTION
Removes the deprecated `sycl_ext_oneapi_discard_queue_events` extension from
preview-breaking builds. 

This guards the property, feature-test macro, runtime usage, and unit test, while disabling its E2E tests in preview mode.

Documentation is marked for removal during the next breaking-changes window.

This partially addresses #22581