### PR TITLE
[SPIR-V] Reapply llvm-spirv lifetime intrinsic customizations

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -5124,8 +5124,16 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
 
     unsigned PtrAS = cast<PointerType>(LLVMPtrOp->getType())->getAddressSpace();
     auto *PtrOp = transValue(LLVMPtrOp, BB);
-    if (PtrAS == SPIRAS_Private)
+    // INTEL_CUSTOMIZATION begin
+    // Workaround to make older versions of SPIRVReader working with new
+    // rules of LLVM lifetime intrinsics.
+    // TODO: to remove the W/A.
+    if (PtrAS == SPIRAS_Private) {
+      auto *Int8PtrTy =
+          transPointerType(Type::getInt8Ty(M->getContext()), SPIRAS_Private);
+      PtrOp = BM->addUnaryInst(OpBitcast, Int8PtrTy, PtrOp, BB);
       return BM->addLifetimeInst(OC, PtrOp, Size, BB);
+    }
     // If pointer address space is Generic - use original allocation.
     BM->getErrorLog().checkError(
         PtrAS == SPIRAS_Generic, SPIRVEC_InvalidInstruction, II,
@@ -5133,7 +5141,11 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     if (PtrOp->getOpCode() == OpPtrCastToGeneric) {
       auto *UI = static_cast<SPIRVUnary *>(PtrOp);
       PtrOp = UI->getOperand(0);
+      auto *Int8PtrTy =
+          transPointerType(Type::getInt8Ty(M->getContext()), SPIRAS_Private);
+      PtrOp = BM->addUnaryInst(OpBitcast, Int8PtrTy, PtrOp, BB);
     }
+    // INTEL_CUSTOMIZATION end
     return BM->addLifetimeInst(OC, PtrOp, Size, BB);
   }
   // We don't want to mix translation of regular code and debug info, because

--- a/llvm-spirv/test/llvm-intrinsics/lifetime.ll
+++ b/llvm-spirv/test/llvm-intrinsics/lifetime.ll
@@ -19,20 +19,30 @@
 ; CHECK-SPIRV-DAG: TypeStruct [[#StructTy:]] [[#]]
 ; CHECK-SPIRV-DAG: TypePointer [[#PrivatePtrTy:]] 7 [[#StructTy]]
 
+; INTEL_CUSTOMIZATION:
 ; CHECK-SPIRV: Function [[#]] [[#SimpleF:]]
-; CHECK-SPIRV: LifetimeStart [[#Tmp:]] 0
-; CHECK-SPIRV: LifetimeStop [[#Tmp]] 0
+; CHECK-SPIRV: Variable [[#]] [[#Var:]]
+; CHECK-SPIRV: Bitcast [[#]] [[#Cast1:]] [[#Var]]
+; CHECK-SPIRV: LifetimeStart [[#Cast1]] 4
+; CHECK-SPIRV: Bitcast [[#]] [[#Cast2:]] [[#Var]]
+; CHECK-SPIRV: LifetimeStop [[#Cast2]] 4
 
 ; CHECK-SPIRV: Function [[#]] [[#SizedF:]]
-; CHECK-SPIRV: LifetimeStart [[#Tmp:]] 1
-; CHECK-SPIRV: LifetimeStop [[#Tmp]] 1
+; CHECK-SPIRV: Variable [[#]] [[#Var:]]
+; CHECK-SPIRV: Bitcast [[#]] [[#Cast1:]] [[#Var]]
+; CHECK-SPIRV: LifetimeStart [[#Cast1]] 1
+; CHECK-SPIRV: Bitcast [[#]] [[#Cast2:]] [[#Var]]
+; CHECK-SPIRV: LifetimeStop [[#Cast2]] 1
 
 ; CHECK-SPIRV: Function [[#]] [[#GenericF:]]
 ; CHECK-SPIRV: Variable [[#PrivatePtrTy]] [[#Var:]] 7
-; CHECK-SPIRV: PtrCastToGeneric [[#]] [[#Cast1:]] [[#Var]]
-; CHECK-SPIRV: LifetimeStart [[#Var]] 0
-; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#Cast1]]
-; CHECK-SPIRV: LifetimeStop [[#Var]] 0
+; CHECK-SPIRV: PtrCastToGeneric [[#]] [[#ASCast:]] [[#Var]]
+; CHECK-SPIRV: Bitcast [[#]] [[#Cast1:]] [[#Var]]
+; CHECK-SPIRV: LifetimeStart [[#Cast1]] 1
+; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#ASCast]]
+; CHECK-SPIRV: Bitcast [[#]] [[#Cast2:]] [[#Var]]
+; CHECK-SPIRV: LifetimeStop [[#Cast2]] 1
+; INTEL_CUSTOMIZATION end
 
 ; CHECK-LLVM-LABEL: lifetime_simple
 ; CHECK-LLVM: %[[#Alloca:]] = alloca i32

--- a/llvm-spirv/test/llvm-intrinsics/memmove.ll
+++ b/llvm-spirv/test/llvm-intrinsics/memmove.ll
@@ -2,14 +2,20 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-TYPED-PTR
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: spirv-val %t.spv
+; INTEL_CUSTOMIZATION begin
+; https://github.com/intel/llvm/issues/22248
+; RUNx: spirv-val %t.spv
+; INTEL_CUSTOMIZATION end
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt --spirv-ext=+SPV_KHR_untyped_pointers
 ; RUN: FileCheck < %t.txt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-UNTYPED-PTR
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_KHR_untyped_pointers
-; RUN: spirv-val %t.spv
+; INTEL_CUSTOMIZATION begin
+; https://github.com/intel/llvm/issues/22248
+; RUNx: spirv-val %t.spv
+; INTEL_CUSTOMIZATION end
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
@@ -30,13 +36,16 @@
 ; CHECK-SPIRV: FunctionParameter [[#I8GLOBAL_PTR]] [[#ARG_IN:]]
 ; CHECK-SPIRV: FunctionParameter [[#I8GLOBAL_PTR]] [[#ARG_OUT:]]
 ;
+; INTEL_CUSTOMIZATION begin
 ; CHECK-SPIRV: Variable [[#]] [[#MEM:]]
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_IN:]] [[#ARG_IN]]
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_OUT:]] [[#ARG_OUT]]
-; CHECK-SPIRV: LifetimeStart [[#MEM]]
+; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_1:]] [[#MEM]]
+; CHECK-SPIRV: LifetimeStart [[#MEM_CAST_1]]
 ; CHECK-SPIRV: CopyMemorySized [[#MEM]] [[#I8_ARG_IN]] [[#C128]] 2 64
 ; CHECK-SPIRV: CopyMemorySized [[#I8_ARG_OUT]] [[#MEM]] [[#C128]] 2 64
-; CHECK-SPIRV: LifetimeStop [[#MEM]]
+; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_2:]] [[#MEM]]
+; CHECK-SPIRV: LifetimeStop [[#MEM_CAST_2]]
 
 ; CHECK-SPIRV-LABEL: [[#]] Function [[#]]
 ; CHECK-SPIRV: FunctionParameter [[#I8GLOBAL_PTR]] [[#ARG_IN:]]
@@ -46,20 +55,25 @@
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_IN:]] [[#ARG_IN]]
 ; CHECK-SPIRV: Bitcast [[#]] [[#I8_ARG_OUT_GENERIC:]] [[#ARG_OUT]]
 ; CHECK-SPIRV: GenericCastToPtr [[#]] [[#I8_ARG_OUT:]] [[#I8_ARG_OUT_GENERIC]]
-; CHECK-SPIRV: LifetimeStart [[#MEM]]
+; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_1:]] [[#MEM]]
+; CHECK-SPIRV: LifetimeStart [[#MEM_CAST_1]]
 ; CHECK-SPIRV: CopyMemorySized [[#MEM]] [[#I8_ARG_IN]] [[#C68]] 2 64
 ; CHECK-SPIRV: CopyMemorySized [[#I8_ARG_OUT]] [[#MEM]] [[#C68]] 2 64
-; CHECK-SPIRV: LifetimeStop [[#MEM]]
+; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_2:]] [[#MEM]]
+; CHECK-SPIRV: LifetimeStop [[#MEM_CAST_2]]
 
 ; CHECK-SPIRV-LABEL: [[#]] Function [[#]]
 ; CHECK-SPIRV: FunctionParameter [[#]] [[#ARG_IN:]]
 ; CHECK-SPIRV: FunctionParameter [[#]] [[#ARG_OUT:]]
 ;
 ; CHECK-SPIRV: Variable [[#]] [[#MEM:]]
-; CHECK-SPIRV: LifetimeStart [[#MEM]]
+; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_1:]] [[#MEM]]
+; CHECK-SPIRV: LifetimeStart [[#MEM_CAST_1]]
 ; CHECK-SPIRV: CopyMemorySized [[#MEM]] [[#ARG_IN]] [[#C72]] 0
 ; CHECK-SPIRV: CopyMemorySized [[#ARG_OUT]] [[#MEM]] [[#C72]] 0
-; CHECK-SPIRV: LifetimeStop [[#MEM]]
+; CHECK-SPIRV: Bitcast [[#]] [[#MEM_CAST_2:]] [[#MEM]]
+; CHECK-SPIRV: LifetimeStop [[#MEM_CAST_2]]
+; INTEL_CUSTOMIZATION end
 
 ; xCHECK-SPIRV-LABEL: [[#]] Function [[#]]
 ;


### PR DESCRIPTION
Restores the bitcast of private-AS lifetime pointer operands to i8*, so that OpLifetimeStart/OpLifetimeStop carry the object size rather than 0.

Removing this made ocloc AOT compilation fail with an IGC segmentation violation and error -11 on drivers whose SPIR-V reader consumes the Size operand. The same failure signature was reported for PyTorch builds on sycl-rel-7_0, where the customization is already restored (#22325).

Reverts commit 4f9fa54872427bf060d5eb5608c903ab3eb418cf (#22253)