### PR TITLE
[SYCL][Driver] Match sanitizer metadata globals by prefix in .tgtsym filter

### DIFF
--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -82,6 +82,23 @@ using namespace clang;
 
 #define DEBUG_TYPE "clang-offload-bundler"
 
+/// Return true if \p Name is a special bitcode symbol that must not be listed
+/// in the target symbol table. Device sanitizer metadata globals carry a
+/// per-module unique id suffix (e.g. "__AsanKernelMetadata_<id>"), so they are
+/// matched by prefix.
+static bool isSpecialBitcodeSymbol(StringRef Name) {
+  if (Name == "llvm.used" || Name == "llvm.compiler.used")
+    return true;
+
+  static constexpr StringRef SanitizerMetadataPrefixes[] = {
+      "__AsanDeviceGlobalMetadata", "__MsanDeviceGlobalMetadata",
+      "__TsanDeviceGlobalMetadata", "__AsanKernelMetadata",
+      "__MsanKernelMetadata",       "__TsanKernelMetadata"};
+  return llvm::any_of(SanitizerMetadataPrefixes, [Name](StringRef Prefix) {
+    return Name.starts_with(Prefix);
+  });
+}
+
 OffloadTargetInfo::OffloadTargetInfo(const StringRef Target,
                                      const OffloadBundlerConfig &BC)
     : BundlerConfig(BC) {
@@ -751,13 +768,7 @@ class ObjectFileHandler final : public FileHandler {
 
         // If we are dealing with a bitcode file do not add special globals to
         // the list of defined symbols.
-        if (SF->isIR() &&
-            (Name == "llvm.used" || Name == "llvm.compiler.used" ||
-             Name == "__AsanDeviceGlobalMetadata" ||
-             Name == "__MsanDeviceGlobalMetadata" ||
-             Name == "__TsanDeviceGlobalMetadata" ||
-             Name == "__AsanKernelMetadata" || Name == "__MsanKernelMetadata" ||
-             Name == "__TsanKernelMetadata"))
+        if (SF->isIR() && isSpecialBitcodeSymbol(Name))
           continue;
 
         // Add symbol name with the target prefix to the buffer.

--- a/clang/test/Driver/clang-offload-bundler-skip-for-symtbl.c.ll
+++ b/clang/test/Driver/clang-offload-bundler-skip-for-symtbl.c.ll
@@ -11,6 +11,21 @@
 @__TsanDeviceGlobalMetadata = global i64 0
 ;CHECK-NOT: __TsanDeviceGlobalMetadata
 
+; The sanitizer metadata globals carry a per-module unique id suffix, so the
+; suffixed names must be skipped as well.
+@__AsanKernelMetadata_0123456789abcdef0123456789abcdef = global i64 0
+;CHECK-NOT: __AsanKernelMetadata_0123456789abcdef0123456789abcdef
+@__MsanKernelMetadata_0123456789abcdef0123456789abcdef = global i64 0
+;CHECK-NOT: __MsanKernelMetadata_0123456789abcdef0123456789abcdef
+@__TsanKernelMetadata_0123456789abcdef0123456789abcdef = global i64 0
+;CHECK-NOT: __TsanKernelMetadata_0123456789abcdef0123456789abcdef
+@__AsanDeviceGlobalMetadata_0123456789abcdef0123456789abcdef = global i64 0
+;CHECK-NOT: __AsanDeviceGlobalMetadata_0123456789abcdef0123456789abcdef
+@__MsanDeviceGlobalMetadata_0123456789abcdef0123456789abcdef = global i64 0
+;CHECK-NOT: __MsanDeviceGlobalMetadata_0123456789abcdef0123456789abcdef
+@__TsanDeviceGlobalMetadata_0123456789abcdef0123456789abcdef = global i64 0
+;CHECK-NOT: __TsanDeviceGlobalMetadata_0123456789abcdef0123456789abcdef
+
 @not_skipping = global i64 0
 ;CHECK: not_skipping
 


### PR DESCRIPTION
Commit 0941896bca24 ("[DeviceSanitizer] Make sanitizer metadata globals per-module unique") appended a per-module unique id to those names (__AsanKernelMetadata_<id>), so none of the six comparisons matched anymore and all of the metadata globals leaked into .tgtsym. Extract the check into isSpecialBitcodeSymbol() and match the sanitizer globals by prefix.