### PR TITLE
[SYCL] Don't release sub-devices on Linux OpenCL either

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -130,14 +130,16 @@ std::vector<device> device_impl::create_sub_devices(
   // incremented. Each device_impl wrapper increments the reference count and
   // decrements it on destruction (shared ownership). So, we have to decrement
   // the reference count once here to release temporary handles.
-#ifdef _WIN32
-  // On Windows OpenCL backend, releasing the sub-devices here leads to a crash
-  // during late shutdown. There have been issues observed with premature
-  // unloading of opencl related dlls and seems like that might be the case. So,
-  // intentionally leak sub-devices on Windows OpenCL backend for now.
+  //
+  // On the OpenCL backend, releasing the sub-devices here can lead to a crash
+  // during late shutdown: the OpenCL ICD may already be tearing down by the
+  // time shutdown_late() releases the platform's cached device_impls, so the
+  // subsequent clReleaseDevice() call fails and trips an assert. This was
+  // previously observed and worked around on Windows only (#21198), but the
+  // same shutdown-ordering issue can also occur on Linux. So, intentionally
+  // leak sub-devices on the OpenCL backend for now.
   // TODO: Remove this workaround.
   if (getAdapter().getBackend() != backend::opencl)
-#endif
     for (ur_device_handle_t &SubDevice : SubDevices)
       Adapter.call<UrApiKind::urDeviceRelease>(SubDevice);
 

--- a/sycl/unittests/context_device/DeviceRefCounter.cpp
+++ b/sycl/unittests/context_device/DeviceRefCounter.cpp
@@ -101,12 +101,12 @@ TEST(SubDevRefCounter, SubDevRefCounter) {
     mock::getCallbacks().set_after_callback("urDeviceGetInfo",
                                             &redefinedDeviceGetInfoAfter);
     sycl::platform Plt = sycl::platform();
-    // Skip for Windows OpenCL.
-#ifdef _WIN32
-    if (Plt.get_backend() == sycl::backend::opencl) {
+    // Sub-devices are intentionally leaked on the OpenCL backend to avoid a
+    // crash during late shutdown (see device_impl::create_sub_devices).
+    bool IsOpenCL = Plt.get_backend() == sycl::backend::opencl;
+    if (IsOpenCL) {
       GTEST_SKIP();
     }
-#endif
     auto Devs = Plt.get_devices();
     if (!Devs.empty()) {
       auto Subdevs = Devs[0]


### PR DESCRIPTION
Releasing temporary sub-device handles at the end of device_impl::create_sub_devices (introduced in 8456b01e74da, "[SYCL] Fix memory leak for sub-devices (#20370)") can crash during late shutdown: shutdown_late() releases the platform's cached device_impls after the OpenCL ICD may have already begun tearing down, so clReleaseDevice() fails and trips assert(Res == CL_SUCCESS) in the opencl adapter's ur_device_handle_t_ destructor, aborting the process.

bdfa20b30ea2 worked around this for Windows OpenCL only. Extend the same workaround to the OpenCL backend regardless of OS, and update DeviceRefCounter unit test accordingly.

Fixes: SYCL :: PlatformDeviceIndex/sycl_ext_oneapi_platform_device_index.cpp

CMPLRLLVM-77426