### PR TITLE
[CI] Add LTS driver job to nightly

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -234,6 +234,54 @@ jobs:
       toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
       toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
 
+  lts_driver_read_tests:
+    name: Read LTS driver test list
+    if: github.repository == 'intel/llvm'
+    runs-on: [Linux, aux-tasks]
+    outputs:
+      LIT_FILTER: ${{ steps.read_filter.outputs.LIT_FILTER }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+        sparse-checkout: |
+          devops/
+    - name: Register cleanup after job is finished
+      uses: ./devops/actions/cleanup
+    - id: read_filter
+      shell: bash
+      run: |
+        # Transform to LIT_FILTER format:
+        # First, remove comments/empty lines, then join lines with "|" as separator.
+        echo LIT_FILTER="$(grep -v '^#\|^\W*$' devops/lts-driver-tests | paste -sd '|')" >> $GITHUB_OUTPUT
+
+  ubuntu2204_test_lts_driver:
+    needs: [ubuntu2204_build, lts_driver_read_tests]
+    name: E2E on Intel LTS driver with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+    permissions:
+      contents: write
+      packages: read
+    if: ${{ !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        enable_new_offload_model: ['False', 'True']
+
+    uses: ./.github/workflows/sycl-linux-run-tests.yml
+    with:
+      name: Intel PVC L0 LTS driver with ${{ matrix.enable_new_offload_model == 'True' && 'New Offload Model' || 'Old Offload Model' }}
+      runner: '["Linux", "pvc_lts"]'
+      image: ghcr.io/intel/llvm/ubuntu2204_intel_lts_drivers:latest
+      image_options: -u 1001 --device=/dev/dri -v /dev/dri/by-path:/dev/dri/by-path --privileged --cap-add SYS_ADMIN
+      target_devices: level_zero:gpu
+      tests_selector: e2e
+      extra_lit_opts: "--param 'cxx_flags=-D_GLIBCXX_USE_CXX11_ABI=0' --param enable_new_offload_model=${{ matrix.enable_new_offload_model }}"
+      env: '{"LIT_FILTER":"${{ needs.lts_driver_read_tests.outputs.LIT_FILTER }}"}'
+      repo_ref: ${{ github.sha }}
+      toolchain_artifact: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact }}
+      toolchain_artifact_filename: ${{ needs.ubuntu2204_build.outputs.toolchain_artifact_filename }}
+      toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.toolchain_decompress_command }}
+
   ubuntu2404_oneapi_test:
     needs: [ubuntu2404_oneapi_build]
     permissions:

--- a/devops/lts-driver-tests
+++ b/devops/lts-driver-tests
@@ -1,0 +1,6 @@
+# List of E2E tests to run against the nightly Intel LTS GPU driver job.
+Basic/built-ins.cpp
+Basic/buffer/buffer_dev_to_dev.cpp
+Scheduler/InOrderQueueDeps.cpp
+Reduction/reduction_deterministic.cpp
+USM/mixed.cpp


### PR DESCRIPTION
Use the new LTS docker container in the nightly to lock down we didn't completely break support on the LTS driver, which we need to support.

Note this runs on a runner with a special label, `pvc_lts`, as we also need the LTS kernel driver for true verification. This runner is only used for this job (I took a machine which had 2 PVC cards and put 1 of them into a VM with the LTS kernel driver, the existing runner for this machine only used 1 PVC card anyway, so there is no slowdown)

A major difference with normal E2E jobs is we don't run all/most tests, actually most tests fail. I think (hope?) this is expected because it's fine if we require a new driver for new SYCL features and probably most tests are for new features, the main idea is to lock down we didn't universally enable some new SPIR-V extension or something that completely breaks everything.

I asked an LLM to pick 5 tests to maximize coverage out of the ~270 passing tests, and made a new file in `devops` that lists them. This file will be read by the job and end up as the `LIT_FILTER` envvar. 

I didn't want to enable/disable tests directly in E2E code as we'd have to either mark thousands of failing tests as `UNSUPPORTED` or make this config `UNSUPPORTED` by default and remove `UNSUPPORTED` from hundreds of passing tests using `lit.local.cfg`, seems much more trouble than it's worth.

I went with a separate file in `devops` instead hardcoding it in the job for better extendability and understandability.

Example CI run: https://github.com/intel/llvm/actions/runs/31633290719/job/94240857548