### PR TITLE
[DeviceSanitizer] Fix circular library dependency causing undefined symbol

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/SYCLUtils.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLUtils.h
@@ -19,7 +19,15 @@
 #include <functional>
 
 namespace llvm {
+
+class Module;
+
 namespace sycl {
+
+bool isModuleUsingAsan(const Module &M);
+bool isModuleUsingMsan(const Module &M);
+bool isModuleUsingTsan(const Module &M);
+
 namespace utils {
 constexpr char ATTR_SYCL_MODULE_ID[] = "sycl-module-id";
 constexpr char ATTR_SYCL_OPTLEVEL[] = "sycl-optlevel";

--- a/llvm/include/llvm/SYCLPostLink/ComputeModuleRuntimeInfo.h
+++ b/llvm/include/llvm/SYCLPostLink/ComputeModuleRuntimeInfo.h
@@ -28,9 +28,6 @@ struct GlobalBinImageProps {
   bool EmitImportedSymbols;
   bool EmitDeviceGlobalPropSet;
 };
-bool isModuleUsingAsan(const Module &M);
-bool isModuleUsingMsan(const Module &M);
-bool isModuleUsingTsan(const Module &M);
 using PropSetRegTy = llvm::util::PropertySetRegistry;
 using EntryPointSet = SetVector<Function *>;
 

--- a/llvm/lib/SYCLLowerIR/SYCLUtils.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLUtils.cpp
@@ -14,6 +14,25 @@
 
 namespace llvm {
 namespace sycl {
+
+bool isModuleUsingAsan(const Module &M) {
+  return any_of(M.globals(), [](const GlobalVariable &GV) {
+    return GV.getName().starts_with("__AsanKernelMetadata");
+  });
+}
+
+bool isModuleUsingMsan(const Module &M) {
+  return any_of(M.globals(), [](const GlobalVariable &GV) {
+    return GV.getName().starts_with("__MsanKernelMetadata");
+  });
+}
+
+bool isModuleUsingTsan(const Module &M) {
+  return any_of(M.globals(), [](const GlobalVariable &GV) {
+    return GV.getName().starts_with("__TsanKernelMetadata");
+  });
+}
+
 namespace utils {
 
 using namespace llvm::esimd;

--- a/llvm/lib/SYCLLowerIR/SanitizerPostOptimizer.cpp
+++ b/llvm/lib/SYCLLowerIR/SanitizerPostOptimizer.cpp
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/SYCLLowerIR/SanitizerPostOptimizer.h"
-#include "llvm/SYCLPostLink/ComputeModuleRuntimeInfo.h"
+#include "llvm/SYCLLowerIR/SYCLUtils.h"
 
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"

--- a/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLPostLink/ComputeModuleRuntimeInfo.cpp
@@ -43,24 +43,6 @@ getSYCLESIMDSplitStatusFromMetadata(const Module &M) {
 }
 } // namespace
 
-bool isModuleUsingAsan(const Module &M) {
-  return any_of(M.globals(), [](const GlobalVariable &GV) {
-    return GV.getName().starts_with("__AsanKernelMetadata");
-  });
-}
-
-bool isModuleUsingMsan(const Module &M) {
-  return any_of(M.globals(), [](const GlobalVariable &GV) {
-    return GV.getName().starts_with("__MsanKernelMetadata");
-  });
-}
-
-bool isModuleUsingTsan(const Module &M) {
-  return any_of(M.globals(), [](const GlobalVariable &GV) {
-    return GV.getName().starts_with("__TsanKernelMetadata");
-  });
-}
-
 // Gets 1- to 3-dimension work-group related information for function Func.
 // Returns an empty vector if not present.
 template <typename T>

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -44,6 +44,7 @@
 #include <llvm/SYCLLowerIR/LowerInvokeSimd.h>
 #include <llvm/SYCLLowerIR/SYCLDeviceLibBF16.h>
 #include <llvm/SYCLLowerIR/SYCLJointMatrixTransform.h>
+#include <llvm/SYCLLowerIR/SYCLUtils.h>
 #include <llvm/SYCLPostLink/ComputeModuleRuntimeInfo.h>
 #include <llvm/SYCLPostLink/ModuleSplitter.h>
 #include <llvm/Support/BLAKE3.h>


### PR DESCRIPTION
Commit 0941896bca24 ("[DeviceSanitizer] Make sanitizer metadata globals per-module unique (#22567)") made SanitizerPostOptimizer.cpp in LLVMSYCLLowerIR call sycl::isModuleUsingMsan(), which is defined in LLVMSYCLPostLink. LLVMSYCLPostLink already links against LLVMSYCLLowerIR, so this created a circular library dependency. It doesn't show up when linking against full static LLVM libs, but breaks with `ld.lld: error: undefined symbol:llvm::sycl::isModuleUsingMsan(llvm::Module const&)` when building LLVMSYCLLowerIR as a standalone shared library (-slibs build).

Fix by moving isModuleUsingAsan/Msan/Tsan down into SYCLLowerIR/SYCLUtils.{h,cpp}, which has no dependency on SYCLPostLink.