### PR TITLE
[Clang] Fix SPIR-V Windows targets for cdecl-as-default CC

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -764,9 +764,10 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       switch (HT.getEnvironment()) {
       default: // Assume MSVC for unknown environments
       case llvm::Triple::MSVC:
-        assert(HT.getArch() == llvm::Triple::x86 &&
-               "Unsupported host architecture");
-        return std::make_unique<MicrosoftX86_32SPIRV32TargetInfo>(Triple, Opts);
+        if (HT.getArch() == llvm::Triple::x86)
+          return std::make_unique<MicrosoftX86_32SPIRV32TargetInfo>(Triple,
+                                                                    Opts);
+        return std::make_unique<SPIRV32TargetInfo>(Triple, Opts);
       }
     default:
       return std::make_unique<SPIRV32TargetInfo>(Triple, Opts);

--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -764,10 +764,9 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
       switch (HT.getEnvironment()) {
       default: // Assume MSVC for unknown environments
       case llvm::Triple::MSVC:
-        if (HT.getArch() == llvm::Triple::x86)
-          return std::make_unique<MicrosoftX86_32SPIRV32TargetInfo>(Triple,
-                                                                    Opts);
-        return std::make_unique<SPIRV32TargetInfo>(Triple, Opts);
+        assert(HT.getArch() == llvm::Triple::x86 &&
+               "Unsupported host architecture");
+        return std::make_unique<MicrosoftX86_32SPIRV32TargetInfo>(Triple, Opts);
       }
     default:
       return std::make_unique<SPIRV32TargetInfo>(Triple, Opts);

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -331,8 +331,9 @@ public:
     if (CC == CC_X86VectorCall)
       // Permit CC_X86VectorCall which is used in Microsoft headers
       return CCCR_OK;
-    return (CC == CC_SpirFunction || CC == CC_DeviceKernel) ? CCCR_OK
-                                    : CCCR_Warning;
+    return (CC == CC_C || CC == CC_SpirFunction || CC == CC_DeviceKernel)
+               ? CCCR_OK
+               : CCCR_Warning;
   }
 };
 
@@ -383,8 +384,9 @@ public:
       // Permit CC_X86RegCall which is used to mark external functions with
       // explicit simd or structure type arguments to pass them via registers.
       return CCCR_OK;
-    return (CC == CC_SpirFunction || CC == CC_DeviceKernel) ? CCCR_OK
-                                    : CCCR_Warning;
+    return (CC == CC_C || CC == CC_SpirFunction || CC == CC_DeviceKernel)
+               ? CCCR_OK
+               : CCCR_Warning;
   }
 
   bool
@@ -432,8 +434,9 @@ public:
   }
 
   CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
-    return (CC == CC_SpirFunction || CC == CC_DeviceKernel) ? CCCR_OK
-                                                            : CCCR_Warning;
+    return (CC == CC_C || CC == CC_SpirFunction || CC == CC_DeviceKernel)
+               ? CCCR_OK
+               : CCCR_Warning;
   }
 };
 
@@ -616,8 +619,9 @@ public:
     if (CC == CC_X86VectorCall)
       // Permit CC_X86VectorCall which is used in Microsoft headers
       return CCCR_OK;
-    return (CC == CC_SpirFunction || CC == CC_DeviceKernel) ? CCCR_OK
-                                                            : CCCR_Warning;
+    return (CC == CC_C || CC == CC_SpirFunction || CC == CC_DeviceKernel)
+               ? CCCR_OK
+               : CCCR_Warning;
   }
 };
 

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -666,8 +666,9 @@ public:
       // Permit CC_X86RegCall which is used to mark external functions with
       // explicit simd or structure type arguments to pass them via registers.
       return CCCR_OK;
-    return (CC == CC_SpirFunction || CC == CC_DeviceKernel) ? CCCR_OK
-                                                            : CCCR_Warning;
+    return (CC == CC_C || CC == CC_SpirFunction || CC == CC_DeviceKernel)
+               ? CCCR_OK
+               : CCCR_Warning;
   }
 };
 

--- a/clang/test/SemaHIP/amdgcnspirv-host-cconv-in-abstract-type.hip
+++ b/clang/test/SemaHIP/amdgcnspirv-host-cconv-in-abstract-type.hip
@@ -1,4 +1,3 @@
-// RUN: %clang_cc1 %s -fcuda-is-device -std=c++17 -triple spirv32 -aux-triple x86_64-pc-windows-msvc -fms-extensions -verify
 // RUN: %clang_cc1 %s -fcuda-is-device -std=c++17 -triple spirv64 -aux-triple x86_64-pc-windows-msvc -fms-extensions -verify
 // RUN: %clang_cc1 %s -fcuda-is-device -std=c++17 -triple spirv64-amd-amdhsa -aux-triple x86_64-pc-windows-msvc -fms-extensions -verify
 


### PR DESCRIPTION
bed58b8b9f39 ([clang][SPIR-V] Use the C calling convention as the target default) made CC_C an accepted calling convention in BaseSPIRTargetInfo::checkCallingConvention, but the downstream-only WindowsX86_64_SPIRV64TargetInfo override (added by d0744751abe5, [SPIR-V][Headers] Enable programs that include system headers on Windows for SPIRV32 and SPIRV64 targets) has its own copy of that method, which needs the same CC_C change.

Drop the amdgcnspirv-host-cconv-in-abstract-type.hip RUN line that
pairs a 32-bit spirv32 device with a 64-bit x86_64 host: AllocateTarget
asserts the MSVC host's arch is x86 for spirv32, so a 64-bit host is
not a supported combination for that device width.

Fixes Clang::SemaHIP/amdgcnspirv-host-cconv-in-abstract-type.hip, Clang::SemaSYCL/sycl-cconv.cpp and sycl-in-tree compile fails on Windows after fd9330c2988d. 