### PR TITLE
[SYCL][CMake] Fix macOS deploy-sycl-toolchain failure for unified-memory-framework

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -657,7 +657,20 @@ foreach(component IN LISTS SYCL_TOOLCHAIN_DEPLOY_COMPONENTS)
     endforeach()
   else()
     set(INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/cmake_install.cmake")
-    sycl_add_install_command("${component}" "${component}" "${INSTALL_SCRIPT}" "")
+    set(COMPONENT_DEPS "")
+    if("${component}" STREQUAL "unified-memory-framework" AND TARGET umf)
+      # The "umf" shared library is only linked (and thus only guaranteed to
+      # be built) as a side effect of building sycl-toolchain when a
+      # statically-linked Level Zero adapter pulls it in (see
+      # unified-runtime/source/loader/CMakeLists.txt). On configurations
+      # where nothing links against it (e.g. macOS, which only builds the
+      # OpenCL adapter), ninja never builds the "umf" target on its own, yet
+      # this install step unconditionally tries to deploy it, causing a
+      # "file INSTALL cannot find ... libumf*.dylib" failure. Depend on it
+      # explicitly so the component can always be installed.
+      set(COMPONENT_DEPS "umf")
+    endif()
+    sycl_add_install_command("${component}" "${component}" "${INSTALL_SCRIPT}" "${COMPONENT_DEPS}")
   endif()
 endforeach()
 


### PR DESCRIPTION
The "unified-memory-framework" install component was unconditionally
added to SYCL_TOOLCHAIN_DEPLOY_COMPONENTS, assuming the "umf" shared
library is always built as a side effect of building sycl-toolchain.
However, "umf" is only actually linked (via target_link_libraries) into
ur_loader when a statically-linked Level Zero adapter needs it, gated by
"UR_STATIC_ADAPTER_L0 AND UR_BUILD_ADAPTER_L0" (see
unified-runtime/source/loader/CMakeLists.txt).

On macOS, only the OpenCL backend is enabled (UR_BUILD_ADAPTER_L0=OFF),
so nothing in the build graph ever depends on the "umf" target, and ninja
never builds it. The "deploy-sycl-toolchain" install step still tried to
deploy it unconditionally, failing with:
```
  file INSTALL cannot find ".../lib/libumf.1.2.0.dylib"
```
This went unnoticed because the macOS workflow was previously never
exercised on pull requests.

Fix: add an explicit build dependency on the "umf" target for the
unified-memory-framework install command, so it is always built before
being installed, regardless of whether anything else in the dependency
graph happens to link against it.

Verified on intel/llvm#22871: the macOS build now completes successfully
end-to-end (libumf.1.2.0.dylib is built before being deployed).

Tested at: https://github.com/intel/llvm/pull/22871

Ref: https://github.com/intel/llvm/pull/22816#issuecomment-5144229598