### PR TITLE
[UR][CMake] Fix broken if(TARGET) check for level-zero-loader targets

### DIFF
--- a/unified-runtime/source/adapters/level_zero/CMakeLists.txt
+++ b/unified-runtime/source/adapters/level_zero/CMakeLists.txt
@@ -150,7 +150,7 @@ if(UR_BUILD_ADAPTER_L0)
     # Note: UR compile options cause issues under MSVC
     if(NOT MSVC)
         foreach(TARGET IN ITEMS ze_loader ze_validation_layer ze_tracing_layer ze_null)
-            if (TARGET TARGET)
+            if (TARGET ${TARGET})
                 add_ur_target_compile_options(${TARGET})
                 add_ur_target_link_options(${TARGET})
                 target_compile_options(${TARGET} PRIVATE


### PR DESCRIPTION
foreach(TARGET IN ITEMS ze_loader ze_validation_layer ze_tracing_layer ze_null) used `if (TARGET TARGET)`, which checks for a target literally named "TARGET" instead of dereferencing the loop variable. This silently skipped add_ur_target_compile_options()/add_ur_target_link_options() (which apply -no-intel-lib=libirc for IntelLLVM) on ze_loader and its siblings, so icx/icpx compiled level-zero-loader sources with default _intel_fast_memcpy/_intel_fast_memset emission and nothing provided those symbols, causing undefined symbol link errors downstream.