### PR TITLE
[SYCL][NFC] Remove redundant forward declaration

### DIFF
--- a/sycl/include/sycl/range.hpp
+++ b/sycl/include/sycl/range.hpp
@@ -15,7 +15,6 @@
 
 namespace sycl {
 inline namespace _V1 {
-template <int Dimensions> class id;
 
 namespace detail {
 class Builder;


### PR DESCRIPTION
The id class in unused in this header.