### PR TITLE
[SYCL][E2E] Enable max_work_group_query test for OpenCL

### DIFF
--- a/sycl/test-e2e/Basic/max_work_group_query.cpp
+++ b/sycl/test-e2e/Basic/max_work_group_query.cpp
@@ -1,4 +1,5 @@
 // RUN: %{build} -o %t.out
+// REQUIRES: cuda || hip || level_zero || opencl
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/max_work_group_query.cpp
+++ b/sycl/test-e2e/Basic/max_work_group_query.cpp
@@ -1,5 +1,4 @@
 // RUN: %{build} -o %t.out
-// REQUIRES: cuda || hip || level_zero || opencl
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/max_work_group_query.cpp
+++ b/sycl/test-e2e/Basic/max_work_group_query.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -o %t.out
-// REQUIRES: cuda || hip || level_zero
+// REQUIRES: cuda || hip || level_zero || opencl
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
This test was marked as not supported on OpenCL in error in commit f19914aaceda.