### PR TITLE
[SYCL] Align item with SYCL 2020

### DIFF
--- a/sycl/include/sycl/item.hpp
+++ b/sycl/include/sycl/item.hpp
@@ -111,11 +111,11 @@ public:
 
   item &operator=(item &&rhs) = default;
 
-  friend bool operator==(const item &lhs, const item &rhs) noexcept {
+  friend bool operator==(const item &lhs, const item &rhs) {
     return lhs.MImpl == rhs.MImpl;
   }
 
-  friend bool operator!=(const item &lhs, const item &rhs) noexcept {
+  friend bool operator!=(const item &lhs, const item &rhs) {
     return !(lhs == rhs);
   }
 

--- a/sycl/include/sycl/item.hpp
+++ b/sycl/include/sycl/item.hpp
@@ -50,51 +50,54 @@ private:
 public:
   item() = delete;
 
-  id<Dimensions> get_id() const { return MImpl.MIndex; }
+  id<Dimensions> get_id() const noexcept { return MImpl.MIndex; }
 
-  size_t __SYCL_ALWAYS_INLINE get_id(int Dimension) const {
+  size_t __SYCL_ALWAYS_INLINE get_id(int Dimension) const noexcept {
     size_t Id = MImpl.MIndex[Dimension];
     __SYCL_ASSUME_ID_RANGE(Id);
     return Id;
   }
 
-  size_t __SYCL_ALWAYS_INLINE operator[](int Dimension) const {
+  size_t __SYCL_ALWAYS_INLINE operator[](int Dimension) const noexcept {
     size_t Id = MImpl.MIndex[Dimension];
     __SYCL_ASSUME_ID_RANGE(Id);
     return Id;
   }
 
-  range<Dimensions> get_range() const { return MImpl.MExtent; }
+  range<Dimensions> get_range() const noexcept { return MImpl.MExtent; }
 
-  size_t __SYCL_ALWAYS_INLINE get_range(int Dimension) const {
+  size_t __SYCL_ALWAYS_INLINE get_range(int Dimension) const noexcept {
     size_t Id = MImpl.MExtent[Dimension];
     __SYCL_ASSUME_ID_RANGE(Id);
     return Id;
   }
 #ifndef __SYCL_DISABLE_ITEM_TO_INT_CONV__
-  operator EnableIfT<Dimensions == 1, std::size_t>() const { return get_id(0); }
+  operator EnableIfT<Dimensions == 1, std::size_t>() const noexcept {
+    return get_id(0);
+  }
 #endif // __SYCL_DISABLE_ITEM_TO_INT_CONV__
   template <bool has_offset = with_offset>
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL2020")
-  std::enable_if_t<has_offset, id<Dimensions>> get_offset() const {
+  std::enable_if_t<has_offset, id<Dimensions>> get_offset() const noexcept {
     return MImpl.MOffset;
   }
 
   template <bool has_offset = with_offset>
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL2020")
   std::enable_if_t<has_offset, size_t> __SYCL_ALWAYS_INLINE
-      get_offset(int Dimension) const {
+      get_offset(int Dimension) const noexcept {
     size_t Id = MImpl.MOffset[Dimension];
     __SYCL_ASSUME_ID_RANGE(Id);
     return Id;
   }
 
   template <bool has_offset = with_offset>
-  operator std::enable_if_t<!has_offset, item<Dimensions, true>>() const {
+  operator std::enable_if_t<!has_offset, item<Dimensions, true>>()
+      const noexcept {
     return item<Dimensions, true>{MImpl.MExtent, MImpl.MIndex, /*Offset*/ {}};
   }
 
-  size_t __SYCL_ALWAYS_INLINE get_linear_id() const {
+  size_t __SYCL_ALWAYS_INLINE get_linear_id() const noexcept {
     size_t Id = MImpl.get_linear_id();
     __SYCL_ASSUME_ID_RANGE(Id);
     return Id;
@@ -108,9 +111,13 @@ public:
 
   item &operator=(item &&rhs) = default;
 
-  bool operator==(const item &rhs) const { return rhs.MImpl == MImpl; }
+  friend bool operator==(const item &lhs, const item &rhs) noexcept {
+    return lhs.MImpl == rhs.MImpl;
+  }
 
-  bool operator!=(const item &rhs) const { return rhs.MImpl != MImpl; }
+  friend bool operator!=(const item &lhs, const item &rhs) noexcept {
+    return !(lhs == rhs);
+  }
 
 protected:
   template <bool has_offset = with_offset>

--- a/sycl/test/basic_tests/item_api.cpp
+++ b/sycl/test/basic_tests/item_api.cpp
@@ -17,15 +17,17 @@ template <typename T, typename = void>
 struct HasMemberEquality : std::false_type {};
 
 template <typename T>
-struct HasMemberEquality<T, std::void_t<decltype(&T::operator==)>>
-    : std::true_type {};
+struct HasMemberEquality<
+    T, std::void_t<decltype(std::declval<const T &>().operator==(
+           std::declval<const T &>()))>> : std::true_type {};
 
 template <typename T, typename = void>
 struct HasMemberInequality : std::false_type {};
 
 template <typename T>
-struct HasMemberInequality<T, std::void_t<decltype(&T::operator!=)>>
-    : std::true_type {};
+struct HasMemberInequality<
+    T, std::void_t<decltype(std::declval<const T &>().operator!=(
+           std::declval<const T &>()))>> : std::true_type {};
 
 using ItemWithOffset = sycl::item<2, true>;
 using ItemWithoutOffset = sycl::item<2, false>;
@@ -43,14 +45,20 @@ static_assert(
     noexcept(static_cast<std::size_t>(std::declval<const OneDimItem &>())));
 static_assert(noexcept(static_cast<sycl::item<2, true>>(
     std::declval<const ItemWithoutOffset &>())));
-static_assert(noexcept(std::declval<const ItemWithOffset &>() ==
-                       std::declval<const ItemWithOffset &>()));
-static_assert(noexcept(std::declval<const ItemWithOffset &>() !=
-                       std::declval<const ItemWithOffset &>()));
+static_assert(std::is_same_v<decltype(std::declval<const ItemWithOffset &>() ==
+                                      std::declval<const ItemWithOffset &>()),
+                             bool>);
+static_assert(std::is_same_v<decltype(std::declval<const ItemWithOffset &>() !=
+                                      std::declval<const ItemWithOffset &>()),
+                             bool>);
 
 static_assert(!HasMemberEquality<ItemWithOffset>::value);
 static_assert(!HasMemberInequality<ItemWithOffset>::value);
-static_assert(noexcept(operator==(std::declval<const ItemWithOffset &>(),
-                                  std::declval<const ItemWithOffset &>())));
-static_assert(noexcept(operator!=(std::declval<const ItemWithOffset &>(),
-                                  std::declval<const ItemWithOffset &>())));
+static_assert(
+    std::is_same_v<decltype(operator==(std::declval<const ItemWithOffset &>(),
+                                       std::declval<const ItemWithOffset &>())),
+                   bool>);
+static_assert(
+    std::is_same_v<decltype(operator!=(std::declval<const ItemWithOffset &>(),
+                                       std::declval<const ItemWithOffset &>())),
+                   bool>);

--- a/sycl/test/basic_tests/item_api.cpp
+++ b/sycl/test/basic_tests/item_api.cpp
@@ -1,0 +1,56 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Wno-deprecated-declarations -fsyntax-only %s
+//==----------- item_api.cpp - SYCL item API test --------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <sycl/item.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+template <typename T, typename = void>
+struct HasMemberEquality : std::false_type {};
+
+template <typename T>
+struct HasMemberEquality<T, std::void_t<decltype(&T::operator==)>>
+    : std::true_type {};
+
+template <typename T, typename = void>
+struct HasMemberInequality : std::false_type {};
+
+template <typename T>
+struct HasMemberInequality<T, std::void_t<decltype(&T::operator!=)>>
+    : std::true_type {};
+
+using ItemWithOffset = sycl::item<2, true>;
+using ItemWithoutOffset = sycl::item<2, false>;
+using OneDimItem = sycl::item<1, false>;
+
+static_assert(noexcept(std::declval<const ItemWithOffset &>().get_id()));
+static_assert(noexcept(std::declval<const ItemWithOffset &>().get_id(0)));
+static_assert(noexcept(std::declval<const ItemWithOffset &>()[0]));
+static_assert(noexcept(std::declval<const ItemWithOffset &>().get_range()));
+static_assert(noexcept(std::declval<const ItemWithOffset &>().get_range(0)));
+static_assert(noexcept(std::declval<const ItemWithOffset &>().get_offset()));
+static_assert(noexcept(std::declval<const ItemWithOffset &>().get_offset(0)));
+static_assert(noexcept(std::declval<const ItemWithOffset &>().get_linear_id()));
+static_assert(
+    noexcept(static_cast<std::size_t>(std::declval<const OneDimItem &>())));
+static_assert(noexcept(static_cast<sycl::item<2, true>>(
+    std::declval<const ItemWithoutOffset &>())));
+static_assert(noexcept(std::declval<const ItemWithOffset &>() ==
+                       std::declval<const ItemWithOffset &>()));
+static_assert(noexcept(std::declval<const ItemWithOffset &>() !=
+                       std::declval<const ItemWithOffset &>()));
+
+static_assert(!HasMemberEquality<ItemWithOffset>::value);
+static_assert(!HasMemberInequality<ItemWithOffset>::value);
+static_assert(noexcept(operator==(std::declval<const ItemWithOffset &>(),
+                                  std::declval<const ItemWithOffset &>())));
+static_assert(noexcept(operator!=(std::declval<const ItemWithOffset &>(),
+                                  std::declval<const ItemWithOffset &>())));


### PR DESCRIPTION
Closes #22870.

Align `sycl::item` with the SYCL 2020 specification:

- Add `noexcept` to the `item` query and conversion functions.
- Implement the equality operators as hidden friends.
- Add compile-time tests covering the exception specifications and hidden-friend lookup.