### PR TITLE
Revert "[UR] Stub _intel_fast_* for statically linked hwloc (#22838)"

### DIFF
--- a/unified-runtime/source/common/CMakeLists.txt
+++ b/unified-runtime/source/common/CMakeLists.txt
@@ -88,7 +88,7 @@ if ((UR_STATIC_ADAPTER_L0 AND UR_BUILD_ADAPTER_L0) OR
         # A statically-linked UMF must also link hwloc statically; otherwise it
         # requires a system hwloc that isn't present on every platform (e.g.
         # macOS), breaking the link.
-        set(UMF_LINK_HWLOC_STATICALLY ON CACHE INTERNAL "static HWLOC")
+        set(UMF_LINK_HWLOC_STATICALLY ON)
     endif()
 endif()
 
@@ -131,6 +131,9 @@ if (UR_UMF_REQUIRED)
     set(UMF_BUILD_TESTS OFF CACHE INTERNAL "Build UMF tests")
     set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "Build UMF examples")
     set(UMF_BUILD_SHARED_LIBRARY ${UMF_BUILD_SHARED_LIBRARY} CACHE INTERNAL "Build UMF shared library")
+    if(UMF_LINK_HWLOC_STATICALLY)
+      set(UMF_LINK_HWLOC_STATICALLY ON CACHE INTERNAL "static HWLOC")
+    endif()
 
     FetchContent_MakeAvailable(unified-memory-framework)
     FetchContent_GetProperties(unified-memory-framework)

--- a/unified-runtime/source/loader/CMakeLists.txt
+++ b/unified-runtime/source/loader/CMakeLists.txt
@@ -236,6 +236,17 @@ if(UR_ENABLE_SANITIZER)
         target_sources(ur_loader
             PRIVATE ${symbolizer_sources}
         )
+        # Symbolizer dependencies and libhwloc may emit calls to
+        # _intel_fast_memcpy/_intel_fast_memset. Those are normally provided
+        # by libirc, but libsycl / ur doesn't link them. Use stubs forwarding to
+        # plain memcpy/memset. The stub is compiled with -no-intel-lib, which
+        # add_ur_target_compile_options() already applies to the whole target.
+        if(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM" AND
+            (UR_ENABLE_SYMBOLIZER OR UMF_LINK_HWLOC_STATICALLY))
+          target_sources(ur_loader PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/intel_fast_mem_stub.c
+            )
+        endif()
         target_include_directories(ur_loader PRIVATE ${LLVM_INCLUDE_DIRS})
         target_link_libraries(ur_loader PRIVATE LLVMSupport LLVMSymbolize)
         target_compile_definitions(ur_loader PRIVATE UR_HAVE_SYMBOLIZER)
@@ -266,18 +277,5 @@ else()
     target_sources(ur_loader
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/linux/adapter_search.cpp
-    )
-endif()
-
-
-# Symbolizer dependencies and libhwloc may emit calls to
-# _intel_fast_memcpy/_intel_fast_memset. Those are normally provided
-# by libirc, but libsycl / ur doesn't link them. Use stubs forwarding to
-# plain memcpy/memset. The stub is compiled with -no-intel-lib, which
-# add_ur_target_compile_options() already applies to the whole target.
-if(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM" AND
-    (UR_ENABLE_SYMBOLIZER OR UMF_LINK_HWLOC_STATICALLY))
-    target_sources(ur_loader PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/intel_fast_mem_stub.c
     )
 endif()


### PR DESCRIPTION
Causes hangs in `check-sycl` in Windows postcommit.