### PR TITLE
[DevOps] Complete Vulkan NVIDIA library workaround in CI containers

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
@@ -410,7 +410,12 @@ int runTest(
                                           q.get_context());
       vkDestroySemaphore(vkCtx.device, vkSem, nullptr);
     }
+    
+    // DEBUG: Print message before cleanup to track where segfault occurs
+    std::cerr << "DEBUG: About to call cleanupVulkan()..." << std::endl;
     cleanupVulkan(vkCtx, imgRes);
+    std::cerr << "DEBUG: cleanupVulkan() completed successfully" << std::endl;
+    
     return passed ? 0 : 1;
 
   } catch (std::exception &e) {


### PR DESCRIPTION
The existing workaround in Dockerfiles only included libnvidia-gl-565, but Vulkan loader also requires libnvidia-gpucomp-565.