### PR TITLE
[SYCL][UT] Eliminate concurrent read-write of mock callbacks map

### DIFF
--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -130,7 +130,7 @@ public:
   using sycl::detail::queue_impl::MStreamsServiceEvents;
 };
 
-TEST_F(SchedulerTest, StreamAUXCmdsWait) {
+TEST_F(SchedulerTest, StreamAUXCmdsWaitDependencies) {
   sycl::unittest::UrMock<> Mock;
 
   {
@@ -162,27 +162,26 @@ TEST_F(SchedulerTest, StreamAUXCmdsWait) {
     ASSERT_TRUE(QueueImpl.MStreamsServiceEvents.empty())
         << "No stream service events are expected to left after wait";
   }
+}
 
-  {
-    sycl::platform Plt = sycl::platform();
-    sycl::queue Q(Plt.get_devices()[0]);
-    auto &QueueImpl =
-        static_cast<QueueImplProxyT &>(*detail::getSyclObjImpl(Q));
+TEST_F(SchedulerTest, StreamAUXCmdsWaitInQueueWait) {
+  sycl::unittest::UrMock<> Mock;
+  mock::getCallbacks().set_before_callback("urEventWait",
+                                           &urEventsWaitRedefineCheckCalled);
 
-    mock::getCallbacks().set_before_callback("urEventWait",
-                                             &urEventsWaitRedefineCheckCalled);
+  sycl::platform Plt = sycl::platform();
+  sycl::queue Q(Plt.get_devices()[0]);
+  auto &QueueImpl = static_cast<QueueImplProxyT &>(*detail::getSyclObjImpl(Q));
 
-    ur_event_handle_t UREvent = mock::createDummyHandle<ur_event_handle_t>();
+  ur_event_handle_t UREvent = mock::createDummyHandle<ur_event_handle_t>();
+  auto EventImpl = sycl::detail::event_impl::create_device_event(QueueImpl);
+  EventImpl->setHandle(UREvent);
 
-    auto EventImpl = sycl::detail::event_impl::create_device_event(QueueImpl);
-    EventImpl->setHandle(UREvent);
+  QueueImpl.registerStreamServiceEvent(EventImpl);
+  QueueImpl.wait();
 
-    QueueImpl.registerStreamServiceEvent(EventImpl);
-    QueueImpl.wait();
-
-    ASSERT_TRUE(GpiEventsWaitRedefineCalled)
-        << "No stream service events are expected to left after wait";
-  }
+  ASSERT_TRUE(GpiEventsWaitRedefineCalled)
+      << "No stream service events are expected to left after wait";
 }
 
 TEST_F(SchedulerTest, CommandsWaitForEvents) {


### PR DESCRIPTION
Initial test implementation allowed concurrent read and write of "before_callbacks" map. After the first part of test where host task is present Q.wait() guarantees all HT work to be finished but some post processing (including memory release) can continue. That post processing can call UR methods (e.g. urEventRelease and others) if needed (read access). The second part of test was updating one of the maps in ur mock (write access). This behavior is UB. 
Split test to 2 separate tests to remove incorrect usage of UR mock functionality.