### PR TITLE
[SYCL] Disable failing bindless images interop e2e tests

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: cuda-ge-13
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21808
 
-// UNSUPPORTED: linux && gpu-intel-gen12
+// UNSUPPORTED: linux && arch-intel_gpu_mtl_u
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22858
 
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_2d_unsampled.cpp
@@ -7,6 +7,9 @@
 // UNSUPPORTED: linux
 // UNSUPPORTED-TRACKER: GSD-12357
 
+// UNSUPPORTED: windows
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22272
+
 /*
     Run all the vulkan formats through a write test. Note this is unsampled
    only, you can't "write" with the image sampler.


### PR DESCRIPTION
This PR is follow up based on reported issues: https://github.com/intel/llvm/pull/22586#issuecomment-5195069316