### PR TITLE
[CI] Add Docker container with LTS driver

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -89,6 +89,9 @@ jobs:
           - name: Build + Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
             tag: latest
+          - name: Build + Intel LTS Drivers Ubuntu 22.04 Docker image
+            file: ubuntu2204_intel_lts_drivers
+            tag: latest
           - name: Build + Intel Drivers Ubuntu 24.04 Docker image
             file: ubuntu2404_intel_drivers
             tag: latest

--- a/devops/containers/ubuntu2204_intel_lts_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_lts_drivers.Dockerfile
@@ -1,0 +1,25 @@
+ARG base_tag=latest
+ARG base_image=ghcr.io/intel/llvm/ubuntu2204_build
+
+FROM $base_image:$base_tag
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+USER root
+
+RUN apt update && apt install -yqq wget
+
+COPY scripts/install_lts_drivers.sh /
+COPY dependencies.json /
+
+RUN mkdir /runtimes
+ENV INSTALL_LOCATION=/runtimes
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) /install_lts_drivers.sh
+
+COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
+
+USER sycl
+
+ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
+

--- a/devops/scripts/install_lts_drivers.sh
+++ b/devops/scripts/install_lts_drivers.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -x
+set -e
+set -o pipefail
+
+. /etc/os-release
+LTS_DRIVER_VERSION="2350.150"
+wget -q https://repositories.intel.com/gpu/ubuntu/dists/${VERSION_CODENAME}/lts/${LTS_DRIVER_VERSION}/intel-gpu-ubuntu-${VERSION_CODENAME}-${LTS_DRIVER_VERSION}.run -O lts_driver.run
+chmod +x lts_driver.run
+./lts_driver.run -y
+sudo ./lts_driver.run -r -y
+sudo apt-get update
+sudo apt install -yqq  \
+    intel-opencl-icd intel-level-zero-gpu level-zero \
+    intel-media-va-driver-non-free libmfxgen1 libvpl2 \
+    libegl-mesa0 libegl1-mesa libegl1-mesa-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri \
+    libglapi-mesa libgles2-mesa-dev libglx-mesa0 libigdgmm12 libxatracker2 mesa-va-drivers \
+    mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all vainfo hwinfo clinfo
+sudo rm -rf /var/lib/apt/lists/*
+rm lts_driver.run


### PR DESCRIPTION
This is the oldest IGC we need to support, so I want to add some basic testing with it.

Add a new container that uses the official download package.  We can't use the PPA because that doesn't let us lock down the version, and we can't use the binaries attached to GitHub release like we usually do because binaries don't exist for many of the projects.

We need to use 22.04 because that's the version supported by the LTS driver.