### PR TITLE
[SYCL] Align `range` with SYCL 2020

### DIFF
--- a/sycl/include/sycl/detail/array.hpp
+++ b/sycl/include/sycl/detail/array.hpp
@@ -102,7 +102,7 @@ public:
 
 protected:
   size_t common_array[dimensions];
-  __SYCL_ALWAYS_INLINE void check_dimension(int dimension) const {
+  __SYCL_ALWAYS_INLINE void check_dimension(int dimension) const noexcept {
     __SYCL_ASSERT(dimension >= 0 && dimension < dimensions &&
                   "Index out of range");
     (void)dimension;

--- a/sycl/include/sycl/detail/array.hpp
+++ b/sycl/include/sycl/detail/array.hpp
@@ -8,11 +8,8 @@
 
 #pragma once
 
+#include <sycl/detail/assert.hpp>             // for __SYCL_ASSERT
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL_ALWAYS_INLINE
-
-#ifndef __SYCL_DEVICE_ONLY__
-#include <sycl/exception.hpp>
-#endif
 
 #include <stddef.h>    // for size_t
 #include <type_traits> // for enable_if_t
@@ -106,12 +103,8 @@ public:
 protected:
   size_t common_array[dimensions];
   __SYCL_ALWAYS_INLINE void check_dimension(int dimension) const {
-#ifndef __SYCL_DEVICE_ONLY__
-    if (dimension >= dimensions || dimension < 0) {
-      throw sycl::exception(make_error_code(errc::invalid),
-                            "Index out of range");
-    }
-#endif
+    __SYCL_ASSERT(dimension >= 0 && dimension < dimensions &&
+                  "Index out of range");
     (void)dimension;
   }
 };

--- a/sycl/include/sycl/detail/array.hpp
+++ b/sycl/include/sycl/detail/array.hpp
@@ -61,17 +61,17 @@ public:
     return result;
   }
 
-  size_t get(int dimension) const {
+  size_t get(int dimension) const noexcept {
     check_dimension(dimension);
     return common_array[dimension];
   }
 
-  size_t &operator[](int dimension) {
+  size_t &operator[](int dimension) noexcept {
     check_dimension(dimension);
     return common_array[dimension];
   }
 
-  size_t operator[](int dimension) const {
+  size_t operator[](int dimension) const noexcept {
     check_dimension(dimension);
     return common_array[dimension];
   }

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -15,6 +15,7 @@
 #include <sycl/ext/oneapi/experimental/uniform.hpp>
 
 #include <sycl/detail/loop.hpp>
+#include <sycl/exception.hpp>
 #include <sycl/sub_group.hpp>
 
 #include <functional>

--- a/sycl/include/sycl/ext/oneapi/free_function_queries.hpp
+++ b/sycl/include/sycl/ext/oneapi/free_function_queries.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <sycl/exception.hpp>
 #include <sycl/group.hpp>
 #include <sycl/nd_item.hpp>
 #include <sycl/sub_group.hpp>

--- a/sycl/include/sycl/range.hpp
+++ b/sycl/include/sycl/range.hpp
@@ -67,7 +67,7 @@ public:
   range(range<Dimensions> &&rhs) = default;
   range<Dimensions> &operator=(const range<Dimensions> &rhs) = default;
   range<Dimensions> &operator=(range<Dimensions> &&rhs) = default;
-  range() = default;
+  range() noexcept = default;
 
   ~range() = default;
 

--- a/sycl/include/sycl/range.hpp
+++ b/sycl/include/sycl/range.hpp
@@ -88,7 +88,7 @@ public:
   __SYCL_GEN_OPT_BASE(op)                                                      \
   template <typename T>                                                        \
   friend IntegralType<T, range<Dimensions>> operator op(                       \
-      const range<Dimensions> &lhs, const T &rhs) noexcept {                   \
+      const range<Dimensions> &lhs, const T & rhs) noexcept {                  \
     range<Dimensions> result(lhs);                                             \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       result.common_array[i] = lhs.common_array[i] op rhs;                     \
@@ -97,7 +97,7 @@ public:
   }                                                                            \
   template <typename T>                                                        \
   friend IntegralType<T, range<Dimensions>> operator op(                       \
-      const T &lhs, const range<Dimensions> &rhs) noexcept {                   \
+      const T & lhs, const range<Dimensions> &rhs) noexcept {                  \
     range<Dimensions> result(rhs);                                             \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       result.common_array[i] = lhs op rhs.common_array[i];                     \
@@ -157,7 +157,7 @@ public:
   }                                                                            \
   template <typename T>                                                        \
   friend IntegralType<T, range<Dimensions>> operator op(                       \
-      range<Dimensions> &lhs, const T &rhs) noexcept {                         \
+      range<Dimensions> &lhs, const T & rhs) noexcept {                        \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       lhs.common_array[i] op rhs;                                              \
     }                                                                          \

--- a/sycl/include/sycl/range.hpp
+++ b/sycl/include/sycl/range.hpp
@@ -64,12 +64,12 @@ public:
   }
 
   range(const range<Dimensions> &rhs) = default;
-  range(range<Dimensions> &&rhs) noexcept = default;
+  range(range<Dimensions> &&rhs) = default;
   range<Dimensions> &operator=(const range<Dimensions> &rhs) = default;
-  range<Dimensions> &operator=(range<Dimensions> &&rhs) noexcept = default;
-  range() noexcept = default;
+  range<Dimensions> &operator=(range<Dimensions> &&rhs) = default;
+  range() = default;
 
-  ~range() noexcept = default;
+  ~range() = default;
 
 // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
 #define __SYCL_GEN_OPT_BASE(op)                                                \
@@ -105,7 +105,7 @@ public:
     return result;                                                             \
   }
 #else
-
+// RFC: remove these as well?
 #define __SYCL_GEN_OPT(op)                                                     \
   __SYCL_GEN_OPT_BASE(op)                                                      \
   friend range<Dimensions> operator op(const range<Dimensions> &lhs,           \
@@ -152,13 +152,6 @@ public:
       range<Dimensions> &lhs, const range<Dimensions> &rhs) noexcept {         \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       lhs.common_array[i] op rhs[i];                                           \
-    }                                                                          \
-    return lhs;                                                                \
-  }                                                                            \
-  friend range<Dimensions> &operator op(range<Dimensions> &lhs,                \
-                                        const size_t &rhs) {                   \
-    for (int i = 0; i < Dimensions; ++i) {                                     \
-      lhs.common_array[i] op rhs;                                              \
     }                                                                          \
     return lhs;                                                                \
   }                                                                            \

--- a/sycl/include/sycl/range.hpp
+++ b/sycl/include/sycl/range.hpp
@@ -39,22 +39,23 @@ public:
   /* The following constructor is only available in the range class
   specialization where: Dimensions==1 */
   template <int N = Dimensions>
-  range(typename std::enable_if_t<(N == 1), size_t> dim0) : base(dim0) {}
+  range(typename std::enable_if_t<(N == 1), size_t> dim0) noexcept
+      : base(dim0) {}
 
   /* The following constructor is only available in the range class
   specialization where: Dimensions==2 */
   template <int N = Dimensions>
-  range(typename std::enable_if_t<(N == 2), size_t> dim0, size_t dim1)
+  range(typename std::enable_if_t<(N == 2), size_t> dim0, size_t dim1) noexcept
       : base(dim0, dim1) {}
 
   /* The following constructor is only available in the range class
   specialization where: Dimensions==3 */
   template <int N = Dimensions>
   range(typename std::enable_if_t<(N == 3), size_t> dim0, size_t dim1,
-        size_t dim2)
+        size_t dim2) noexcept
       : base(dim0, dim1, dim2) {}
 
-  size_t size() const {
+  size_t size() const noexcept {
     size_t size = 1;
     for (int i = 0; i < Dimensions; ++i) {
       size *= this->common_array[i];
@@ -63,15 +64,17 @@ public:
   }
 
   range(const range<Dimensions> &rhs) = default;
-  range(range<Dimensions> &&rhs) = default;
+  range(range<Dimensions> &&rhs) noexcept = default;
   range<Dimensions> &operator=(const range<Dimensions> &rhs) = default;
-  range<Dimensions> &operator=(range<Dimensions> &&rhs) = default;
-  range() = default;
+  range<Dimensions> &operator=(range<Dimensions> &&rhs) noexcept = default;
+  range() noexcept = default;
+
+  ~range() noexcept = default;
 
 // OP is: +, -, *, /, %, <<, >>, &, |, ^, &&, ||, <, >, <=, >=
 #define __SYCL_GEN_OPT_BASE(op)                                                \
-  friend range<Dimensions> operator op(const range<Dimensions> &lhs,           \
-                                       const range<Dimensions> &rhs) {         \
+  friend range<Dimensions> operator op(                                        \
+      const range<Dimensions> &lhs, const range<Dimensions> &rhs) noexcept {   \
     range<Dimensions> result(lhs);                                             \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       result.common_array[i] = lhs.common_array[i] op rhs.common_array[i];     \
@@ -85,7 +88,7 @@ public:
   __SYCL_GEN_OPT_BASE(op)                                                      \
   template <typename T>                                                        \
   friend IntegralType<T, range<Dimensions>> operator op(                       \
-      const range<Dimensions> &lhs, const T &rhs) {                            \
+      const range<Dimensions> &lhs, const T &rhs) noexcept {                   \
     range<Dimensions> result(lhs);                                             \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       result.common_array[i] = lhs.common_array[i] op rhs;                     \
@@ -94,7 +97,7 @@ public:
   }                                                                            \
   template <typename T>                                                        \
   friend IntegralType<T, range<Dimensions>> operator op(                       \
-      const T &lhs, const range<Dimensions> &rhs) {                            \
+      const T &lhs, const range<Dimensions> &rhs) noexcept {                   \
     range<Dimensions> result(rhs);                                             \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       result.common_array[i] = lhs op rhs.common_array[i];                     \
@@ -102,6 +105,9 @@ public:
     return result;                                                             \
   }
 #else
+
+// Can't find either of them in documentation, not adding noexcept for these,
+// maybe need to be removed
 #define __SYCL_GEN_OPT(op)                                                     \
   __SYCL_GEN_OPT_BASE(op)                                                      \
   friend range<Dimensions> operator op(const range<Dimensions> &lhs,           \
@@ -144,8 +150,8 @@ public:
 
 // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
 #define __SYCL_GEN_OPT(op)                                                     \
-  friend range<Dimensions> &operator op(range<Dimensions> &lhs,                \
-                                        const range<Dimensions> &rhs) {        \
+  friend range<Dimensions> &operator op(                                       \
+      range<Dimensions> &lhs, const range<Dimensions> &rhs) noexcept {         \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       lhs.common_array[i] op rhs[i];                                           \
     }                                                                          \
@@ -157,7 +163,18 @@ public:
       lhs.common_array[i] op rhs;                                              \
     }                                                                          \
     return lhs;                                                                \
+  }                                                                            \
+  template <typename T>                                                        \
+  friend IntegralType<T, range<Dimensions>> operator op(                       \
+      range<Dimensions> &lhs, const T &rhs) noexcept {                         \
+    for (int i = 0; i < Dimensions; ++i) {                                     \
+      lhs.common_array[i] op rhs;                                              \
+    }                                                                          \
+    return lhs;                                                                \
   }
+
+  // second overload above is not in documentation, maybe need to be removed or
+  // guarded against __SYCL_DISABLE_ID_TO_INT_CONV__ like the other operators
 
   __SYCL_GEN_OPT(+=)
   __SYCL_GEN_OPT(-=)
@@ -174,7 +191,8 @@ public:
 
 // OP is unary +, -
 #define __SYCL_GEN_OPT(op)                                                     \
-  friend range<Dimensions> operator op(const range<Dimensions> &rhs) {         \
+  friend range<Dimensions> operator op(                                        \
+      const range<Dimensions> &rhs) noexcept {                                 \
     range<Dimensions> result(rhs);                                             \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       result.common_array[i] = (op rhs.common_array[i]);                       \
@@ -189,7 +207,7 @@ public:
 
 // OP is prefix ++, --
 #define __SYCL_GEN_OPT(op)                                                     \
-  friend range<Dimensions> &operator op(range<Dimensions> &rhs) {              \
+  friend range<Dimensions> &operator op(range<Dimensions> &rhs) noexcept {     \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       op rhs.common_array[i];                                                  \
     }                                                                          \
@@ -203,7 +221,7 @@ public:
 
 // OP is postfix ++, --
 #define __SYCL_GEN_OPT(op)                                                     \
-  friend range<Dimensions> operator op(range<Dimensions> &lhs, int) {          \
+  friend range<Dimensions> operator op(range<Dimensions> &lhs, int) noexcept { \
     range<Dimensions> old_lhs(lhs);                                            \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       op lhs.common_array[i];                                                  \
@@ -225,9 +243,9 @@ private:
 };
 
 #ifdef __cpp_deduction_guides
-range(size_t)->range<1>;
-range(size_t, size_t)->range<2>;
-range(size_t, size_t, size_t)->range<3>;
+range(size_t) -> range<1>;
+range(size_t, size_t) -> range<2>;
+range(size_t, size_t, size_t) -> range<3>;
 #endif
 
 } // namespace _V1

--- a/sycl/include/sycl/range.hpp
+++ b/sycl/include/sycl/range.hpp
@@ -82,8 +82,6 @@ public:
     return result;                                                             \
   }
 
-#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
-  // Enable operators with integral types only
 #define __SYCL_GEN_OPT(op)                                                     \
   __SYCL_GEN_OPT_BASE(op)                                                      \
   template <typename T>                                                        \
@@ -104,27 +102,6 @@ public:
     }                                                                          \
     return result;                                                             \
   }
-#else
-// RFC: remove these as well?
-#define __SYCL_GEN_OPT(op)                                                     \
-  __SYCL_GEN_OPT_BASE(op)                                                      \
-  friend range<Dimensions> operator op(const range<Dimensions> &lhs,           \
-                                       const size_t &rhs) {                    \
-    range<Dimensions> result(lhs);                                             \
-    for (int i = 0; i < Dimensions; ++i) {                                     \
-      result.common_array[i] = lhs.common_array[i] op rhs;                     \
-    }                                                                          \
-    return result;                                                             \
-  }                                                                            \
-  friend range<Dimensions> operator op(const size_t &lhs,                      \
-                                       const range<Dimensions> &rhs) {         \
-    range<Dimensions> result(rhs);                                             \
-    for (int i = 0; i < Dimensions; ++i) {                                     \
-      result.common_array[i] = lhs op rhs.common_array[i];                     \
-    }                                                                          \
-    return result;                                                             \
-  }
-#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
 
   __SYCL_GEN_OPT(+)
   __SYCL_GEN_OPT(-)

--- a/sycl/include/sycl/range.hpp
+++ b/sycl/include/sycl/range.hpp
@@ -82,11 +82,13 @@ public:
     return result;                                                             \
   }
 
+#ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
+  // Enable operators with integral types only
 #define __SYCL_GEN_OPT(op)                                                     \
   __SYCL_GEN_OPT_BASE(op)                                                      \
   template <typename T>                                                        \
   friend IntegralType<T, range<Dimensions>> operator op(                       \
-      const range<Dimensions> &lhs, const T & rhs) noexcept {                  \
+      const range<Dimensions> &lhs, const T &rhs) noexcept {                   \
     range<Dimensions> result(lhs);                                             \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       result.common_array[i] = lhs.common_array[i] op rhs;                     \
@@ -95,13 +97,33 @@ public:
   }                                                                            \
   template <typename T>                                                        \
   friend IntegralType<T, range<Dimensions>> operator op(                       \
-      const T & lhs, const range<Dimensions> &rhs) noexcept {                  \
+      const T &lhs, const range<Dimensions> &rhs) noexcept {                   \
     range<Dimensions> result(rhs);                                             \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       result.common_array[i] = lhs op rhs.common_array[i];                     \
     }                                                                          \
     return result;                                                             \
   }
+#else
+#define __SYCL_GEN_OPT(op)                                                     \
+  __SYCL_GEN_OPT_BASE(op)                                                      \
+  friend range<Dimensions> operator op(const range<Dimensions> &lhs,           \
+                                       const size_t &rhs) noexcept {           \
+    range<Dimensions> result(lhs);                                             \
+    for (int i = 0; i < Dimensions; ++i) {                                     \
+      result.common_array[i] = lhs.common_array[i] op rhs;                     \
+    }                                                                          \
+    return result;                                                             \
+  }                                                                            \
+  friend range<Dimensions> operator op(                                        \
+      const size_t &lhs, const range<Dimensions> &rhs) noexcept {              \
+    range<Dimensions> result(rhs);                                             \
+    for (int i = 0; i < Dimensions; ++i) {                                     \
+      result.common_array[i] = lhs op rhs.common_array[i];                     \
+    }                                                                          \
+    return result;                                                             \
+  }
+#endif // __SYCL_DISABLE_ID_TO_INT_CONV__
 
   __SYCL_GEN_OPT(+)
   __SYCL_GEN_OPT(-)
@@ -134,7 +156,7 @@ public:
   }                                                                            \
   template <typename T>                                                        \
   friend IntegralType<T, range<Dimensions>> operator op(                       \
-      range<Dimensions> &lhs, const T & rhs) noexcept {                        \
+      range<Dimensions> &lhs, const T &rhs) noexcept {                         \
     for (int i = 0; i < Dimensions; ++i) {                                     \
       lhs.common_array[i] op rhs;                                              \
     }                                                                          \
@@ -208,9 +230,9 @@ private:
 };
 
 #ifdef __cpp_deduction_guides
-range(size_t) -> range<1>;
-range(size_t, size_t) -> range<2>;
-range(size_t, size_t, size_t) -> range<3>;
+range(size_t)->range<1>;
+range(size_t, size_t)->range<2>;
+range(size_t, size_t, size_t)->range<3>;
 #endif
 
 } // namespace _V1

--- a/sycl/include/sycl/range.hpp
+++ b/sycl/include/sycl/range.hpp
@@ -106,8 +106,6 @@ public:
   }
 #else
 
-// Can't find either of them in documentation, not adding noexcept for these,
-// maybe need to be removed
 #define __SYCL_GEN_OPT(op)                                                     \
   __SYCL_GEN_OPT_BASE(op)                                                      \
   friend range<Dimensions> operator op(const range<Dimensions> &lhs,           \
@@ -172,9 +170,6 @@ public:
     }                                                                          \
     return lhs;                                                                \
   }
-
-  // second overload above is not in documentation, maybe need to be removed or
-  // guarded against __SYCL_DISABLE_ID_TO_INT_CONV__ like the other operators
 
   __SYCL_GEN_OPT(+=)
   __SYCL_GEN_OPT(-=)


### PR DESCRIPTION
fixes #22736 

This PR introduces an explicit line for range destructor (Rule of 5 or 0 is mandatory) and a missing overload for operator op, alongside multiple missing noexcept keywords for functions