### PR TITLE
[SYCL][NFC] Switch the rest of E2E to access_mode

### DIFF
--- a/sycl/test-e2e/XPTI/image/accessors.cpp
+++ b/sycl/test-e2e/XPTI/image/accessors.cpp
@@ -26,22 +26,29 @@ int main() {
 
     Q.submit([&](sycl::handler &CGH) {
       // CHECK:{{[0-9]+}}|Construct unsampled image accessor|[[UIMGID]]|0x{{[0-9,a-f]+}}|1|1024|{{.*}}vec{{.*}}|16|{{.*}}accessors.cpp:[[# @LINE + 1]]:22
-      auto A1 = UImg.get_access<sycl::uint4, mode::read,
+      auto A1 = UImg.get_access<sycl::uint4, sycl::access_mode::read,
                                 sycl::image_target::host_task>(CGH);
     });
 
     Q.submit([&](sycl::handler &CGH) {
       // CHECK:{{[0-9]+}}|Construct unsampled image accessor|[[UIMGID]]|0x{{[0-9,a-f]+}}|1|1025|{{.*}}vec{{.*}}|16|{{.*}}accessors.cpp:[[# @LINE + 1]]:22
-      auto A1 = UImg.get_access<sycl::uint4, mode::write,
+      auto A1 = UImg.get_access<sycl::uint4, sycl::access_mode::write,
                                 sycl::image_target::host_task>(CGH);
     });
 
-    // CHECK:{{[0-9]+}}|Construct host unsampled image accessor|[[UIMGID]]|0x{{[0-9,a-f]+}}|1024|{{.*}}vec{{.*}}|16|{{.*}}accessors.cpp:[[# @LINE + 1]]:22
-    { auto HA = UImg.get_host_access<sycl::int4, mode::read>(); }
-    // CHECK:{{[0-9]+}}|Construct host unsampled image accessor|[[UIMGID]]|0x{{[0-9,a-f]+}}|1025|{{.*}}vec{{.*}}|16|{{.*}}accessors.cpp:[[# @LINE + 1]]:22
-    { auto HA = UImg.get_host_access<sycl::float4, mode::write>(); }
-    // CHECK:{{[0-9]+}}|Construct host unsampled image accessor|[[UIMGID]]|0x{{[0-9,a-f]+}}|1026|{{.*}}vec{{.*}}|8|{{.*}}accessors.cpp:[[# @LINE + 1]]:22
-    { auto HA = UImg.get_host_access<sycl::half4, mode::read_write>(); }
+    // CHECK:{{[0-9]+}}|Construct host unsampled image accessor|[[UIMGID]]|0x{{[0-9,a-f]+}}|1024|{{.*}}vec{{.*}}|16|{{.*}}accessors.cpp:[[# @LINE + 2]]:22
+    {
+      auto HA = UImg.get_host_access<sycl::int4, sycl::access_mode::read>();
+    }
+    // CHECK:{{[0-9]+}}|Construct host unsampled image accessor|[[UIMGID]]|0x{{[0-9,a-f]+}}|1025|{{.*}}vec{{.*}}|16|{{.*}}accessors.cpp:[[# @LINE + 2]]:22
+    {
+      auto HA = UImg.get_host_access<sycl::float4, sycl::access_mode::write>();
+    }
+    // CHECK:{{[0-9]+}}|Construct host unsampled image accessor|[[UIMGID]]|0x{{[0-9,a-f]+}}|1026|{{.*}}vec{{.*}}|8|{{.*}}accessors.cpp:[[# @LINE + 3]]:16
+    {
+      auto HA =
+          UImg.get_host_access<sycl::half4, sycl::access_mode::read_write>();
+    }
   }
   // CHECK:{{[0-9]+}}|Destruct image|[[UIMGID]]
 

--- a/sycl/test-e2e/XPTI/kernel/basic.cpp
+++ b/sycl/test-e2e/XPTI/kernel/basic.cpp
@@ -21,27 +21,29 @@ constexpr sycl::specialization_id<int> int_id(42);
 class Functor1 {
 public:
   Functor1(short X_,
-           sycl::accessor<int, 1, mode::read_write, target::device> &Acc_)
+           sycl::accessor<int, 1, sycl::access_mode::read_write, target::device>
+               &Acc_)
       : X(X_), Acc(Acc_) {}
 
   void operator()() const { Acc[0] += X; }
 
 private:
   short X;
-  sycl::accessor<int, 1, mode::read_write, target::device> Acc;
+  sycl::accessor<int, 1, sycl::access_mode::read_write, target::device> Acc;
 };
 
 class Functor2 {
 public:
   Functor2(short X_,
-           sycl::accessor<int, 1, mode::read_write, target::device> &Acc_)
+           sycl::accessor<int, 1, sycl::access_mode::read_write, target::device>
+               &Acc_)
       : X(X_), Acc(Acc_) {}
 
   void operator()(sycl::id<1> id = 0) const { Acc[id] += X; }
 
 private:
   short X;
-  sycl::accessor<int, 1, mode::read_write, target::device> Acc;
+  sycl::accessor<int, 1, sycl::access_mode::read_write, target::device> Acc;
 };
 
 int main() {


### PR DESCRIPTION
access::mode is deprecated in SYCL 2020. Use access_mode instead.