### PR TITLE
[SYCL][CMake] Only build/install UMF when an enabled adapter requires it

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -536,11 +536,25 @@ set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      sycl-headers-extras
      sycl
      libsycldevice
-     unified-memory-framework
      unified-runtime-loader
      ${XPTIFW_LIBS}
      ${SYCL_TOOLCHAIN_DEPS}
 )
+
+# The "unified-memory-framework" component (libumf) is only built (see
+# UR_UMF_REQUIRED in unified-runtime/source/common/CMakeLists.txt) when an
+# enabled backend actually links against it: level_zero, level_zero_v2, cuda,
+# and hip. native_cpu and offload implement USM allocation themselves and do
+# not use UMF. Deploying it unconditionally (e.g. on a macOS build that only
+# enables "opencl", which never references UMF) would either package an
+# unused library or, worse, race with a "umf" target that ninja has no
+# reason to build, causing an install failure.
+if ("level_zero" IN_LIST SYCL_ENABLE_BACKENDS OR
+    "level_zero_v2" IN_LIST SYCL_ENABLE_BACKENDS OR
+    "cuda" IN_LIST SYCL_ENABLE_BACKENDS OR
+    "hip" IN_LIST SYCL_ENABLE_BACKENDS)
+  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS unified-memory-framework)
+endif()
 
 if("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS clang-nvlink-wrapper)
@@ -657,7 +671,16 @@ foreach(component IN LISTS SYCL_TOOLCHAIN_DEPLOY_COMPONENTS)
     endforeach()
   else()
     set(INSTALL_SCRIPT "${CMAKE_BINARY_DIR}/cmake_install.cmake")
-    sycl_add_install_command("${component}" "${component}" "${INSTALL_SCRIPT}" "")
+    set(COMPONENT_DEPS "")
+    if("${component}" STREQUAL "unified-memory-framework" AND TARGET umf)
+      # Only present in SYCL_TOOLCHAIN_DEPLOY_COMPONENTS when an enabled
+      # backend actually links UMF (see the gate above), in which case the
+      # "umf" target always exists too. Depend on it explicitly so ninja is
+      # guaranteed to build libumf* before this install step deploys it,
+      # regardless of parallel build ordering.
+      set(COMPONENT_DEPS "umf")
+    endif()
+    sycl_add_install_command("${component}" "${component}" "${INSTALL_SCRIPT}" "${COMPONENT_DEPS}")
   endif()
 endforeach()
 

--- a/sycl/cmake/modules/BuildUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/BuildUnifiedRuntime.cmake
@@ -110,7 +110,11 @@ set(UNIFIED_RUNTIME_COMMON_INCLUDE_DIR "${UNIFIED_RUNTIME_SOURCE_DIR}/source/com
 
 add_library(UnifiedRuntimeLoader ALIAS ur_loader)
 add_library(UnifiedRuntimeCommon ALIAS ur_common)
-add_library(UnifiedMemoryFramework ALIAS ur_umf)
+# ur_umf only exists when some enabled backend actually links UMF (see
+# UR_UMF_REQUIRED in unified-runtime/source/common/CMakeLists.txt).
+if(TARGET ur_umf)
+  add_library(UnifiedMemoryFramework ALIAS ur_umf)
+endif()
 
 add_library(UnifiedRuntime-Headers INTERFACE)
 

--- a/unified-runtime/source/adapters/native_cpu/CMakeLists.txt
+++ b/unified-runtime/source/adapters/native_cpu/CMakeLists.txt
@@ -85,7 +85,6 @@ find_package(Threads REQUIRED)
 target_link_libraries(${TARGET_NAME} PRIVATE
         ${PROJECT_NAME}::headers
         ${PROJECT_NAME}::common
-        ${PROJECT_NAME}::umf
         Threads::Threads
 )
 

--- a/unified-runtime/source/adapters/offload/CMakeLists.txt
+++ b/unified-runtime/source/adapters/offload/CMakeLists.txt
@@ -135,7 +135,6 @@ endif()
 target_link_libraries(${TARGET_NAME} PRIVATE
     ${PROJECT_NAME}::headers
     ${PROJECT_NAME}::common
-    ${PROJECT_NAME}::umf
     ur_common
     ${UR_OFFLOAD_INSTALL_DIR}/lib/libLLVMOffload.so
     ${ADDITIONAL_LINK_LIBS}

--- a/unified-runtime/source/common/CMakeLists.txt
+++ b/unified-runtime/source/common/CMakeLists.txt
@@ -2,6 +2,21 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# UMF is only ever linked in (statically or dynamically) by the adapters
+# below, either directly (level_zero) or through the ur_umf INTERFACE target
+# (cuda, hip). native_cpu and offload implement USM allocation themselves and
+# do not use UMF. Adapters that don't build (e.g. opencl on a macOS build
+# that only enables "opencl") never reference UMF at all, so there is no
+# need to fetch/build it in that case. UR_BUILD_ADAPTER_ALL builds every
+# adapter, including the UMF-consuming ones, so it also requires UMF.
+if (UR_BUILD_ADAPTER_L0 OR UR_BUILD_ADAPTER_L0_V2 OR
+    UR_BUILD_ADAPTER_CUDA OR UR_BUILD_ADAPTER_HIP OR
+    UR_BUILD_ADAPTER_ALL)
+    set(UR_UMF_REQUIRED ON)
+else()
+    set(UR_UMF_REQUIRED OFF)
+endif()
+
 if (UR_BUILD_ADAPTER_L0 OR UR_BUILD_ADAPTER_L0_V2)
     include(FetchLevelZero)
     set(UMF_BUILD_LEVEL_ZERO_PROVIDER ON CACHE INTERNAL "Build Level Zero Provider")
@@ -76,44 +91,52 @@ if ((UR_STATIC_ADAPTER_L0 AND UR_BUILD_ADAPTER_L0) OR
         set(UMF_LINK_HWLOC_STATICALLY ON CACHE INTERNAL "static HWLOC")
     endif()
 endif()
-  
+
 set(UR_USE_EXTERNAL_UMF ON CACHE BOOL "Use a pre-built UMF if available")
 
-if(UR_USE_EXTERNAL_UMF)
-  find_package(umf 1.1.0 QUIET)
-endif()
-if(umf_FOUND)
-  message(STATUS "Using preinstalled UMF at ${umf_DIR}, ignoring UMF build related options")
-  # Promote umf::umf and umf::umf_headers IMPORTED targets to global scope so
-  # sibling subdirectories (loader, adapters) can link against them.
-  set_target_properties(umf::umf PROPERTIES IMPORTED_GLOBAL TRUE)
-  set_target_properties(umf::umf_headers PROPERTIES IMPORTED_GLOBAL TRUE)
-  # Add an alias matching the FetchContent case
-  add_library(umf::headers ALIAS umf::umf_headers)
-else()
-  set(UMF_REPO "https://github.com/oneapi-src/unified-memory-framework.git")
-
-  # commit d8763834d68f9545db30bea5d092edd78ad3d748
-  # Author: Lukasz Stolarczuk <lukasz.stolarczuk@intel.com>
-  # Date:   Mon Jul 27 15:32:41 2026 +0200
-  #     1.2.0 release
-  set(UMF_TAG v1.2.0)
-
-  if(NOT FETCHCONTENT_SOURCE_DIR_UNIFIED-MEMORY-FRAMEWORK)
-    message(STATUS "Will fetch Unified Memory Framework from ${UMF_REPO}")
+# Only fetch/build UMF when some adapter actually links against it
+# (UR_UMF_REQUIRED, computed above from the enabled adapters). On builds where
+# no adapter references umf::umf (e.g. a macOS build that only enables
+# "opencl"), skip it entirely: nothing needs it at build time or at runtime.
+if (UR_UMF_REQUIRED)
+  if(UR_USE_EXTERNAL_UMF)
+    find_package(umf 1.1.0 QUIET)
   endif()
+  if(umf_FOUND)
+    message(STATUS "Using preinstalled UMF at ${umf_DIR}, ignoring UMF build related options")
+    # Promote umf::umf and umf::umf_headers IMPORTED targets to global scope so
+    # sibling subdirectories (loader, adapters) can link against them.
+    set_target_properties(umf::umf PROPERTIES IMPORTED_GLOBAL TRUE)
+    set_target_properties(umf::umf_headers PROPERTIES IMPORTED_GLOBAL TRUE)
+    # Add an alias matching the FetchContent case
+    add_library(umf::headers ALIAS umf::umf_headers)
+  else()
+    set(UMF_REPO "https://github.com/oneapi-src/unified-memory-framework.git")
 
-  include(FetchContent)
-  FetchContent_Declare(unified-memory-framework
-    GIT_REPOSITORY    ${UMF_REPO}
-    GIT_TAG           ${UMF_TAG}
-    )
-  set(UMF_BUILD_TESTS OFF CACHE INTERNAL "Build UMF tests")
-  set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "Build UMF examples")
-  set(UMF_BUILD_SHARED_LIBRARY ${UMF_BUILD_SHARED_LIBRARY} CACHE INTERNAL "Build UMF shared library")
+    # commit d8763834d68f9545db30bea5d092edd78ad3d748
+    # Author: Lukasz Stolarczuk <lukasz.stolarczuk@intel.com>
+    # Date:   Mon Jul 27 15:32:41 2026 +0200
+    #     1.2.0 release
+    set(UMF_TAG v1.2.0)
 
-  FetchContent_MakeAvailable(unified-memory-framework)
-  FetchContent_GetProperties(unified-memory-framework)
+    if(NOT FETCHCONTENT_SOURCE_DIR_UNIFIED-MEMORY-FRAMEWORK)
+      message(STATUS "Will fetch Unified Memory Framework from ${UMF_REPO}")
+    endif()
+
+    include(FetchContent)
+    FetchContent_Declare(unified-memory-framework
+      GIT_REPOSITORY    ${UMF_REPO}
+      GIT_TAG           ${UMF_TAG}
+      )
+    set(UMF_BUILD_TESTS OFF CACHE INTERNAL "Build UMF tests")
+    set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "Build UMF examples")
+    set(UMF_BUILD_SHARED_LIBRARY ${UMF_BUILD_SHARED_LIBRARY} CACHE INTERNAL "Build UMF shared library")
+
+    FetchContent_MakeAvailable(unified-memory-framework)
+    FetchContent_GetProperties(unified-memory-framework)
+  endif()
+else()
+  message(STATUS "No adapter requires UMF, skipping its build")
 endif()
 
 if(UR_ENABLE_LATENCY_HISTOGRAM)
@@ -158,27 +181,31 @@ install(TARGETS ur_common
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-add_library(ur_umf INTERFACE)
-target_sources(ur_umf INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/umf_helpers.hpp>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/umf_pools/disjoint_pool_config_parser.cpp>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ur_pool_manager.hpp>
-)
-
-add_library(${PROJECT_NAME}::umf ALIAS ur_umf)
-
-target_link_libraries(ur_umf INTERFACE
-    umf::umf
-    umf::headers
-)
-
-# Install ur_umf when any static adapter is enabled, so install(EXPORT ...)
-# can resolve it for static consumers.
-if(UR_STATIC_ADAPTER_L0 OR UR_STATIC_ADAPTER_L0_V2 OR UR_STATIC_ADAPTER_OPENCL)
-    install(TARGETS ur_umf
-        EXPORT ${PROJECT_NAME}-targets
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+# ur_umf (and the umf::umf target it wraps) only exists when UR_UMF_REQUIRED,
+# i.e. when some adapter actually links against it (see top of this file).
+if (UR_UMF_REQUIRED)
+    add_library(ur_umf INTERFACE)
+    target_sources(ur_umf INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/umf_helpers.hpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/umf_pools/disjoint_pool_config_parser.cpp>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ur_pool_manager.hpp>
     )
+
+    add_library(${PROJECT_NAME}::umf ALIAS ur_umf)
+
+    target_link_libraries(ur_umf INTERFACE
+        umf::umf
+        umf::headers
+    )
+
+    # Install ur_umf when any static adapter is enabled, so install(EXPORT ...)
+    # can resolve it for static consumers.
+    if(UR_STATIC_ADAPTER_L0 OR UR_STATIC_ADAPTER_L0_V2 OR UR_STATIC_ADAPTER_OPENCL)
+        install(TARGETS ur_umf
+            EXPORT ${PROJECT_NAME}-targets
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+    endif()
 endif()

--- a/unified-runtime/test/usm/CMakeLists.txt
+++ b/unified-runtime/test/usm/CMakeLists.txt
@@ -18,4 +18,8 @@ function(add_usm_test name)
     target_compile_definitions(${TEST_TARGET_NAME} PRIVATE DEVICES_ENVIRONMENT)
 endfunction()
 
-add_usm_test(usmPoolManager usmPoolManager.cpp)
+# ${PROJECT_NAME}::umf only exists when UR_UMF_REQUIRED (i.e. some enabled
+# adapter actually links UMF, see source/common/CMakeLists.txt).
+if(TARGET ${PROJECT_NAME}::umf)
+    add_usm_test(usmPoolManager usmPoolManager.cpp)
+endif()


### PR DESCRIPTION
Unified Memory Framework (UMF) was being unconditionally fetched, built,
and deployed as part of sycl-toolchain, even on configurations where no
adapter actually links against it (e.g. a macOS build, which by default
only enables the OpenCL adapter). This meant an unused library was
compiled and shipped for no reason, and also created a build-ordering
hazard: ninja had no dependency edge forcing the "umf" target to be
built before the "unified-memory-framework" install/deploy step tried to
package it, occasionally causing "file INSTALL cannot find libumf*"
failures under parallel builds.

Only the level_zero, level_zero_v2, cuda, hip, native_cpu, and offload
adapters link against umf::umf (directly or via the ur_umf interface
target); opencl and mock never reference it.

Introduce UR_UMF_REQUIRED in unified-runtime/source/common/CMakeLists.txt,
true only when one of those adapters is being built, and use it to:
- Skip the find_package/FetchContent of UMF entirely, and skip defining
  the ur_umf interface target (and its install rule), when nothing needs it.
- Guard the UnifiedMemoryFramework ALIAS in
  sycl/cmake/modules/BuildUnifiedRuntime.cmake and the umf-linked
  usmPoolManager test in unified-runtime/test/usm/CMakeLists.txt with
  target-existence checks.
- Only add "unified-memory-framework" to SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
  in sycl/CMakeLists.txt when one of the UMF-consuming backends is
  enabled, keeping the explicit "umf" target dependency on the install
  step as a safety net for correct build ordering when it is deployed.

It fixes the following failure on macOS (where only the OpenCL backend
is enabled (UR_BUILD_ADAPTER_L0=OFF)):
```
  file INSTALL cannot find ".../lib/libumf.1.2.0.dylib"
```

Verified on intel/llvm#22871: the macOS build now completes successfully

Ref: https://github.com/intel/llvm/pull/22816#issuecomment-5144229598