### PR TITLE
[SYCL][NFC] Update some ESIMD tests

### DIFF
--- a/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: !arch-intel_gpu_pvc
-// There is a separate version of this test for PVC.
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// UNSUPPORTED: arch-intel_gpu_pvc
+// REQUIRES: !arch-intel_gpu_pvc
+// There is a separate version of this test for PVC.
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/api/simd_copy_to_from.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_copy_to_from.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: arch-intel_gpu_pvc
+// REQUIRES: !arch-intel_gpu_pvc
+// There is a separate version of this test for PVC.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/api/simd_copy_to_from.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_copy_to_from.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: arch-intel_gpu_pvc
 // UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
-// There is a separate version of this test for PVC.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/api/simd_copy_to_from.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_copy_to_from.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: !arch-intel_gpu_pvc
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
 // There is a separate version of this test for PVC.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/api/simd_copy_to_from_stateful.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_copy_to_from_stateful.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: arch-intel_gpu_pvc
+// REQUIRES: !arch-intel_gpu_pvc
+// There is a separate version of this test for PVC.
 // Use -O2 to avoid huge stack usage under -O0.
 // RUN: %{build} -O2 -fno-sycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/api/simd_copy_to_from_stateful.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_copy_to_from_stateful.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: !arch-intel_gpu_pvc
-// There is a separate version of this test for PVC.
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
 // Use -O2 to avoid huge stack usage under -O0.
 // RUN: %{build} -O2 -fno-sycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/api/simd_subscript_operator.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_subscript_operator.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: !arch-intel_gpu_pvc
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
 // There is a separate version of this test for PVC.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/api/simd_subscript_operator.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_subscript_operator.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: arch-intel_gpu_pvc
+// REQUIRES: !arch-intel_gpu_pvc
+// There is a separate version of this test for PVC.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/api/simd_subscript_operator.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_subscript_operator.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: arch-intel_gpu_pvc
 // UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
-// There is a separate version of this test for PVC.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/api/simd_view_subscript_operator.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_view_subscript_operator.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: !arch-intel_gpu_pvc
-// There is a separate version of this test for PVC.
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/api/simd_view_subscript_operator.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_view_subscript_operator.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: arch-intel_gpu_pvc
+// REQUIRES: !arch-intel_gpu_pvc
+// There is a separate version of this test for PVC.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/api/svm_gather_scatter.cpp
+++ b/sycl/test-e2e/ESIMD/api/svm_gather_scatter.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: arch-intel_gpu_pvc
+// REQUIRES: !arch-intel_gpu_pvc
+// There is a separate version of this test for PVC.
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/api/svm_gather_scatter.cpp
+++ b/sycl/test-e2e/ESIMD/api/svm_gather_scatter.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: !arch-intel_gpu_pvc
-// There is a separate version of this test for PVC.
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/ext_math.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math.cpp
@@ -9,7 +9,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: arch-intel_gpu_pvc
+// REQUIRES: !arch-intel_gpu_pvc
+// There is a separate version of this test for PVC.
 
 // This test checks extended math operations. Combinations of
 // - argument type - half, float

--- a/sycl/test-e2e/ESIMD/ext_math.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math.cpp
@@ -9,8 +9,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// REQUIRES: !arch-intel_gpu_pvc
-// There is a separate version of this test for PVC.
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
 
 // This test checks extended math operations. Combinations of
 // - argument type - half, float

--- a/sycl/test-e2e/ESIMD/ext_math_fast.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math_fast.cpp
@@ -9,8 +9,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -ffast-math %{slpflags} -o %t.out
 // RUN: %{run} %t.out
 
-// REQUIRES: !arch-intel_gpu_pvc
-// There is a separate version of this test for PVC.
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
 
 // This test checks extended math operations. Combinations of
 // - argument type - half, float

--- a/sycl/test-e2e/ESIMD/ext_math_fast.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math_fast.cpp
@@ -9,7 +9,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -ffast-math %{slpflags} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: arch-intel_gpu_pvc
+// REQUIRES: !arch-intel_gpu_pvc
+// There is a separate version of this test for PVC.
 
 // This test checks extended math operations. Combinations of
 // - argument type - half, float

--- a/sycl/test-e2e/ESIMD/ext_math_saturate.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math_saturate.cpp
@@ -9,7 +9,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: arch-intel_gpu_pvc
+// REQUIRES: !arch-intel_gpu_pvc
+// There is a separate version of this test for PVC.
 
 // This test checks extended math operations called with saturation.
 // Combinations of

--- a/sycl/test-e2e/ESIMD/ext_math_saturate.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math_saturate.cpp
@@ -9,8 +9,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// REQUIRES: !arch-intel_gpu_pvc
-// There is a separate version of this test for PVC.
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
 
 // This test checks extended math operations called with saturation.
 // Combinations of

--- a/sycl/test-e2e/ESIMD/private_memory/private_memory.cpp
+++ b/sycl/test-e2e/ESIMD/private_memory/private_memory.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: !arch-intel_gpu_pvc
-// There is a separate version of this test for PVC.
+// UNSUPPORTED: arch-intel_gpu_pvc
+// UNSUPPORTED-INTENDED: There is a separate version of this test for PVC.
 
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/private_memory/private_memory.cpp
+++ b/sycl/test-e2e/ESIMD/private_memory/private_memory.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: arch-intel_gpu_pvc
+// REQUIRES: !arch-intel_gpu_pvc
+// There is a separate version of this test for PVC.
 
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 31
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 21
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.
@@ -65,18 +65,8 @@
 // CHECK-NEXT: Basic/gpu_max_wgs_error.cpp
 // CHECK-NEXT: DeprecatedFeatures/DiscardEvents/discard_events_using_assert.cpp
 // CHECK-NEXT: DeviceLib/separate_compile_test.cpp
-// CHECK-NEXT: ESIMD/api/replicate_smoke.cpp
-// CHECK-NEXT: ESIMD/api/simd_copy_to_from.cpp
-// CHECK-NEXT: ESIMD/api/simd_copy_to_from_stateful.cpp
-// CHECK-NEXT: ESIMD/api/simd_subscript_operator.cpp
-// CHECK-NEXT: ESIMD/api/simd_view_subscript_operator.cpp
-// CHECK-NEXT: ESIMD/api/svm_gather_scatter.cpp
 // CHECK-NEXT: ESIMD/api/svm_gather_scatter_scalar_off.cpp
-// CHECK-NEXT: ESIMD/ext_math.cpp
-// CHECK-NEXT: ESIMD/ext_math_fast.cpp
-// CHECK-NEXT: ESIMD/ext_math_saturate.cpp
 // CHECK-NEXT: ESIMD/matrix_transpose2.cpp
-// CHECK-NEXT: ESIMD/private_memory/private_memory.cpp
 // CHECK-NEXT: ESIMD/regression/copyto_char_test.cpp
 // CHECK-NEXT: ESIMD/regression/variable_gather_mask.cpp
 // CHECK-NEXT: KernelAndProgram/multiple-kernel-linking.cpp


### PR DESCRIPTION
These tests are disabled on PVC because there are seperate versions of these tests for PVC.