### PR TITLE
[SYCL] Use aux triple when mangling neon vectors

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4328,9 +4328,11 @@ void CXXNameMangler::mangleRISCVFixedRVVVectorType(
 void CXXNameMangler::mangleType(const VectorType *T) {
   if ((T->getVectorKind() == VectorKind::Neon ||
        T->getVectorKind() == VectorKind::NeonPoly)) {
-    llvm::Triple Target = getASTContext().getTargetInfo().getTriple();
-    llvm::Triple::ArchType Arch =
-        getASTContext().getTargetInfo().getTriple().getArch();
+    const TargetInfo *TI = getASTContext().getLangOpts().SYCLIsDevice
+                               ? getASTContext().getAuxTargetInfo()
+                               : &getASTContext().getTargetInfo();
+    llvm::Triple Target = TI->getTriple();
+    llvm::Triple::ArchType Arch = Target.getArch();
     if ((Arch == llvm::Triple::aarch64 ||
          Arch == llvm::Triple::aarch64_be) && !Target.isOSDarwin())
       mangleAArch64NeonVectorType(T);

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4331,8 +4331,8 @@ void CXXNameMangler::mangleType(const VectorType *T) {
     const TargetInfo *TI = getASTContext().getLangOpts().isTargetDevice()
                                ? getASTContext().getAuxTargetInfo()
                                : &getASTContext().getTargetInfo();
-    if(!TI)
-        TI = &getASTContext().getTargetInfo();
+    if (!TI)
+      TI = &getASTContext().getTargetInfo();
     llvm::Triple Target = TI->getTriple();
     llvm::Triple::ArchType Arch = Target.getArch();
     if ((Arch == llvm::Triple::aarch64 ||

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -4328,9 +4328,11 @@ void CXXNameMangler::mangleRISCVFixedRVVVectorType(
 void CXXNameMangler::mangleType(const VectorType *T) {
   if ((T->getVectorKind() == VectorKind::Neon ||
        T->getVectorKind() == VectorKind::NeonPoly)) {
-    const TargetInfo *TI = getASTContext().getLangOpts().SYCLIsDevice
+    const TargetInfo *TI = getASTContext().getLangOpts().isTargetDevice()
                                ? getASTContext().getAuxTargetInfo()
                                : &getASTContext().getTargetInfo();
+    if(!TI)
+        TI = &getASTContext().getTargetInfo();
     llvm::Triple Target = TI->getTriple();
     llvm::Triple::ArchType Arch = Target.getArch();
     if ((Arch == llvm::Triple::aarch64 ||

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8547,8 +8547,6 @@ static bool isPermittedNeonBaseType(QualType &Ty, VectorKind VecKind, Sema &S) {
     return false;
 
   llvm::Triple Triple = S.Context.getTargetInfo().getTriple();
-  if(S.getLangOpts().SYCLIsDevice)
-    Triple = S.Context.getAuxTargetInfo()->getTriple();
 
   // Signed poly is mathematically wrong, but has been baked into some ABIs by
   // now.

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8547,6 +8547,8 @@ static bool isPermittedNeonBaseType(QualType &Ty, VectorKind VecKind, Sema &S) {
     return false;
 
   llvm::Triple Triple = S.Context.getTargetInfo().getTriple();
+  if(S.getLangOpts().SYCLIsDevice)
+    Triple = S.Context.getAuxTargetInfo()->getTriple();
 
   // Signed poly is mathematically wrong, but has been baked into some ABIs by
   // now.
@@ -8558,8 +8560,9 @@ static bool isPermittedNeonBaseType(QualType &Ty, VectorKind VecKind, Sema &S) {
       // AArch64 polynomial vectors are unsigned.
       return BTy->getKind() == BuiltinType::UChar ||
              BTy->getKind() == BuiltinType::UShort ||
-             BTy->getKind() == BuiltinType::ULong ||
-             BTy->getKind() == BuiltinType::ULongLong;
+             ((BTy->getKind() == BuiltinType::ULong ||
+               BTy->getKind() == BuiltinType::ULongLong) &&
+              S.Context.getTypeSize(BTy) == 64);
     } else {
       // AArch32 polynomial vectors are signed.
       return BTy->getKind() == BuiltinType::SChar ||

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8558,11 +8558,9 @@ static bool isPermittedNeonBaseType(QualType &Ty, VectorKind VecKind, Sema &S) {
   if (VecKind == VectorKind::NeonPoly) {
     if (IsPolyUnsigned) {
       // AArch64 polynomial vectors are unsigned.
-      return BTy->getKind() == BuiltinType::UChar ||
-             BTy->getKind() == BuiltinType::UShort ||
-             ((BTy->getKind() == BuiltinType::ULong ||
-               BTy->getKind() == BuiltinType::ULongLong) &&
-              S.Context.getTypeSize(BTy) == 64);
+      auto bitwidth = S.Context.getTypeSize(BTy);
+      return BTy->isUnsignedInteger() &&
+             (bitwidth == 8 || bitwidth == 16 || bitwidth == 64);
     } else {
       // AArch32 polynomial vectors are signed.
       return BTy->getKind() == BuiltinType::SChar ||

--- a/clang/test/SemaSYCL/neon-polyvector-types.cpp
+++ b/clang/test/SemaSYCL/neon-polyvector-types.cpp
@@ -1,5 +1,5 @@
 // Does a run with a SYCL device, where neon polyvector type errors are ignored.
-// afterwards compile for the host where neon polyvector type errors aren't ignored
+// Afterwards compile for the host where neon polyvector type errors aren't ignored.
 
 // polyvector type errors get ignored with SYCL enabled
 // RUN: %clang_cc1 %s -fsycl-is-device -triple spir64 -aux-triple arm64-unknown-linux-gnu -target-feature +neon -fsyntax-only -verify=quiet

--- a/clang/test/SemaSYCL/neon-polyvector-types.cpp
+++ b/clang/test/SemaSYCL/neon-polyvector-types.cpp
@@ -1,0 +1,24 @@
+// Both of these should fail on bad_poly32_t, yielding 32-bit types
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64 -aux-triple aarch64-pc-windows-msvc -target-feature +neon -DLONG -fsyntax-only -verify
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64 -aux-triple arm64-unknown-linux-gnu -target-feature +neon -ULONG -fsyntax-only -verify
+// This will succeed on linux as long is 64-bit
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64 -aux-triple arm64-unknown-linux-gnu -target-feature +neon -DLONG -fsyntax-only -verify=quiet
+typedef unsigned char poly8_t;
+typedef unsigned short poly16_t;
+typedef __UINT64_TYPE__ poly64_t;
+
+#if defined(LONG)
+// 32-bit on windows (LLP64)
+// 64-bit on linux (LP64)
+typedef unsigned long bad_poly32_t;
+#else
+typedef unsigned int bad_poly32_t;
+#endif
+
+typedef __attribute__((neon_polyvector_type(16))) poly8_t poly8x16_t;
+typedef __attribute__((neon_polyvector_type(8))) poly16_t poly16x8_t;
+typedef __attribute__((neon_polyvector_type(2))) poly64_t poly64x2_t;
+
+// quiet-no-diagnostics
+typedef __attribute__((neon_polyvector_type(2))) bad_poly32_t bad_poly32x2_t;
+// expected-error@-1{{invalid vector element type}}

--- a/clang/test/SemaSYCL/neon-polyvector-types.cpp
+++ b/clang/test/SemaSYCL/neon-polyvector-types.cpp
@@ -1,24 +1,22 @@
-// Both of these should fail on bad_poly32_t, yielding 32-bit types
-// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64 -aux-triple aarch64-pc-windows-msvc -target-feature +neon -DLONG -fsyntax-only -verify
-// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64 -aux-triple arm64-unknown-linux-gnu -target-feature +neon -ULONG -fsyntax-only -verify
-// This will succeed on linux as long is 64-bit
-// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64 -aux-triple arm64-unknown-linux-gnu -target-feature +neon -DLONG -fsyntax-only -verify=quiet
+// Does a run with a SYCL device, where neon polyvector type errors are ignored.
+// afterwards compile for the host where neon polyvector type errors aren't ignored
+
+// polyvector type errors get ignored with SYCL enabled
+// RUN: %clang_cc1 %s -fsycl-is-device -triple spir64 -aux-triple arm64-unknown-linux-gnu -target-feature +neon -fsyntax-only -verify=quiet
+
+// diagnostic for bad_poly32_t
+// RUN: %clang_cc1 %s -triple arm64-unknown-linux-gnu -target-feature +neon -fsyntax-only -verify
 typedef unsigned char poly8_t;
 typedef unsigned short poly16_t;
-typedef __UINT64_TYPE__ poly64_t;
+typedef unsigned long poly64_t;
 
-#if defined(LONG)
-// 32-bit on windows (LLP64)
-// 64-bit on linux (LP64)
-typedef unsigned long bad_poly32_t;
-#else
 typedef unsigned int bad_poly32_t;
-#endif
 
 typedef __attribute__((neon_polyvector_type(16))) poly8_t poly8x16_t;
 typedef __attribute__((neon_polyvector_type(8))) poly16_t poly16x8_t;
 typedef __attribute__((neon_polyvector_type(2))) poly64_t poly64x2_t;
 
+// this error will get ignored when running SYCL
 // quiet-no-diagnostics
 typedef __attribute__((neon_polyvector_type(2))) bad_poly32_t bad_poly32x2_t;
 // expected-error@-1{{invalid vector element type}}


### PR DESCRIPTION
The aux triple needs to be passed for the mangling to go into the correct function.
Without this the `arm_neon.h` header will generate unsigned poly types as is done
for aarch64. But due to not checking the aux triple it will require the arm signed poly types.
