### PR TITLE
[SYCL] Remove sycl_ext_oneapi_sub_group in preview-breaking mode

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13920,6 +13920,12 @@ def warn_ivdep_attribute_argument : Warning<
 def warn_attribute_spelling_deprecated : Warning<
   "attribute %0 is deprecated">,
   InGroup<DeprecatedAttributes>;
+def warn_intel_named_sub_group_size_deprecated : Warning<
+  "the '%0' attribute is deprecated; use the "
+  "'sycl::ext::oneapi::experimental::sub_group_size_primary' or "
+  "'sycl::ext::oneapi::experimental::sub_group_size_automatic' property "
+  "instead">,
+  InGroup<DeprecatedAttributes>;
 def warn_attribute_deprecated_ignored : Warning<
   "attribute %0 is deprecated; attribute ignored">,
   InGroup<DeprecatedAttributes>;

--- a/clang/lib/Sema/SemaSYCLDeclAttr.cpp
+++ b/clang/lib/Sema/SemaSYCLDeclAttr.cpp
@@ -125,6 +125,16 @@ bool SemaSYCL::hasDependentExpr(Expr **Exprs, const size_t ExprsSize) {
 
 void SemaSYCL::checkDeprecatedSYCLAttributeSpelling(const ParsedAttr &A,
                                                     StringRef NewName) {
+  // The Intel named sub-group size spelling is deprecated in favor of the
+  // corresponding SYCL properties extension. Keep accepting it for now so
+  // existing code remains source-compatible.
+  if (A.getKind() == ParsedAttr::AT_IntelNamedSubGroupSize &&
+      A.getScopeName() && A.getScopeName()->isStr("intel")) {
+    Diag(A.getLoc(), diag::warn_attribute_spelling_deprecated)
+        << "'" + A.getNormalizedFullName() + "'";
+    return;
+  }
+
   // Additionally, diagnose deprecated [[intel::reqd_sub_group_size]] spelling
   if (A.getKind() == ParsedAttr::AT_IntelReqdSubGroupSize && A.getScopeName() &&
       A.getScopeName()->isStr("intel")) {
@@ -1159,6 +1169,8 @@ SemaSYCL::mergeIntelNamedSubGroupSizeAttr(Decl *D,
 }
 
 void SemaSYCL::handleIntelNamedSubGroupSizeAttr(Decl *D, const ParsedAttr &AL) {
+  checkDeprecatedSYCLAttributeSpelling(AL);
+
   StringRef SizeStr;
   SourceLocation Loc;
   if (AL.isArgIdent(0)) {

--- a/clang/lib/Sema/SemaSYCLDeclAttr.cpp
+++ b/clang/lib/Sema/SemaSYCLDeclAttr.cpp
@@ -125,13 +125,13 @@ bool SemaSYCL::hasDependentExpr(Expr **Exprs, const size_t ExprsSize) {
 
 void SemaSYCL::checkDeprecatedSYCLAttributeSpelling(const ParsedAttr &A,
                                                     StringRef NewName) {
-  // The Intel named sub-group size spelling is deprecated in favor of the
+  // The [[intel::named_sub_group_size]] attribute is deprecated in favor of the
   // corresponding SYCL properties extension. Keep accepting it for now so
   // existing code remains source-compatible.
   if (A.getKind() == ParsedAttr::AT_IntelNamedSubGroupSize &&
       A.getScopeName() && A.getScopeName()->isStr("intel")) {
-    Diag(A.getLoc(), diag::warn_attribute_spelling_deprecated)
-        << "'" + A.getNormalizedFullName() + "'";
+    Diag(A.getLoc(), diag::warn_intel_named_sub_group_size_deprecated)
+        << A.getNormalizedFullName();
     return;
   }
 

--- a/clang/test/SemaSYCL/named_sub_group_size.cpp
+++ b/clang/test/SemaSYCL/named_sub_group_size.cpp
@@ -5,11 +5,13 @@
 #include "Inputs/sycl.hpp"
 
 struct Functor {
+  // expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
   [[intel::named_sub_group_size(automatic)]] void operator()() const {
   }
 };
 
 struct Functor1 {
+  // expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
   [[intel::named_sub_group_size(primary)]] void operator()() const {
   }
 };
@@ -18,6 +20,7 @@ struct Functor1 {
 void calls_kernel_1() {
   // CHECK: FunctionDecl {{.*}}Kernel1
   // CHECK: IntelNamedSubGroupSizeAttr {{.*}} Automatic
+  // expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
   sycl::kernel_single_task<class Kernel1>([]() [[intel::named_sub_group_size(automatic)]] {
   });
 }
@@ -34,6 +37,7 @@ void calls_kernel_2() {
   sycl::kernel_single_task<class Kernel3>(F1);
 }
 
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(primary)]] void AttrFunc() {} // expected-error{{kernel-called function must have a sub group size that matches the size specified for the kernel}}
 
 // Test attribute does not get propagated to the kernel.

--- a/clang/test/SemaSYCL/sub-group-size.cpp
+++ b/clang/test/SemaSYCL/sub-group-size.cpp
@@ -12,57 +12,71 @@
 
 // expected-error@+2 {{'intel::named_sub_group_size' and 'sycl::reqd_sub_group_size' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[sycl::reqd_sub_group_size(1)]] [[intel::named_sub_group_size(automatic)]] void f1();
 // expected-error@+2 {{'sycl::reqd_sub_group_size' and 'intel::named_sub_group_size' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(primary)]] [[sycl::reqd_sub_group_size(1)]] void f2();
 
 // expected-note@+1 {{conflicting attribute is here}}
 [[sycl::reqd_sub_group_size(1)]] void f3();
 // expected-error@+1 {{'intel::named_sub_group_size' and 'sycl::reqd_sub_group_size' attributes are not compatible}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(primary)]] void f3();
 
 // expected-note@+1 {{conflicting attribute is here}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(primary)]] void f4();
 // expected-error@+1 {{'sycl::reqd_sub_group_size' and 'intel::named_sub_group_size' attributes are not compatible}}
 [[sycl::reqd_sub_group_size(1)]] void f4();
 
 // expected-note@+1 {{previous attribute is here}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(automatic)]] void f5();
 
 // expected-warning@+1 {{attribute 'intel::named_sub_group_size' is already applied with different arguments}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(primary)]] void f5();
 
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(automatic)]] void f6();
 
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(automatic)]] void f6();
 
 // expected-warning@+1 {{'intel::named_sub_group_size' attribute argument not supported: invalid}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(invalid)]] void f7();
 
 // expected-error@+2 {{'intel::named_sub_group_size' and 'intel::sycl_explicit_simd' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::sycl_explicit_simd]] [[intel::named_sub_group_size(automatic)]] void f8();
 // expected-error@+2 {{'intel::sub_group_size' and 'intel::sycl_explicit_simd' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
 [[intel::sycl_explicit_simd]] [[intel::sub_group_size(1)]] void f9();
 
 // expected-note@+1 {{conflicting attribute is here}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(primary)]] void f10();
 // expected-error@+1 {{'intel::sycl_explicit_simd' and 'intel::named_sub_group_size' attributes are not compatible}}
 [[intel::sycl_explicit_simd]] void f10();
 
 // expected-note@+1 {{conflicting attribute is here}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size("primary")]] void f11();
 // expected-error@+1 {{'intel::sycl_explicit_simd' and 'intel::named_sub_group_size' attributes are not compatible}}
 [[intel::sycl_explicit_simd]] void f11();
 
 // expected-note@+1 {{conflicting attribute is here}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size("automatic")]] void f12();
 // expected-error@+1 {{'intel::sycl_explicit_simd' and 'intel::named_sub_group_size' attributes are not compatible}}
 [[intel::sycl_explicit_simd]] void f12();
 
 // expected-warning@+1 {{'intel::named_sub_group_size' attribute argument not supported: invalid string}}
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size("invalid string")]] void f13();
 
 void NoAttrFunc() {}
@@ -72,6 +86,7 @@ SYCL_EXTERNAL void NoAttrExternalNotDefined(); // #NoAttrExternalNotDefined
 // If the kernel function has an attribute, only an undefined SYCL_EXTERNAL
 // should diagnose.
 void calls_kernel_1() {
+  // expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
   sycl::kernel_single_task<class Kernel1>([]() [[intel::named_sub_group_size(automatic)]] {
     NoAttrFunc();
     NoAttrExternalDefined();
@@ -82,6 +97,7 @@ void calls_kernel_1() {
 }
 
 struct Functor {
+  // expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
   [[intel::named_sub_group_size(automatic)]] void operator()() const {
     NoAttrFunc();
     //   NoAttrExternalDefined();
@@ -97,8 +113,11 @@ void calls_kernel_2() {
 }
 
 // If the kernel doesn't have an attribute,
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(primary)]] void AttrFunc() {}                           // #AttrFunc
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(primary)]] SYCL_EXTERNAL void AttrExternalDefined() {}  // #AttrExternalDefined
+// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
 [[intel::named_sub_group_size(primary)]] SYCL_EXTERNAL void AttrExternalNotDefined(); // #AttrExternalNotDefined
 
 void calls_kernel_3() {
@@ -143,6 +162,7 @@ void calls_kernel_4() {
 
 // Both have an attribute.
 void calls_kernel_5() {
+  // expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
   sycl::kernel_single_task<class Kernel5>([]() [[intel::named_sub_group_size(automatic)]] { // #Kernel5
     // expected-error@#AttrFunc{{kernel-called function must have a sub group size that matches the size specified for the kernel}}
     // expected-note@#Kernel5{{conflicting attribute is here}}

--- a/clang/test/SemaSYCL/sub-group-size.cpp
+++ b/clang/test/SemaSYCL/sub-group-size.cpp
@@ -12,71 +12,71 @@
 
 // expected-error@+2 {{'intel::named_sub_group_size' and 'sycl::reqd_sub_group_size' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[sycl::reqd_sub_group_size(1)]] [[intel::named_sub_group_size(automatic)]] void f1();
 // expected-error@+2 {{'sycl::reqd_sub_group_size' and 'intel::named_sub_group_size' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(primary)]] [[sycl::reqd_sub_group_size(1)]] void f2();
 
 // expected-note@+1 {{conflicting attribute is here}}
 [[sycl::reqd_sub_group_size(1)]] void f3();
 // expected-error@+1 {{'intel::named_sub_group_size' and 'sycl::reqd_sub_group_size' attributes are not compatible}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(primary)]] void f3();
 
 // expected-note@+1 {{conflicting attribute is here}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(primary)]] void f4();
 // expected-error@+1 {{'sycl::reqd_sub_group_size' and 'intel::named_sub_group_size' attributes are not compatible}}
 [[sycl::reqd_sub_group_size(1)]] void f4();
 
 // expected-note@+1 {{previous attribute is here}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(automatic)]] void f5();
 
 // expected-warning@+1 {{attribute 'intel::named_sub_group_size' is already applied with different arguments}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(primary)]] void f5();
 
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(automatic)]] void f6();
 
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(automatic)]] void f6();
 
 // expected-warning@+1 {{'intel::named_sub_group_size' attribute argument not supported: invalid}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(invalid)]] void f7();
 
 // expected-error@+2 {{'intel::named_sub_group_size' and 'intel::sycl_explicit_simd' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::sycl_explicit_simd]] [[intel::named_sub_group_size(automatic)]] void f8();
 // expected-error@+2 {{'intel::sub_group_size' and 'intel::sycl_explicit_simd' attributes are not compatible}}
 // expected-note@+1 {{conflicting attribute is here}}
 [[intel::sycl_explicit_simd]] [[intel::sub_group_size(1)]] void f9();
 
 // expected-note@+1 {{conflicting attribute is here}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(primary)]] void f10();
 // expected-error@+1 {{'intel::sycl_explicit_simd' and 'intel::named_sub_group_size' attributes are not compatible}}
 [[intel::sycl_explicit_simd]] void f10();
 
 // expected-note@+1 {{conflicting attribute is here}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size("primary")]] void f11();
 // expected-error@+1 {{'intel::sycl_explicit_simd' and 'intel::named_sub_group_size' attributes are not compatible}}
 [[intel::sycl_explicit_simd]] void f11();
 
 // expected-note@+1 {{conflicting attribute is here}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size("automatic")]] void f12();
 // expected-error@+1 {{'intel::sycl_explicit_simd' and 'intel::named_sub_group_size' attributes are not compatible}}
 [[intel::sycl_explicit_simd]] void f12();
 
 // expected-warning@+1 {{'intel::named_sub_group_size' attribute argument not supported: invalid string}}
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size("invalid string")]] void f13();
 
 void NoAttrFunc() {}
@@ -86,7 +86,7 @@ SYCL_EXTERNAL void NoAttrExternalNotDefined(); // #NoAttrExternalNotDefined
 // If the kernel function has an attribute, only an undefined SYCL_EXTERNAL
 // should diagnose.
 void calls_kernel_1() {
-  // expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+  // expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
   sycl::kernel_single_task<class Kernel1>([]() [[intel::named_sub_group_size(automatic)]] {
     NoAttrFunc();
     NoAttrExternalDefined();
@@ -97,7 +97,7 @@ void calls_kernel_1() {
 }
 
 struct Functor {
-  // expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+  // expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
   [[intel::named_sub_group_size(automatic)]] void operator()() const {
     NoAttrFunc();
     //   NoAttrExternalDefined();
@@ -113,11 +113,11 @@ void calls_kernel_2() {
 }
 
 // If the kernel doesn't have an attribute,
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(primary)]] void AttrFunc() {}                           // #AttrFunc
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(primary)]] SYCL_EXTERNAL void AttrExternalDefined() {}  // #AttrExternalDefined
-// expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+// expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
 [[intel::named_sub_group_size(primary)]] SYCL_EXTERNAL void AttrExternalNotDefined(); // #AttrExternalNotDefined
 
 void calls_kernel_3() {
@@ -162,7 +162,7 @@ void calls_kernel_4() {
 
 // Both have an attribute.
 void calls_kernel_5() {
-  // expected-warning@+1 {{'intel::named_sub_group_size' attribute is deprecated}}
+  // expected-warning@+1 {{the 'intel::named_sub_group_size' attribute is deprecated; use the}}
   sycl::kernel_single_task<class Kernel5>([]() [[intel::named_sub_group_size(automatic)]] { // #Kernel5
     // expected-error@#AttrFunc{{kernel-called function must have a sub group size that matches the size specified for the kernel}}
     // expected-note@#Kernel5{{conflicting attribute is here}}

--- a/sycl/doc/extensions/deprecated/sycl_ext_oneapi_sub_group.asciidoc
+++ b/sycl/doc/extensions/deprecated/sycl_ext_oneapi_sub_group.asciidoc
@@ -1,4 +1,8 @@
 = SYCL_INTEL_sub_group
+
+// __INTEL_PREVIEW_BREAKING_CHANGES: Move this specification to the "removed"
+// folder when the feature is removed at the next breaking changes window.
+
 :source-highlighter: coderay
 :coderay-linenums-mode: table
 

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_sub_group.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_sub_group.asciidoc
@@ -1,2 +1,5 @@
+// __INTEL_PREVIEW_BREAKING_CHANGES: Remove this specification when the feature
+// is removed at the next breaking changes window.
+
 This extension has been deprecated, but the specification is still available
 link:../deprecated/sycl_ext_oneapi_sub_group.asciidoc[here].

--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -35,7 +35,10 @@ inline namespace _V1 {
 struct sub_group;
 namespace ext {
 namespace oneapi {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+// Deprecated compatibility type for sycl::sub_group.
 struct sub_group;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 struct sub_group_mask;
 namespace experimental {
 template <typename ParentGroup> class fragment;
@@ -82,9 +85,11 @@ template <int Dimensions> struct group_scope<group<Dimensions>> {
   static constexpr __spv::Scope::Flag value = __spv::Scope::Flag::Workgroup;
 };
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <> struct group_scope<::sycl::ext::oneapi::sub_group> {
   static constexpr __spv::Scope::Flag value = __spv::Scope::Flag::Subgroup;
 };
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 template <> struct group_scope<::sycl::sub_group> {
   static constexpr __spv::Scope::Flag value = __spv::Scope::Flag::Subgroup;
 };
@@ -279,9 +284,11 @@ using WidenOpenCLTypeTo32_t = std::conditional_t<
 template <typename Group> struct GroupId {
   using type = size_t;
 };
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <> struct GroupId<::sycl::ext::oneapi::sub_group> {
   using type = uint32_t;
 };
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 template <> struct GroupId<::sycl::sub_group> {
   using type = uint32_t;
 };

--- a/sycl/include/sycl/detail/type_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits.hpp
@@ -22,7 +22,10 @@ inline namespace _V1 {
 template <int Dimensions> class group;
 struct sub_group;
 namespace ext::oneapi {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+// Deprecated compatibility type for sycl::sub_group.
 struct sub_group;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 namespace experimental {
 template <typename Group, std::size_t Extent> class group_with_scratchpad;
@@ -40,9 +43,11 @@ struct is_fixed_topology_group<root_group<Dimensions>> : std::true_type {};
 template <int Dimensions>
 struct is_fixed_topology_group<sycl::group<Dimensions>> : std::true_type {};
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <>
 struct is_fixed_topology_group<sycl::ext::oneapi::sub_group> : std::true_type {
 };
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 template <> struct is_fixed_topology_group<sycl::sub_group> : std::true_type {};
 
 template <class T> struct is_user_constructed_group : std::false_type {};
@@ -74,7 +79,9 @@ struct is_group<group<Dimensions>> : std::true_type {};
 
 template <typename T> struct is_sub_group : std::false_type {};
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <> struct is_sub_group<ext::oneapi::sub_group> : std::true_type {};
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 template <> struct is_sub_group<sycl::sub_group> : std::true_type {};
 
 template <typename T>

--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -15,6 +15,9 @@
 
 namespace sycl {
 inline namespace _V1 {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+// Deprecated compatibility alias for sycl::sub_group. This is removed when
+// preview breaking changes are enabled.
 namespace ext::oneapi {
 struct __SYCL_DEPRECATED("use sycl::sub_group() instead") sub_group
     : sycl::sub_group {
@@ -32,5 +35,6 @@ private:
   sub_group() = default;
 };
 } // namespace ext::oneapi
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 } // namespace _V1
 } // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+// TODO: Remove this header.
+
 #pragma once
 
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL_DEPRECATED
@@ -15,9 +18,6 @@
 
 namespace sycl {
 inline namespace _V1 {
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-// Deprecated compatibility alias for sycl::sub_group. This is removed when
-// preview breaking changes are enabled.
 namespace ext::oneapi {
 struct __SYCL_DEPRECATED("use sycl::sub_group() instead") sub_group
     : sycl::sub_group {
@@ -35,6 +35,7 @@ private:
   sub_group() = default;
 };
 } // namespace ext::oneapi
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 } // namespace _V1
 } // namespace sycl
+
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES

--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -38,16 +38,25 @@ template <typename Group> struct group_scope;
 
 namespace ext::oneapi {
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+// Deprecated compatibility overload for sycl::ext::oneapi::sub_group.
 // forward decalre sycl::ext::oneapi::sub_group
 struct sub_group;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 // defining `group_ballot` here to make predicate default `true`
 // need to forward declare sub_group_mask first
 struct sub_group_mask;
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <typename Group>
 std::enable_if_t<std::is_same_v<std::decay_t<Group>, sub_group> ||
                      std::is_same_v<std::decay_t<Group>, sycl::sub_group>,
                  sub_group_mask>
+#else
+template <typename Group>
+std::enable_if_t<std::is_same_v<std::decay_t<Group>, sycl::sub_group>,
+                 sub_group_mask>
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 group_ballot(Group g, bool predicate = true);
 
 struct sub_group_mask {
@@ -360,8 +369,12 @@ ext::oneapi::sub_group_mask commonGroupBallotImpl(Group G, bool Predicate) {
           Val, __spirv_BuiltInSubgroupMaxSize());
   // For sub-groups we do not need to apply the mask, but for others it will
   // split converging groups accordingly.
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   if constexpr (!std::is_same_v<std::decay_t<Group>, ext::oneapi::sub_group> &&
                 !std::is_same_v<std::decay_t<Group>, sycl::sub_group>)
+#else
+  if constexpr (!std::is_same_v<std::decay_t<Group>, sycl::sub_group>)
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
     Mask &= sycl::detail::GetMask(G);
   return Mask;
 }
@@ -370,10 +383,16 @@ ext::oneapi::sub_group_mask commonGroupBallotImpl(Group G, bool Predicate) {
 
 namespace ext::oneapi {
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 template <typename Group>
 std::enable_if_t<std::is_same_v<std::decay_t<Group>, sub_group> ||
                      std::is_same_v<std::decay_t<Group>, sycl::sub_group>,
                  sub_group_mask>
+#else
+template <typename Group>
+std::enable_if_t<std::is_same_v<std::decay_t<Group>, sycl::sub_group>,
+                 sub_group_mask>
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 group_ballot([[maybe_unused]] Group g, [[maybe_unused]] bool predicate) {
 #ifdef __SYCL_DEVICE_ONLY__
   return sycl::detail::commonGroupBallotImpl(g, predicate);

--- a/sycl/include/sycl/info/device.hpp
+++ b/sycl/include/sycl/info/device.hpp
@@ -462,11 +462,15 @@ struct __SYCL_DEPRECATED("use device::get_info instead") opencl_c_version
 };
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 // Extensions
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+// Deprecated compatibility descriptor. This is removed when preview
+// breaking changes are enabled.
 struct __SYCL_DEPRECATED("extension is deprecated")
     sub_group_independent_forward_progress
     : device_traits<UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS> {
   using return_type = bool;
 };
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 struct ext_oneapi_srgb : device_traits<UR_DEVICE_INFO_IMAGE_SRGB> {
   using return_type = bool;
 };

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -156,7 +156,10 @@ can be disabled by setting SYCL_DISABLE_FSYCL_SYCLHPP_WARNING macro.")
 #include <sycl/ext/oneapi/owner_less.hpp>
 #include <sycl/ext/oneapi/properties.hpp>
 #include <sycl/ext/oneapi/properties/property_value.hpp>
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+// Deprecated compatibility header for sycl::ext::oneapi::sub_group.
 #include <sycl/ext/oneapi/sub_group.hpp>
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 #include <sycl/ext/oneapi/sub_group_mask.hpp>
 #include <sycl/ext/oneapi/virtual_mem/physical_mem.hpp>
 #include <sycl/ext/oneapi/virtual_mem/virtual_mem.hpp>

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -291,7 +291,9 @@ __SYCL_DEVICE_INFO_INST(usm_system_allocations, bool)
 __SYCL_DEVICE_INFO_INST(image_max_array_size, size_t)
 __SYCL_DEVICE_INFO_INST(opencl_c_version, std::string)
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 __SYCL_DEVICE_INFO_INST(sub_group_independent_forward_progress, bool)
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 __SYCL_DEVICE_INFO_INST(ext_oneapi_srgb, bool)
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 __SYCL_DEVICE_INFO_INST(ext_intel_pci_address, std::string)

--- a/sycl/source/feature_test.hpp.in
+++ b/sycl/source/feature_test.hpp.in
@@ -59,7 +59,10 @@ inline namespace _V1 {
 #define SYCL_EXT_ONEAPI_USE_PINNED_HOST_MEMORY_PROPERTY 1
 #define SYCL_EXT_ONEAPI_ROOT_GROUP 1
 #define SYCL_EXT_ONEAPI_SRGB 1
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+// Advertise the deprecated sub-group extension in non-preview builds.
 #define SYCL_EXT_ONEAPI_SUB_GROUP 1
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 #define SYCL_EXT_ONEAPI_PROPERTIES 1
 #define SYCL_EXT_ONEAPI_NATIVE_MATH 1
 #define SYCL_EXT_ONEAPI_BFLOAT16 1


### PR DESCRIPTION
Guards the deprecated SYCL_INTEL_sub_group feature-test macro from preview-breaking builds.

Documentation is marked for removal or relocation during the next breaking-changes window.

This closes #22581.