### PR TITLE
Revert "Fix DebugFunction Parent when DISubprogram is scoped in DIModule"

### DIFF
--- a/llvm-spirv/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/llvm-spirv/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1250,22 +1250,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgFunction(const DISubprogram *Func) {
   Ops[LineIdx] = Func->getLine();
   Ops[ColumnIdx] = 0; // This version of DISubprogram has no column number
   auto *Scope = Func->getScope();
-#if 1 // INTEL_CUSTOMIZATION
-  // For now we must ensure to keep DebugModule as a parent scope of
-  // DebugFunction in forward translation, otherwise DISubprogram
-  // can't restore its parent DIModule in reverse translation.
-  // This is needed by Fortran.
   if (Scope && !isa<DIFile>(Scope)) {
-#else  // INTEL_CUSTOMIZATION
-  // NonSemantic.Shader.DebugInfo requires DebugFunction Parent to be a
-  // lexical scope: DebugCompilationUnit, DebugFunction, DebugLexicalBlock or
-  // DebugTypeComposite.
-  // DebugModule (introduced in .200) is not a lexical scope, so fall back to
-  // the compile unit when the DISubprogram is scoped inside a DIModule.
-  bool ScopeIsLexical = Scope && !isa<DIFile>(Scope) &&
-                        !(isNonSemanticDebugInfo() && isa<DIModule>(Scope));
-  if (ScopeIsLexical) {
-#endif // INTEL_CUSTOMIZATION
     Ops[ParentIdx] = getScope(Scope)->getId();
   } else {
     if (auto *Unit = Func->getUnit())

--- a/llvm-spirv/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/llvm-spirv/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1250,6 +1250,13 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgFunction(const DISubprogram *Func) {
   Ops[LineIdx] = Func->getLine();
   Ops[ColumnIdx] = 0; // This version of DISubprogram has no column number
   auto *Scope = Func->getScope();
+#if 1 // INTEL_CUSTOMIZATION
+  // For now we must ensure to keep DebugModule as a parent scope of
+  // DebugFunction in forward translation, otherwise DISubprogram
+  // can't restore its parent DIModule in reverse translation.
+  // This is needed by Fortran.
+  if (Scope && !isa<DIFile>(Scope)) {
+#else  // INTEL_CUSTOMIZATION
   // NonSemantic.Shader.DebugInfo requires DebugFunction Parent to be a
   // lexical scope: DebugCompilationUnit, DebugFunction, DebugLexicalBlock or
   // DebugTypeComposite.
@@ -1258,6 +1265,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgFunction(const DISubprogram *Func) {
   bool ScopeIsLexical = Scope && !isa<DIFile>(Scope) &&
                         !(isNonSemanticDebugInfo() && isa<DIModule>(Scope));
   if (ScopeIsLexical) {
+#endif // INTEL_CUSTOMIZATION
     Ops[ParentIdx] = getScope(Scope)->getId();
   } else {
     if (auto *Unit = Func->getUnit())

--- a/llvm-spirv/test/DebugInfo/NonSemantic/Shader200/DebugLineOnlyOnce.ll
+++ b/llvm-spirv/test/DebugInfo/NonSemantic/Shader200/DebugLineOnlyOnce.ll
@@ -11,11 +11,9 @@
 
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
-; INTEL_CUSTOMIZATION
 ; TODO: re-enable spirv-val if it allows DebugModule to be parent scope of
 ; DebugFunction.
 ; RUNx: spirv-val %t.spv
-; end INTEL_CUSTOMIZATION
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64"

--- a/llvm-spirv/test/DebugInfo/NonSemantic/Shader200/DebugLineOnlyOnce.ll
+++ b/llvm-spirv/test/DebugInfo/NonSemantic/Shader200/DebugLineOnlyOnce.ll
@@ -11,7 +11,11 @@
 
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
-; RUN: spirv-val %t.spv
+; INTEL_CUSTOMIZATION
+; TODO: re-enable spirv-val if it allows DebugModule to be parent scope of
+; DebugFunction.
+; RUNx: spirv-val %t.spv
+; end INTEL_CUSTOMIZATION
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64"


### PR DESCRIPTION
This reverts the change in LLVMToSPIRVDbgTran.cpp, made by https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3753.

For Fortran, we must ensure the DebugModule remain as operand of DebugFunction during forward-translation. Otherwise, the DIModule can't be restored as the parent scope of DISubprogram during reverse-translation, which is problematic when debugging Fortran code.

The spirv-val check is temporarily disabled as well because it rejects DebugModule being an operand of DebugFunction now.