### PR TITLE
[SYCL] Fix FileCheck patterns for new dead_on_return attribute ordering

### DIFF
--- a/clang/test/CodeGenSYCL/nontrivial_device_copyable.cpp
+++ b/clang/test/CodeGenSYCL/nontrivial_device_copyable.cpp
@@ -29,7 +29,7 @@ int main() {
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name(ptr noundef byval(%struct.NontriviallyCopyable)
 // CHECK-NOT: define {{.*}}spir_func void @{{.*}}device_func{{.*}}({{.*}}byval(%struct.NontriviallyCopyable)
-// CHECK: define {{.*}}spir_func void @_Z11device_func20NontriviallyCopyable(ptr noundef align 4 dead_on_return %X)
+// CHECK: define {{.*}}spir_func void @_Z11device_func20NontriviallyCopyable(ptr nofree noundef align 4 dead_on_return dereferenceable(4) %X)
 // CHECK: %X.indirect_addr = alloca ptr addrspace(4)
 // CHECK: %X.ascast = addrspacecast ptr %X to ptr addrspace(4)
 // CHECK: store ptr %X, ptr %X.indirect_addr

--- a/clang/test/CodeGenSYCL/regcall-cc-test.cpp
+++ b/clang/test/CodeGenSYCL/regcall-cc-test.cpp
@@ -333,7 +333,7 @@ struct NonCopyable {
 // CHECK-DAG: %struct.NonCopyable = type { i32 }
 
 SYCL_DEVICE int __regcall bar(NonCopyable x) {
-// CHECK-DAG: define dso_local x86_regcallcc noundef i32 @_Z15__regcall3__bar11NonCopyable(ptr noundef align 4 dead_on_return %x)
+// CHECK-DAG: define dso_local x86_regcallcc noundef i32 @_Z15__regcall3__bar11NonCopyable(ptr nofree noundef align 4 dead_on_return dereferenceable(4) %x)
   return x.a;
 }
 

--- a/sycl/test/check_device_code/esimd/vec_arg_call_conv_ext.cpp
+++ b/sycl/test/check_device_code/esimd/vec_arg_call_conv_ext.cpp
@@ -62,7 +62,7 @@ SYCL_EXTERNAL void callee_void__noopt_opt(simd<int, 8>& x, simd<int, 8> y) SYCL_
 
 __attribute__((noinline))
 SYCL_EXTERNAL simd<int, 8> test__sret__noopt_opt(simd<int, 8> x) SYCL_ESIMD_FUNCTION {
-// CHECK: define dso_local spir_func <8 x i32> @_Z21test__sret__noopt_opt{{.*}}(ptr noundef align 32 dead_on_return %{{.*}})
+// CHECK: define dso_local spir_func <8 x i32> @_Z21test__sret__noopt_opt{{.*}}(ptr nofree noundef align 32 dead_on_return dereferenceable(32) %{{.*}})
   callee_void__noopt_opt(x, x);
 // CHECK:  call spir_func void @_Z22callee_void__noopt_opt{{.*}}(ptr addrspace(4) %{{.*}}, <8 x i32> %{{.*}})
   return x;


### PR DESCRIPTION
Merge commit 2044c110ccc8 pulled in upstream commit 291516026ec5 ("[Clang][CodeGen] Emit dereferenceable and nofree for indirect arguments"), which now emits a dereferenceable(N) attribute alongside dead_on_return for indirect-but-not-byval parameters. This broke exact-match CHECK lines in these tests. Relax the patterns to tolerate the additional attributes.

CMPLRLLVM-77558