### PR TITLE
[SYCL] Small API edits to handler and nd_range

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1082,6 +1082,8 @@ private:
   kernel_bundle<bundle_state::input> getKernelBundle() const;
 
 public:
+  handler() = delete;
+
   handler(const handler &) = delete;
   handler(handler &&) = delete;
   handler &operator=(const handler &) = delete;

--- a/sycl/include/sycl/nd_range.hpp
+++ b/sycl/include/sycl/nd_range.hpp
@@ -62,7 +62,6 @@ public:
   nd_range(nd_range<Dimensions> &&rhs) = default;
   nd_range<Dimensions> &operator=(const nd_range<Dimensions> &rhs) = default;
   nd_range<Dimensions> &operator=(nd_range<Dimensions> &&rhs) = default;
-  nd_range() = default;
   ~nd_range() = default;
 
   // Common hidden friend functions for by-value semantics

--- a/sycl/test/extensions/free_function_kernels/free_function_host_compiler.cpp
+++ b/sycl/test/extensions/free_function_kernels/free_function_host_compiler.cpp
@@ -26,7 +26,7 @@ int main() {
   sycl::kernel krn = bundle.get_kernel(kID);
 
   q.submit([&](sycl::handler &cgh) {
-    sycl::nd_range<1> ndr;
+    sycl::nd_range<1> ndr(1, 1);
     cgh.parallel_for(ndr, krn);
   });
   return 0;


### PR DESCRIPTION
According to SYCL 2020 nd_range doesn't have a default constructor. Handler has a deleted constructor. That doesn't change the behavior since previosly it wasn't defined, so now we just explicitly state this.