### PR TITLE
[Driver] Allow Intel CPU/GPU offload-arch values for OFK_OpenMP

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1030,8 +1030,7 @@ static TripleSet inferOffloadToolchains(Compilation &C,
           << "CUDA" << Arch;
       return {};
     }
-    if (Kind == Action::OFK_OpenMP && (ID.isIntelCPU() || ID.isIntelGPU() ||
-                                       ID.isUnknown() || ID.isUnused())) {
+    if (Kind == Action::OFK_OpenMP && (ID.isUnknown() || ID.isUnused())) {
       C.getDriver().Diag(clang::diag::err_drv_failed_to_deduce_target_from_arch)
           << Arch;
       return {};

--- a/clang/test/Driver/openmp-offload-infer.c
+++ b/clang/test/Driver/openmp-offload-infer.c
@@ -36,10 +36,10 @@
 // CHECK-ARCH-BINDINGS: "x86_64-unknown-linux-gnu" - "Offload::Linker", inputs: ["[[HOST_OBJ]]"], output: "a.out"
 
 // RUN:   not %clang -### --target=x86_64-unknown-linux-gnu -ccc-print-bindings -fopenmp=libomp \
-// RUN:     --offload-arch=sm_70 --offload-arch=gfx908 --offload-arch=skylake \
+// RUN:     --offload-arch=sm_70 --offload-arch=gfx908 --offload-arch=skylakex \
 // RUN:     -nogpulib %s 2>&1 | FileCheck %s --check-prefix=CHECK-FAILED
 
-// CHECK-FAILED: error: failed to deduce triple for target architecture 'skylake'; specify the triple using '-fopenmp-targets' and '-Xopenmp-target' instead
+// CHECK-FAILED: error: failed to deduce triple for target architecture 'skylakex'; specify the triple using '-fopenmp-targets' and '-Xopenmp-target' instead
 
 
 // RUN:   %clang -### --target=x86_64-unknown-linux-gnu -ccc-print-bindings -fopenmp=libomp \


### PR DESCRIPTION
This PR aligns the code with both upstream and downstream.

Do not reject Intel CPU/GPU offload-arch values for OFK_OpenMP. Allow -fiopenmp --offload-arch=<intel-cpu> to succeed. Update openmp-offload-infer.c's bad-arch case to use invalid Intel CPU arch.