### PR TITLE
[SYCL] Add support for passing multiple archs in command line

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7919,18 +7919,11 @@ Driver::getOffloadArchs(Compilation &C, const llvm::opt::DerivedArgList &Args,
       ArgStringList TargetArgs;
       DeviceTC->TranslateBackendTargetArgs(DeviceTC->getTriple(),
                                            C.getInputArgs(), TargetArgs);
-      // Look for -device <string> and use that as the known
-      // arch to be associated with the current spir64_gen entry. Grab
-      // the right most entry.
-      for (int i = TargetArgs.size() - 2; i >= 0; --i) {
-        if (StringRef(TargetArgs[i]) == "-device") {
-          StringRef Arch;
-          Arch = TargetArgs[i + 1];
-          if (!Arch.empty())
-            Archs.insert(Arch);
-          break;
-        }
-      }
+      // Use the rightmost embedded "-device <arch>" as the arch bound to
+      // the raw spir64_gen entry.
+      if (StringRef Arch = tools::SYCL::gen::getEmbeddedDeviceArch(TargetArgs);
+          !Arch.empty())
+        Archs.insert(Arch);
     }
   }
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11014,12 +11014,10 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
           static_cast<const toolchains::SYCLToolChain &>(*TC);
       SYCLTC.AddSPIRVImpliedTargetArgs(TC->getTriple(), Args, BuildArgs, JA,
                                        *HostTC, Arch.ArchName);
-      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs,
-                                        Arch.ArchName);
+      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs);
       createArgString("compile-opts=");
       BuildArgs.clear();
-      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs,
-                                       Arch.ArchName);
+      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs);
       createArgString("link-opts=");
     }
 
@@ -12333,8 +12331,8 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     // -Xdevice-post-link -> --sycl-post-link-options
     // -Xspirv-translator -> --llvm-spirv-options
     // -Xspirv-to-ir-wrapper -> --spirv-to-ir-wrapper-options.
-    // For spir64_gen the value is qualified with "/<arch>" and emitted per
-    // (triple, arch) to keep per-arch tokens from crossing across archs.
+    // For spir64_gen the key is qualified with "/<arch>" and emitted per
+    // (triple, arch) to keep per-arch tokens from leaking between archs.
     const toolchains::SYCLToolChain &SYCLTC =
         static_cast<const toolchains::SYCLToolChain &>(getToolChain());
     for (auto &ToolChainMember :

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11014,10 +11014,12 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
           static_cast<const toolchains::SYCLToolChain &>(*TC);
       SYCLTC.AddSPIRVImpliedTargetArgs(TC->getTriple(), Args, BuildArgs, JA,
                                        *HostTC, Arch.ArchName);
-      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs);
+      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs,
+                                        Arch.ArchName);
       createArgString("compile-opts=");
       BuildArgs.clear();
-      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs);
+      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs,
+                                       Arch.ArchName);
       createArgString("link-opts=");
     }
 
@@ -12331,6 +12333,8 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     // -Xdevice-post-link -> --sycl-post-link-options
     // -Xspirv-translator -> --llvm-spirv-options
     // -Xspirv-to-ir-wrapper -> --spirv-to-ir-wrapper-options.
+    // For spir64_gen the value is qualified with "/<arch>" and emitted per
+    // (triple, arch) to keep per-arch tokens from crossing across archs.
     const toolchains::SYCLToolChain &SYCLTC =
         static_cast<const toolchains::SYCLToolChain &>(getToolChain());
     for (auto &ToolChainMember :
@@ -12338,20 +12342,42 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       const ToolChain *TC = ToolChainMember.second;
       if (!TC->getTriple().isSPIROrSPIRV())
         continue;
-      ArgStringList BuildArgs;
-      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs);
-      for (const auto &A : BuildArgs)
-        CmdArgs.push_back(
-            Args.MakeArgString("--device-compiler=" +
-                               Action::GetOffloadKindName(Action::OFK_SYCL) +
-                               ":" + TC->getTripleString() + "=" + A));
 
-      BuildArgs.clear();
-      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs);
-      for (const auto &A : BuildArgs)
-        CmdArgs.push_back(Args.MakeArgString(
-            "--device-linker=" + Action::GetOffloadKindName(Action::OFK_SYCL) +
-            ":" + TC->getTripleString() + "=" + A));
+      SmallVector<StringRef, 4> Devices;
+      if (TC->getTriple().isSPIR() &&
+          TC->getTriple().getSubArch() == llvm::Triple::SPIRSubArch_gen) {
+        for (BoundArch BA : C.getDriver().getOffloadArchs(
+                 C, C.getArgs(), Action::OFK_SYCL, *TC))
+          if (!BA.ArchName.empty())
+            Devices.push_back(BA.ArchName);
+      }
+      if (Devices.empty())
+        Devices.push_back(StringRef());
+
+      // One --device-compiler/--device-linker per token; per-arch routing
+      // rides on the key (<triple>/<arch>). Preserves dd9abc1's per-token
+      // AOT forwarding invariant. Wrapper filters by key, no reparse.
+      StringRef KindPrefix = Action::GetOffloadKindName(Action::OFK_SYCL);
+      ArgStringList BuildArgs;
+      for (StringRef Device : Devices) {
+        SmallString<64> Key(TC->getTripleString());
+        if (!Device.empty()) {
+          Key += '/';
+          Key += Device;
+        }
+        BuildArgs.clear();
+        SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs,
+                                          Device);
+        for (const char *T : BuildArgs)
+          CmdArgs.push_back(Args.MakeArgString(
+              "--device-compiler=" + KindPrefix + ":" + Key + "=" + T));
+        BuildArgs.clear();
+        SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs,
+                                         Device);
+        for (const char *T : BuildArgs)
+          CmdArgs.push_back(Args.MakeArgString("--device-linker=" + KindPrefix +
+                                               ":" + Key + "=" + T));
+      }
 
       BuildArgs.clear();
       SYCLTC.TranslateTargetOpt(

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -12355,8 +12355,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         Devices.push_back(StringRef());
 
       // One --device-compiler/--device-linker per token; per-arch routing
-      // rides on the key (<triple>/<arch>). Preserves dd9abc1's per-token
-      // AOT forwarding invariant. Wrapper filters by key, no reparse.
+      // rides on the key (<triple>/<arch>).
       StringRef KindPrefix = Action::GetOffloadKindName(Action::OFK_SYCL);
       ArgStringList BuildArgs;
       for (StringRef Device : Devices) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -12328,16 +12328,14 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back(
           Args.MakeArgString("-sycl-allow-device-image-dependencies"));
 
-    // Pass backend compiler, linker, sycl-post-link,
-    // llvm-spirv, and spirv-to-ir-wrapper options specified at link
-    // time to clang-linker-wrapper, using the following mapping:
     // -Xsycl-target-backend  -> --device-compiler
-    // -Xsycl-target-linker -> --device-linker
-    // -Xdevice-post-link -> --sycl-post-link-options
-    // -Xspirv-translator -> --llvm-spirv-options
-    // -Xspirv-to-ir-wrapper -> --spirv-to-ir-wrapper-options.
-    // For spir64_gen the key is qualified with "/<arch>" and emitted per
-    // (triple, arch) to keep per-arch tokens from leaking between archs.
+    // -Xsycl-target-linker   -> --device-linker
+    // -Xdevice-post-link     -> --sycl-post-link-options
+    // -Xspirv-translator     -> --llvm-spirv-options
+    // -Xspirv-to-ir-wrapper  -> --spirv-to-ir-wrapper-options
+    // AOT compile-time opts ride on per-image compile-opts=/link-opts=
+    // (one ocloc/opencl-aot call per fsycl-target entry). Link-time-only opts
+    // still flow via the wrapper CLI here (triple-scoped, no /<arch>).
     const toolchains::SYCLToolChain &SYCLTC =
         static_cast<const toolchains::SYCLToolChain &>(getToolChain());
     for (auto &ToolChainMember :
@@ -12346,40 +12344,19 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       if (!TC->getTriple().isSPIROrSPIRV())
         continue;
 
-      SmallVector<StringRef, 4> Devices;
-      if (TC->getTriple().isSPIR() &&
-          TC->getTriple().getSubArch() == llvm::Triple::SPIRSubArch_gen) {
-        for (BoundArch BA : C.getDriver().getOffloadArchs(
-                 C, C.getArgs(), Action::OFK_SYCL, *TC))
-          if (!BA.ArchName.empty())
-            Devices.push_back(BA.ArchName);
-      }
-      if (Devices.empty())
-        Devices.push_back(StringRef());
-
-      // One --device-compiler/--device-linker per token; per-arch routing
-      // rides on the key (<triple>/<arch>).
       StringRef KindPrefix = Action::GetOffloadKindName(Action::OFK_SYCL);
       ArgStringList BuildArgs;
-      for (StringRef Device : Devices) {
-        SmallString<64> Key(TC->getTripleString());
-        if (!Device.empty()) {
-          Key += '/';
-          Key += Device;
-        }
-        BuildArgs.clear();
-        SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs,
-                                          Device);
-        for (const char *T : BuildArgs)
-          CmdArgs.push_back(Args.MakeArgString(
-              "--device-compiler=" + KindPrefix + ":" + Key + "=" + T));
-        BuildArgs.clear();
-        SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs,
-                                         Device);
-        for (const char *T : BuildArgs)
-          CmdArgs.push_back(Args.MakeArgString("--device-linker=" + KindPrefix +
-                                               ":" + Key + "=" + T));
-      }
+      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs);
+      for (const char *T : BuildArgs)
+        CmdArgs.push_back(Args.MakeArgString("--device-compiler=" + KindPrefix +
+                                             ":" + TC->getTripleString() + "=" +
+                                             T));
+      BuildArgs.clear();
+      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs);
+      for (const char *T : BuildArgs)
+        CmdArgs.push_back(Args.MakeArgString("--device-linker=" + KindPrefix +
+                                             ":" + TC->getTripleString() + "=" +
+                                             T));
 
       BuildArgs.clear();
       SYCLTC.TranslateTargetOpt(

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11014,10 +11014,15 @@ void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
           static_cast<const toolchains::SYCLToolChain &>(*TC);
       SYCLTC.AddSPIRVImpliedTargetArgs(TC->getTriple(), Args, BuildArgs, JA,
                                        *HostTC, Arch.ArchName);
-      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs);
+      // Filter per-arch only when this image is bound to a single arch;
+      // legacy "-device pvc,bdw" buckets should keep all opts.
+      StringRef PerArch = Archs.size() == 1 ? Arch.ArchName : StringRef();
+      SYCLTC.TranslateBackendTargetArgs(TC->getTriple(), Args, BuildArgs,
+                                        PerArch);
       createArgString("compile-opts=");
       BuildArgs.clear();
-      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs);
+      SYCLTC.TranslateLinkerTargetArgs(TC->getTriple(), Args, BuildArgs,
+                                       PerArch);
       createArgString("link-opts=");
     }
 

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1097,6 +1097,13 @@ StringRef SYCL::gen::getGenGRFFlag(StringRef GRFMode) {
   return GRFModeFlagMap[GRFMode];
 }
 
+StringRef SYCL::gen::getEmbeddedDeviceArch(ArrayRef<const char *> Tokens) {
+  for (int I = static_cast<int>(Tokens.size()) - 2; I >= 0; --I)
+    if (StringRef(Tokens[I]) == "-device")
+      return Tokens[I + 1];
+  return {};
+}
+
 void SYCL::gen::BackendCompiler::ConstructJob(Compilation &C,
                                               const JobAction &JA,
                                               const InputInfo &Output,

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1663,30 +1663,19 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::Triple &Triple,
       bool IsGenTriple = Triple.isSPIR() &&
                          Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen;
       if (IsGenTriple) {
-        if (!GenDevice.empty() && Device != GenDevice && !Device.empty())
+        // "aot_generic" is a new-offload-model pseudo-arch bucket for raw
+        // -Xsycl-target-backend=spir64_gen entries; inert in old model.
+        StringRef AOTGenericArch = "aot_generic";
+        if (Device != GenDevice && !Device.empty() &&
+            !(GenDevice.empty() && Device == AOTGenericArch))
           continue;
         if (OptTargetTriple != Triple && GenDevice.empty())
           // Triples do not match, but only skip when we know we are not
           // comparing against intel_gpu_*
           continue;
-        if (OptTargetTriple == Triple && !Device.empty()) {
-          // Raw spir64_gen entry: if the value embeds "-device X", route
-          // only to arch X. Absent -> shared, applies to every arch.
-          StringRef Value = A->getValue(1);
-          SmallVector<const char *, 8> Tokens;
-          llvm::BumpPtrAllocator Alloc;
-          llvm::StringSaver S(Alloc);
-          llvm::cl::TokenizeGNUCommandLine(Value, S, Tokens);
-          bool EmbDeviceNoMatch = false;
-          for (size_t I = 0; I + 1 < Tokens.size(); ++I) {
-            if (StringRef(Tokens[I]) == "-device") {
-              EmbDeviceNoMatch = StringRef(Tokens[I + 1]) != Device;
-              break;
-            }
-          }
-          if (EmbDeviceNoMatch)
-            continue;
-        }
+        if (OptTargetTriple == Triple && !Device.empty() &&
+            Device != AOTGenericArch)
+          continue;
       } else if (OptTargetTriple != Triple)
         continue;
     } else if (!OptNoTriple)

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1663,15 +1663,30 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::Triple &Triple,
       bool IsGenTriple = Triple.isSPIR() &&
                          Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen;
       if (IsGenTriple) {
-        if (Device != GenDevice && !Device.empty())
+        if (!GenDevice.empty() && Device != GenDevice && !Device.empty())
           continue;
         if (OptTargetTriple != Triple && GenDevice.empty())
           // Triples do not match, but only skip when we know we are not
           // comparing against intel_gpu_*
           continue;
-        if (OptTargetTriple == Triple && !Device.empty())
-          // Triples match, but we are expecting a specific device to be set.
-          continue;
+        if (OptTargetTriple == Triple && !Device.empty()) {
+          // Raw spir64_gen entry: if the value embeds "-device X", route
+          // only to arch X. Absent -> shared, applies to every arch.
+          StringRef Value = A->getValue(1);
+          SmallVector<const char *, 8> Tokens;
+          llvm::BumpPtrAllocator Alloc;
+          llvm::StringSaver S(Alloc);
+          llvm::cl::TokenizeGNUCommandLine(Value, S, Tokens);
+          bool EmbDeviceNoMatch = false;
+          for (size_t I = 0; I + 1 < Tokens.size(); ++I) {
+            if (StringRef(Tokens[I]) == "-device") {
+              EmbDeviceNoMatch = StringRef(Tokens[I + 1]) != Device;
+              break;
+            }
+          }
+          if (EmbDeviceNoMatch)
+            continue;
+        }
       } else if (OptTargetTriple != Triple)
         continue;
     } else if (!OptNoTriple)

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1670,18 +1670,14 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::Triple &Triple,
       bool IsGenTriple = Triple.isSPIR() &&
                          Triple.getSubArch() == llvm::Triple::SPIRSubArch_gen;
       if (IsGenTriple) {
-        // "aot_generic" is a new-offload-model pseudo-arch bucket for raw
-        // -Xsycl-target-backend=spir64_gen entries; inert in old model.
-        StringRef AOTGenericArch = "aot_generic";
-        if (Device != GenDevice && !Device.empty() &&
-            !(GenDevice.empty() && Device == AOTGenericArch))
+        if (Device != GenDevice && !Device.empty())
           continue;
         if (OptTargetTriple != Triple && GenDevice.empty())
           // Triples do not match, but only skip when we know we are not
           // comparing against intel_gpu_*
           continue;
-        if (OptTargetTriple == Triple && !Device.empty() &&
-            Device != AOTGenericArch)
+        if (OptTargetTriple == Triple && !Device.empty())
+          // Triples match, but we are expecting a specific device to be set.
           continue;
       } else if (OptTargetTriple != Triple)
         continue;

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -82,6 +82,9 @@ StringRef resolveGenDevice(StringRef DeviceName);
 SmallString<64> getGenDeviceMacro(StringRef DeviceName);
 StringRef getGenGRFFlag(StringRef GRFMode);
 
+// Returns the rightmost "-device <arch>" value in Tokens, or empty if none.
+StringRef getEmbeddedDeviceArch(ArrayRef<const char *> Tokens);
+
 // Returns the full path of the ocloc tool to be used for AOT compilation and
 // for emitting the ocloc help information.  A user provided --ocloc-path= is
 // honored above all other lookup locations.  If not found, the tool (ocloc) is

--- a/clang/test/Driver/clang-linker-wrapper.cpp
+++ b/clang/test/Driver/clang-linker-wrapper.cpp
@@ -153,6 +153,19 @@
 // RUN: not clang-linker-wrapper --ocloc-path= --linker-path=/usr/bin/ld -o /dev/null %t1.o --dry-run 2>&1 | FileCheck -check-prefix=CHK-OCLOC-PATH-NOARG %s
 // CHK-OCLOC-PATH-NOARG: no directory given for '--ocloc-path='
 
+// "/<arch>" qualifier on --device-compiler=/--device-linker= routes each
+// value to that arch's ocloc call and per-arch sycl-post-link output name.
+// RUN: %clang %s -fsycl -fsycl-targets=intel_gpu_skl -c --offload-new-driver --no-offloadlib -fno-sycl-instrument-device-code -o %t1_skl.o
+// RUN: clang-linker-wrapper \
+// RUN:   --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_pvc \
+// RUN:   --device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl \
+// RUN:   --linker-path=/usr/bin/ld -o /dev/null %t1.o %t1_skl.o --dry-run 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-PER-ARCH-DC %s
+// CHK-PER-ARCH-DC-DAG: sycl-post-link{{.*}} -o intel_gpu_pvc,{{.*}}.table
+// CHK-PER-ARCH-DC-DAG: ocloc{{.*}} -device pvc{{.*}}-extraopt_pvc
+// CHK-PER-ARCH-DC-DAG: sycl-post-link{{.*}} -o intel_gpu_skl,{{.*}}.table
+// CHK-PER-ARCH-DC-DAG: ocloc{{.*}} -device skl{{.*}}-extraopt_skl
+
 /// Check for list of commands for standalone clang-linker-wrapper run for sycl (AOT for Intel CPU)
 // -------
 // Generate .o file as linker wrapper input.

--- a/clang/test/Driver/clang-linker-wrapper.cpp
+++ b/clang/test/Driver/clang-linker-wrapper.cpp
@@ -162,9 +162,9 @@
 // RUN:   --linker-path=/usr/bin/ld -o /dev/null %t1.o %t1_skl.o --dry-run 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-PER-ARCH-DC %s
 // CHK-PER-ARCH-DC-DAG: sycl-post-link{{.*}} -o intel_gpu_pvc,{{.*}}.table
-// CHK-PER-ARCH-DC-DAG: ocloc{{.*}} -device pvc{{.*}}-extraopt_pvc
+// CHK-PER-ARCH-DC-DAG: ocloc{{.*}} -device pvc{{.*}}-extraopt_pvc -output
 // CHK-PER-ARCH-DC-DAG: sycl-post-link{{.*}} -o intel_gpu_skl,{{.*}}.table
-// CHK-PER-ARCH-DC-DAG: ocloc{{.*}} -device skl{{.*}}-extraopt_skl
+// CHK-PER-ARCH-DC-DAG: ocloc{{.*}} -device skl{{.*}}-extraopt_skl -output
 
 /// Check for list of commands for standalone clang-linker-wrapper run for sycl (AOT for Intel CPU)
 // -------

--- a/clang/test/Driver/clang-linker-wrapper.cpp
+++ b/clang/test/Driver/clang-linker-wrapper.cpp
@@ -153,18 +153,17 @@
 // RUN: not clang-linker-wrapper --ocloc-path= --linker-path=/usr/bin/ld -o /dev/null %t1.o --dry-run 2>&1 | FileCheck -check-prefix=CHK-OCLOC-PATH-NOARG %s
 // CHK-OCLOC-PATH-NOARG: no directory given for '--ocloc-path='
 
-// "/<arch>" qualifier on --device-compiler=/--device-linker= routes each
-// value to that arch's ocloc call and per-arch sycl-post-link output name.
+// entry-id= routes each value to its own entry's ocloc call, no cross-entry leak.
 // RUN: %clang %s -fsycl -fsycl-targets=intel_gpu_skl -c --offload-new-driver --no-offloadlib -fno-sycl-instrument-device-code -o %t1_skl.o
 // RUN: clang-linker-wrapper \
-// RUN:   --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_pvc \
-// RUN:   --device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl \
+// RUN:   --device-compiler=spir64_gen-unknown-unknown,entry-id=0="-device pvc -extraopt_pvc" \
+// RUN:   --device-compiler=spir64_gen-unknown-unknown,entry-id=1="-device skl -extraopt_skl" \
 // RUN:   --linker-path=/usr/bin/ld -o /dev/null %t1.o %t1_skl.o --dry-run 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-PER-ARCH-DC %s
-// CHK-PER-ARCH-DC-DAG: sycl-post-link{{.*}} -o intel_gpu_pvc,{{.*}}.table
-// CHK-PER-ARCH-DC-DAG: ocloc{{.*}} -device pvc{{.*}}-extraopt_pvc -output
-// CHK-PER-ARCH-DC-DAG: sycl-post-link{{.*}} -o intel_gpu_skl,{{.*}}.table
-// CHK-PER-ARCH-DC-DAG: ocloc{{.*}} -device skl{{.*}}-extraopt_skl -output
+// RUN:   | FileCheck -check-prefix=CHK-PER-ENTRY-DC %s
+// CHK-PER-ENTRY-DC-DAG: ocloc{{.*}} -device pvc{{.*}}-extraopt_pvc -output
+// CHK-PER-ENTRY-DC-DAG: ocloc{{.*}} -device skl{{.*}}-extraopt_skl -output
+// CHK-PER-ENTRY-DC-NOT: ocloc{{.*}} -device pvc{{.*}}-extraopt_skl
+// CHK-PER-ENTRY-DC-NOT: ocloc{{.*}} -device skl{{.*}}-extraopt_pvc
 
 /// Check for list of commands for standalone clang-linker-wrapper run for sycl (AOT for Intel CPU)
 // -------

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -169,29 +169,16 @@
 /// Two spir64_gen sub-targets on the same triple: each arch's tokens
 /// carry their own "/<arch>" qualifier so options don't cross-contaminate.
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
-// RUN:          -fsycl-targets=spir64_gen,intel_gpu_skl \
-// RUN:          -Xsycl-target-backend=spir64_gen "-device pvc -options -extraopt_pvc" \
+// RUN:          -fsycl-targets=intel_gpu_pvc,intel_gpu_skl \
+// RUN:          -Xsycl-target-backend=intel_gpu_pvc "-options -extraopt_pvc" \
 // RUN:          -Xsycl-target-backend=intel_gpu_skl "-options -extraopt_skl" \
 // RUN:          -### %s 2>&1 \
-// RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_MULTI_GEN %s
+// RUN:   | FileCheck --implicit-check-not='/pvc=-extraopt_skl' \
+// RUN:               --implicit-check-not='/skl=-extraopt_pvc' \
+// RUN:               -check-prefix WRAPPER_OPTIONS_MULTI_GEN %s
 // WRAPPER_OPTIONS_MULTI_GEN: clang-linker-wrapper
 // WRAPPER_OPTIONS_MULTI_GEN-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_pvc"
 // WRAPPER_OPTIONS_MULTI_GEN-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl"
-// WRAPPER_OPTIONS_MULTI_GEN-NOT: "--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_skl"
-// WRAPPER_OPTIONS_MULTI_GEN-NOT: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_pvc"
-
-/// Aliased-target case: intel_gpu_skl and raw spir64_gen "-device skl ..."
-/// name the same arch. Their per-target options must merge into the same
-/// /skl bucket rather than land under different keys or drop each other.
-// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
-// RUN:          -fsycl-targets=spir64_gen,intel_gpu_skl \
-// RUN:          -Xsycl-target-backend=spir64_gen "-device skl -options extraopt_skl1" \
-// RUN:          -Xsycl-target-backend=intel_gpu_skl "-options -extraopt_skl2" \
-// RUN:          -### %s 2>&1 \
-// RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_SAME_ARCH %s
-// WRAPPER_OPTIONS_SAME_ARCH: clang-linker-wrapper
-// WRAPPER_OPTIONS_SAME_ARCH-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=extraopt_skl1"
-// WRAPPER_OPTIONS_SAME_ARCH-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl2"
 
 /// Verify arch settings for nvptx and amdgcn targets
 // RUN: %clangxx -fsycl -### -fsycl-targets=amdgcn-amd-amdhsa -fno-sycl-libspirv \

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -155,17 +155,43 @@
 // WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown=-backend-gen-opt"
 // WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--device-compiler=sycl:spir64_x86_64-unknown-unknown=-backend-cpu-opt"
 
-/// Test that -Xsycl-target-backend and -Xsycl-target-linker options for an
-/// AOT (ocloc) target are forwarded via --device-compiler=/--device-linker=
-/// respectively, each token as its own argument, the same as for JIT
-/// targets.
+/// -Xsycl-target-backend/-Xsycl-target-linker forward to
+/// --device-compiler=/--device-linker= one token per occurrence; per-arch
+/// routing rides on a "/<arch>" qualifier appended to the triple key.
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -fsycl-targets=intel_gpu_pvc \
 // RUN:          -Xsycl-target-backend -opt1 -Xsycl-target-linker -opt2 \
 // RUN:          -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_AOT_SEPARATE %s
-// WRAPPER_OPTIONS_AOT_SEPARATE: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64_gen-unknown-unknown=-opt1"
-// WRAPPER_OPTIONS_AOT_SEPARATE-SAME: "--device-linker=sycl:spir64_gen-unknown-unknown=-opt2"
+// WRAPPER_OPTIONS_AOT_SEPARATE: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-opt1"
+// WRAPPER_OPTIONS_AOT_SEPARATE-SAME: "--device-linker=sycl:spir64_gen-unknown-unknown/pvc=-opt2"
+
+/// Two spir64_gen sub-targets on the same triple: each arch's tokens
+/// carry their own "/<arch>" qualifier so options don't cross-contaminate.
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
+// RUN:          -fsycl-targets=spir64_gen,intel_gpu_skl \
+// RUN:          -Xsycl-target-backend=spir64_gen "-device pvc -options -extraopt_pvc" \
+// RUN:          -Xsycl-target-backend=intel_gpu_skl "-options -extraopt_skl" \
+// RUN:          -### %s 2>&1 \
+// RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_MULTI_GEN %s
+// WRAPPER_OPTIONS_MULTI_GEN: clang-linker-wrapper
+// WRAPPER_OPTIONS_MULTI_GEN-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_pvc"
+// WRAPPER_OPTIONS_MULTI_GEN-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl"
+// WRAPPER_OPTIONS_MULTI_GEN-NOT: "--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_skl"
+// WRAPPER_OPTIONS_MULTI_GEN-NOT: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_pvc"
+
+/// Aliased-target case: intel_gpu_skl and raw spir64_gen "-device skl ..."
+/// name the same arch. Their per-target options must merge into the same
+/// /skl bucket rather than land under different keys or drop each other.
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
+// RUN:          -fsycl-targets=spir64_gen,intel_gpu_skl \
+// RUN:          -Xsycl-target-backend=spir64_gen "-device skl -options extraopt_skl1" \
+// RUN:          -Xsycl-target-backend=intel_gpu_skl "-options -extraopt_skl2" \
+// RUN:          -### %s 2>&1 \
+// RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_SAME_ARCH %s
+// WRAPPER_OPTIONS_SAME_ARCH: clang-linker-wrapper
+// WRAPPER_OPTIONS_SAME_ARCH-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=extraopt_skl1"
+// WRAPPER_OPTIONS_SAME_ARCH-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl2"
 
 /// Verify arch settings for nvptx and amdgcn targets
 // RUN: %clangxx -fsycl -### -fsycl-targets=amdgcn-amd-amdhsa -fno-sycl-libspirv \

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -180,6 +180,19 @@
 // WRAPPER_OPTIONS_MULTI_GEN-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_pvc"
 // WRAPPER_OPTIONS_MULTI_GEN-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl"
 
+/// spir64_gen + intel_gpu_* aliases to the same arch. FIXME: raw spir64_gen
+/// "-device X" tokens are dropped for now; follow-up will merge them onto /X=.
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
+// RUN:          -fsycl-targets=spir64_gen,intel_gpu_skl \
+// RUN:          -Xsycl-target-backend=spir64_gen "-device skl -DSKL1" \
+// RUN:          -Xsycl-target-backend=intel_gpu_skl -DSKL2 \
+// RUN:          -### %s 2>&1 \
+// RUN:   | FileCheck --implicit-check-not='/pvc=' \
+// RUN:               --implicit-check-not='/dg1=' \
+// RUN:               -check-prefix WRAPPER_OPTIONS_GEN_ALIAS %s
+// WRAPPER_OPTIONS_GEN_ALIAS: clang-linker-wrapper
+// WRAPPER_OPTIONS_GEN_ALIAS-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-DSKL2"
+
 /// Verify arch settings for nvptx and amdgcn targets
 // RUN: %clangxx -fsycl -### -fsycl-targets=amdgcn-amd-amdhsa -fno-sycl-libspirv \
 // RUN:          -nocudalib --offload-new-driver --sysroot=%S/Inputs/SYCL \

--- a/clang/test/Driver/sycl-offload-new-driver.cpp
+++ b/clang/test/Driver/sycl-offload-new-driver.cpp
@@ -144,54 +144,42 @@
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_LINK %s
 // WRAPPER_OPTIONS_LINK: clang-linker-wrapper{{.*}} "--device-linker=sycl:spir64-unknown-unknown=-link-opt"
 
-/// Test option passing behavior for clang-offload-wrapper options for AOT.
+/// AOT: -Xsycl-target-backend tokens ride the packager's per-image
+/// compile-opts=/link-opts= (one image per fsycl-target entry, one
+/// ocloc/opencl-aot call per image).
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -fsycl-targets=spir64_gen,spir64_x86_64 \
 // RUN:          -Xsycl-target-backend=spir64_gen -backend-gen-opt \
 // RUN:          -Xsycl-target-backend=spir64_x86_64 -backend-cpu-opt \
 // RUN:          -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_BACKEND_AOT %s
-// WRAPPER_OPTIONS_BACKEND_AOT: clang-linker-wrapper{{.*}}  "--host-triple=x86_64-unknown-linux-gnu"
-// WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown=-backend-gen-opt"
-// WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--device-compiler=sycl:spir64_x86_64-unknown-unknown=-backend-cpu-opt"
+// WRAPPER_OPTIONS_BACKEND_AOT: llvm-offload-binary
+// WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--image={{[^"]*}}triple=spir64_gen-unknown-unknown{{[^"]*}}compile-opts={{[^"]*}}-backend-gen-opt
+// WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--image={{[^"]*}}triple=spir64_x86_64-unknown-unknown{{[^"]*}}compile-opts={{[^"]*}}-backend-cpu-opt
 
-/// -Xsycl-target-backend/-Xsycl-target-linker forward to
-/// --device-compiler=/--device-linker= one token per occurrence; per-arch
-/// routing rides on a "/<arch>" qualifier appended to the triple key.
+/// Single AOT entry: compile-opts= carries -Xsycl-target-backend and
+/// link-opts= carries -Xsycl-target-linker.
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -fsycl-targets=intel_gpu_pvc \
 // RUN:          -Xsycl-target-backend -opt1 -Xsycl-target-linker -opt2 \
 // RUN:          -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_AOT_SEPARATE %s
-// WRAPPER_OPTIONS_AOT_SEPARATE: clang-linker-wrapper{{.*}} "--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-opt1"
-// WRAPPER_OPTIONS_AOT_SEPARATE-SAME: "--device-linker=sycl:spir64_gen-unknown-unknown/pvc=-opt2"
+// WRAPPER_OPTIONS_AOT_SEPARATE: llvm-offload-binary
+// WRAPPER_OPTIONS_AOT_SEPARATE-SAME: "--image={{[^"]*}}arch=pvc{{[^"]*}}compile-opts={{[^"]*}}-opt1{{[^"]*}}link-opts=-opt2
 
-/// Two spir64_gen sub-targets on the same triple: each arch's tokens
-/// carry their own "/<arch>" qualifier so options don't cross-contaminate.
+/// Two disjoint intel_gpu_* archs: each image's compile-opts= only carries
+/// tokens for its own fsycl-target entry (no cross-arch leak).
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
 // RUN:          -fsycl-targets=intel_gpu_pvc,intel_gpu_skl \
 // RUN:          -Xsycl-target-backend=intel_gpu_pvc "-options -extraopt_pvc" \
 // RUN:          -Xsycl-target-backend=intel_gpu_skl "-options -extraopt_skl" \
 // RUN:          -### %s 2>&1 \
-// RUN:   | FileCheck --implicit-check-not='/pvc=-extraopt_skl' \
-// RUN:               --implicit-check-not='/skl=-extraopt_pvc' \
+// RUN:   | FileCheck --implicit-check-not='arch=pvc{{[^"]*}}-extraopt_skl' \
+// RUN:               --implicit-check-not='arch=skl{{[^"]*}}-extraopt_pvc' \
 // RUN:               -check-prefix WRAPPER_OPTIONS_MULTI_GEN %s
-// WRAPPER_OPTIONS_MULTI_GEN: clang-linker-wrapper
-// WRAPPER_OPTIONS_MULTI_GEN-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_pvc"
-// WRAPPER_OPTIONS_MULTI_GEN-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl"
-
-/// spir64_gen + intel_gpu_* aliases to the same arch. FIXME: raw spir64_gen
-/// "-device X" tokens are dropped for now; follow-up will merge them onto /X=.
-// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver --sysroot=%S/Inputs/SYCL \
-// RUN:          -fsycl-targets=spir64_gen,intel_gpu_skl \
-// RUN:          -Xsycl-target-backend=spir64_gen "-device skl -DSKL1" \
-// RUN:          -Xsycl-target-backend=intel_gpu_skl -DSKL2 \
-// RUN:          -### %s 2>&1 \
-// RUN:   | FileCheck --implicit-check-not='/pvc=' \
-// RUN:               --implicit-check-not='/dg1=' \
-// RUN:               -check-prefix WRAPPER_OPTIONS_GEN_ALIAS %s
-// WRAPPER_OPTIONS_GEN_ALIAS: clang-linker-wrapper
-// WRAPPER_OPTIONS_GEN_ALIAS-SAME: "--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-DSKL2"
+// WRAPPER_OPTIONS_MULTI_GEN: llvm-offload-binary
+// WRAPPER_OPTIONS_MULTI_GEN-SAME: "--image={{[^"]*}}arch=pvc{{[^"]*}}compile-opts={{[^"]*}}-options -extraopt_pvc
+// WRAPPER_OPTIONS_MULTI_GEN-SAME: "--image={{[^"]*}}arch=skl{{[^"]*}}compile-opts={{[^"]*}}-options -extraopt_skl
 
 /// Verify arch settings for nvptx and amdgcn targets
 // RUN: %clangxx -fsycl -### -fsycl-targets=amdgcn-amd-amdhsa -fno-sycl-libspirv \

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -2569,12 +2569,11 @@ DerivedArgList getLinkerArgs(ArrayRef<OffloadFile> Input,
   if (llvm::all_of(Input, ContainsBitcode))
     DAL.AddFlagArg(nullptr, Tbl.getOption(OPT_whole_program));
 
-  // This function filters the SYCL device compiler, linker, sycl-post-link,
-  // llvm-spirv and spirv-to-ir-wrapper options by target triple and offload
-  // kind. The options accept values in the form [<kind>:][<triple>=]<value>.
-  // An example of passing such an option to clang-linker-wrapper is:
-  // --device-compiler=sycl:spir64_gen-unknown-unknown=opt_val.
+  // Filter by kind, triple, and optional /<arch> qualifier on the key.
+  // Format: [<kind>:][<triple>[/<arch>]=]<value>. Entries without /<arch>
+  // apply to every arch of the matching triple.
   const StringRef TripleStr = DAL.getLastArgValue(OPT_triple_EQ);
+  const StringRef ArchStr = DAL.getLastArgValue(OPT_arch_EQ);
   auto ProcessDeviceArgs = [&](llvm::opt::OptSpecifier DeviceArgsOptionID,
                                llvm::opt::OptSpecifier ForwardedOptionID) {
     for (StringRef DeviceArgValue : Args.getAllArgValues(DeviceArgsOptionID)) {
@@ -2587,11 +2586,14 @@ DerivedArgList getLinkerArgs(ArrayRef<OffloadFile> Input,
       }
       size_t EqPos = DeviceArgValue.find('=');
       if (EqPos != StringRef::npos) {
-        StringRef ArgTargetTripleStr = DeviceArgValue.take_front(EqPos);
+        StringRef Key = DeviceArgValue.take_front(EqPos);
+        auto [ArgTargetTripleStr, ArgArchStr] = Key.split('/');
         llvm::Triple ArgTargetTriple(ArgTargetTripleStr);
         // If this isn't a recognized triple then it's an `arg=value` option.
         if (ArgTargetTriple.getArch() != Triple::ArchType::UnknownArch) {
           if (ArgTargetTripleStr != TripleStr)
+            continue;
+          if (!ArgArchStr.empty() && ArgArchStr != ArchStr)
             continue;
           DeviceArgValue = DeviceArgValue.drop_front(EqPos + 1);
         }

--- a/sycl/doc/design/OffloadDesign.md
+++ b/sycl/doc/design/OffloadDesign.md
@@ -256,27 +256,33 @@ model's usage pattern. This will be implemented by invoking `clang-linker-wrappe
 TU's device code independently, embedding the result directly into the host object.
 
 #### Format of the --device-compiler Option
-The `--device-compiler` option uses the format `--device-compiler=[<kind>:][<triple>=]<value>` where:
+The `--device-compiler` option uses the format `--device-compiler=[<kind>:][<triple>[/<arch>]=]<value>` where:
 - `<kind>` : specifies the offloading kind (e.g., sycl, hip, openmp) and is optional.
 - `<triple>` : specifies the target triple (e.g., `spir64_gen-unknown-unknown`, `spir64_x86_64-unknown-unknown`) and is optional.
-- `<value>` : contains the arguments to be passed to the backend compiler.
+- `<arch>` : optional architecture qualifier appended to the triple after a `/`. Used for `spir64_gen`, where a single triple may back several GPU architectures.
+- `<value>` : one option token to be passed to the backend compiler. Each `--device-compiler` occurrence carries a single token; multi-token option strings are emitted as multiple `--device-compiler` occurrences with the same key.
 
-In clang-linker-wrapper, the `<kind>` and `<triple>` are matched against the current compilation target. Only arguments that match both the offloading kind and target triple will be passed to the backend compiler. If `<kind>` is not specified, the arguments will match any offloading kind; if `<triple>` is not specified, the arguments will match any target triple; and if neither is specified, the arguments will be applied to all targets. 
+In clang-linker-wrapper, the `<kind>`, `<triple>`, and `<arch>` are matched against the current compilation target. Only arguments that match all specified filters are forwarded to the backend compiler. If `<kind>` is not specified, the arguments will match any offloading kind; if `<triple>` is not specified, the arguments will match any target triple; if `<arch>` is not specified, the arguments will match every architecture of the matching triple.
 
-To support multiple device architectures, a new `--device-compiler` option must be specified for each device. For example, to compile for Ponte Vecchio (PVC) and Skylake (SKL) architectures and put them in a fat binary, the user must add the following two `--device-compiler` options:
+To supply per-architecture backend options, emit a separate `--device-compiler` occurrence for each `(triple, arch)` pair and for each option token. For example, to build for Ponte Vecchio (PVC) and Skylake (SKL) architectures and put them in a fat binary, the driver emits one `--device-compiler` occurrence per token per arch:
 
-`--device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options ...`
+```
+--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-options
+--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-cl-mad-enable
+--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-options
+--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-cl-unsafe-math-optimizations
+```
 
-`--device-compiler=sycl:spir64_gen-unknown-unknown=-device skl -options ...`
+Here is an example of a clang-linker-wrapper invocation where the user wants to create a fat binary with PVC and SKL architectures to run on an x86_64 Linux host. For SKL they want aggressive floating-point relaxation (`-cl-unsafe-math-optimizations`); for PVC they want multiply-and-add fusion (`-cl-mad-enable`). The source binaries are called `host.o` and `kernel.o` and the output should be called `out.exe`.
 
-Device specific options for each of the device architectures should be specified after `-device <name>`.
-
-Here is an example of a clang-linker-wrapper invocation where ther user wants to create a fat binary with PVC and SKL architectures to be run on a x86_64 Linux host. In addition, they would like to enable aggressive mathematical optimizations and are tolerant for slightly imprecise floating-point values just for SKL, that is, use the `-cl-unsafe-math-optimizations` flag. For PVC, they would like to enable the multiply and add instruction usage (`-cl-mad-enable`). The source binaries are called host.o and kernel.o and the output should be called out.exe.
-
-`clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu
- --device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options "-cl-mad-enable"
- --device-compiler=sycl:spir64_gen-unknown-unknown=-device skl -options "-cl-unsafe-math-optimizations" -- /usr/bin/ld
-host.o kernel.o -o out.exe`
+```
+clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu \
+  --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-options \
+  --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-cl-mad-enable \
+  --device-compiler=sycl:spir64_gen-unknown-unknown/skl=-options \
+  --device-compiler=sycl:spir64_gen-unknown-unknown/skl=-cl-unsafe-math-optimizations \
+  -- /usr/bin/ld host.o kernel.o -o out.exe
+```
 
 #### Other Supported Options
 To complete the support needed for the various targets using the
@@ -316,19 +322,21 @@ list to be passed along.
 
 *Example: spir64_gen enabling options*
 
-> "--device-compiler=sycl:spir64_gen-unknown-unknown=-device pvc -options extraopt_pvc"
-"--device-compiler=sycl:spir64_gen-unknown-unknown=-options -extraopt_skl"
+> --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-device
+--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=pvc
+--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-options
+--device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_pvc
+--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-options
+--device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl
 
 *Example: clang-linker-wrapper options*
 
-Each OCLOC call will be represented as a separate device binary that is
-individually wrapped and linked into the final executable.
-
-Additionally, the syntax can be expanded to enable the ability to pass specific
-options to a specific device GPU target for spir64_gen.  The syntax will
-resemble `--device-compiler=sycl:spir64_gen-unknown-unknown=<arch> <arg>`.  This corresponds to the existing
-option syntax of `-fsycl-targets=intel_gpu_arch` where `arch` can be a fixed
-set of targets.
+Each `(triple, arch)` pair produces its own OCLOC call and its own device
+binary that is individually wrapped and linked into the final executable. The
+`/<arch>` qualifier on the key routes each option token to the ocloc
+invocation for that arch; a `--device-compiler` occurrence with no
+`/<arch>` (or from a non-gen triple) applies to every arch of the matching
+triple.
 
 #### --offload-arch
 

--- a/sycl/doc/design/OffloadDesign.md
+++ b/sycl/doc/design/OffloadDesign.md
@@ -303,40 +303,31 @@ that may be useful for our usage.
 
 Compilation behaviors involving AOT for GPU involve an additional call to
 the OpenCL Offline compiler (OCLOC).  This call occurs after the post-link
-step performed by `sycl-post-link` and the SPIR-V translation step which is done
-by `llvm-spirv`.  Additional options passed by the user via the
-`-Xsycl-target-backend=spir64_gen <opts>` command as well as the implied
-options set via target options such as `-fsycl-targets=intel_gpu_skl`
-will be processed by a new options to the wrapper, `--gpu-tool-arg=<arg>`
+step performed by `sycl-post-link` and the SPIR-V translation step which is
+done by `llvm-spirv`.  User options from `-Xsycl-target-backend=<triple> <opts>`
+and the implied options for `-fsycl-targets=intel_gpu_<arch>` are forwarded to
+the wrapper as `--device-compiler=[<kind>:][<triple>[/<arch>]=]<value>` (one
+occurrence per token).  For the `spir64_gen` triple, the `/<arch>` qualifier
+routes each token to the OCLOC invocation for that arch, so per-arch options
+do not leak between archs.  A `--device-compiler` occurrence with no
+`/<arch>` (or from a non-gen triple) applies to every arch of the matching
+triple.
 
-To support multiple target specifications, for instance:
-`-fsycl-targets=intel_gpu_skl,intel_gpu_pvc`, multiple `--gpu-tool-arg`
-options can be passed on the command line.  Each instance will be considered
-a separate OCLOC call passing along the `<args>` as options to the OCLOC call.
-The compiler driver will be responsible for putting together the full option
-list to be passed along.
+*Example:*
 
-> -fsycl -fsycl-targets=spir64_gen,intel_gpu_skl
--Xsycl-target-backend=spir64_gen "-device pvc -options -extraopt_pvc"
+> -fsycl -fsycl-targets=intel_gpu_pvc,intel_gpu_skl
+-Xsycl-target-backend=intel_gpu_pvc "-options -extraopt_pvc"
 -Xsycl-target-backend=intel_gpu_skl "-options -extraopt_skl"
 
-*Example: spir64_gen enabling options*
+produces:
 
-> --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-device
---device-compiler=sycl:spir64_gen-unknown-unknown/pvc=pvc
---device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-options
+> --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-options
 --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_pvc
 --device-compiler=sycl:spir64_gen-unknown-unknown/skl=-options
 --device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl
 
-*Example: clang-linker-wrapper options*
-
 Each `(triple, arch)` pair produces its own OCLOC call and its own device
-binary that is individually wrapped and linked into the final executable. The
-`/<arch>` qualifier on the key routes each option token to the ocloc
-invocation for that arch; a `--device-compiler` occurrence with no
-`/<arch>` (or from a non-gen triple) applies to every arch of the matching
-triple.
+binary that is individually wrapped and linked into the final executable.
 
 #### --offload-arch
 

--- a/sycl/doc/design/OffloadDesign.md
+++ b/sycl/doc/design/OffloadDesign.md
@@ -107,8 +107,9 @@ to be taken.
 For example, when an embedded device binary is of the `OFK_SYCL` kind and of
 the `spir64_gen` architecture triple, the resulting extracted binary is linked,
 post-link processed and converted to SPIR-V before being passed to `ocloc` to
-generate the final device binary.  Options passed via `--device-compiler=sycl:spir64_gen-unknown-unknown=<arg>` will
-be applied to the `ocloc` step as well.
+generate the final device binary.  Options for the `ocloc` step ride on the
+image's `compile-opts=`/`link-opts=` metadata (one image per `-fsycl-targets`
+entry, one `ocloc` call per image).
 
 Binaries generated during the offload compilation will be 'bundled' together
 to create a conglomerate fat binary.  Depending on the type of binary, the
@@ -231,15 +232,15 @@ compiler that is used to create the target device image.  It is expected that
 the offline compiler will also use unique command lines specific to the tool
 to create the image.
 
-To support the needed option passing triggered by use of the
-`-Xsycl-target-backend` option and implied options based on the optional
-device behaviors for AOT compilations for GPU and CPU, new command line interfaces
-are needed to pass along this information.
+For AOT targets, options from `-Xsycl-target-backend` and implied device
+options are embedded per image via the packager's `compile-opts=` /
+`link-opts=` metadata. The wrapper reads that metadata off each `--image=`
+entry and hands it to the offline tool below.
 
-| Target | Triple        | Offline Tool   | Option for Additional Args                                       |
-|--------|---------------|----------------|------------------------------------------------------------------|
-| CPU    | spir64_x86_64 | opencl-aot     | `--device-compiler=sycl:spir64_x86_64-unknown-unknown=<arg>`     |
-| GPU    | spir64_gen    | ocloc          | `--device-compiler=sycl:spir64_gen-unknown-unknown=<arg>`        |
+| Target | Triple        | Offline Tool |
+|--------|---------------|--------------|
+| CPU    | spir64_x86_64 | opencl-aot   |
+| GPU    | spir64_gen    | ocloc        |
 
 *Table: Ahead of Time Info*
 
@@ -256,33 +257,10 @@ model's usage pattern. This will be implemented by invoking `clang-linker-wrappe
 TU's device code independently, embedding the result directly into the host object.
 
 #### Format of the --device-compiler Option
-The `--device-compiler` option uses the format `--device-compiler=[<kind>:][<triple>[/<arch>]=]<value>` where:
-- `<kind>` : specifies the offloading kind (e.g., sycl, hip, openmp) and is optional.
-- `<triple>` : specifies the target triple (e.g., `spir64_gen-unknown-unknown`, `spir64_x86_64-unknown-unknown`) and is optional.
-- `<arch>` : optional architecture qualifier appended to the triple after a `/`. Used for `spir64_gen`, where a single triple may back several GPU architectures.
-- `<value>` : one option token to be passed to the backend compiler. Each `--device-compiler` occurrence carries a single token; multi-token option strings are emitted as multiple `--device-compiler` occurrences with the same key.
-
-In clang-linker-wrapper, the `<kind>`, `<triple>`, and `<arch>` are matched against the current compilation target. Only arguments that match all specified filters are forwarded to the backend compiler. If `<kind>` is not specified, the arguments will match any offloading kind; if `<triple>` is not specified, the arguments will match any target triple; if `<arch>` is not specified, the arguments will match every architecture of the matching triple.
-
-To supply per-architecture backend options, emit a separate `--device-compiler` occurrence for each `(triple, arch)` pair and for each option token. For example, to build for Ponte Vecchio (PVC) and Skylake (SKL) architectures and put them in a fat binary, the driver emits one `--device-compiler` occurrence per token per arch:
-
-```
---device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-options
---device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-cl-mad-enable
---device-compiler=sycl:spir64_gen-unknown-unknown/skl=-options
---device-compiler=sycl:spir64_gen-unknown-unknown/skl=-cl-unsafe-math-optimizations
-```
-
-Here is an example of a clang-linker-wrapper invocation where the user wants to create a fat binary with PVC and SKL architectures to run on an x86_64 Linux host. For SKL they want aggressive floating-point relaxation (`-cl-unsafe-math-optimizations`); for PVC they want multiply-and-add fusion (`-cl-mad-enable`). The source binaries are called `host.o` and `kernel.o` and the output should be called `out.exe`.
-
-```
-clang-linker-wrapper --host-triple=x86_64-unknown-linux-gnu \
-  --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-options \
-  --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-cl-mad-enable \
-  --device-compiler=sycl:spir64_gen-unknown-unknown/skl=-options \
-  --device-compiler=sycl:spir64_gen-unknown-unknown/skl=-cl-unsafe-math-optimizations \
-  -- /usr/bin/ld host.o kernel.o -o out.exe
-```
+The `--device-compiler` option uses the format `--device-compiler=[<kind>:][<triple>=]<value>` where:
+- `<kind>` : optional offloading kind (e.g. `sycl`, `hip`, `openmp`).
+- `<triple>` : optional target triple. For SYCL this is only used for JIT triples (`spir64`, `spirv64`); AOT triples (`spir64_gen`, `spir64_x86_64`) route their backend options via per-image `compile-opts=` metadata instead (see below).
+- `<value>` : one option token passed to the backend compiler. Multi-token strings emit multiple `--device-compiler` occurrences with the same key.
 
 #### Other Supported Options
 To complete the support needed for the various targets using the
@@ -301,17 +279,13 @@ that may be useful for our usage.
 
 #### spir64_gen support
 
-Compilation behaviors involving AOT for GPU involve an additional call to
-the OpenCL Offline compiler (OCLOC).  This call occurs after the post-link
-step performed by `sycl-post-link` and the SPIR-V translation step which is
-done by `llvm-spirv`.  User options from `-Xsycl-target-backend=<triple> <opts>`
-and the implied options for `-fsycl-targets=intel_gpu_<arch>` are forwarded to
-the wrapper as `--device-compiler=[<kind>:][<triple>[/<arch>]=]<value>` (one
-occurrence per token).  For the `spir64_gen` triple, the `/<arch>` qualifier
-routes each token to the OCLOC invocation for that arch, so per-arch options
-do not leak between archs.  A `--device-compiler` occurrence with no
-`/<arch>` (or from a non-gen triple) applies to every arch of the matching
-triple.
+Compilation involving AOT for GPU calls OCLOC after `sycl-post-link` /
+`llvm-spirv`. Each `-fsycl-targets` entry produces one image, one OCLOC
+invocation. User options from `-Xsycl-target-backend=<entry> <opts>` ride on
+that image's `compile-opts=` metadata (embedded in the packager `--image=`
+argument), so per-entry options never leak across images. When two entries
+resolve to the same arch (e.g. `spir64_gen "-device skl"` and `intel_gpu_skl`)
+they remain separate images with separate OCLOC calls.
 
 *Example:*
 
@@ -319,15 +293,12 @@ triple.
 -Xsycl-target-backend=intel_gpu_pvc "-options -extraopt_pvc"
 -Xsycl-target-backend=intel_gpu_skl "-options -extraopt_skl"
 
-produces:
+produces two packager `--image=` entries:
 
-> --device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-options
---device-compiler=sycl:spir64_gen-unknown-unknown/pvc=-extraopt_pvc
---device-compiler=sycl:spir64_gen-unknown-unknown/skl=-options
---device-compiler=sycl:spir64_gen-unknown-unknown/skl=-extraopt_skl
+> --image=file=...pvc.bc,triple=spir64_gen-unknown-unknown,arch=pvc,kind=sycl,compile-opts=-options -extraopt_pvc
+--image=file=...skl.bc,triple=spir64_gen-unknown-unknown,arch=skl,kind=sycl,compile-opts=-options -extraopt_skl
 
-Each `(triple, arch)` pair produces its own OCLOC call and its own device
-binary that is individually wrapped and linked into the final executable.
+each of which produces its own OCLOC call and its own device binary.
 
 #### --offload-arch
 
@@ -457,8 +428,9 @@ Compilation behaviors involving AOT for CPU involve an additional call to
 `opencl-aot`.  This call occurs after the post-link step performed by
 `sycl-post-link` and the SPIR-V translation step performed by `llvm-spirv`.
 Additional options passed by the user via the
-`-Xsycl-target-backend=spir64_x86_64 <opts>` command will be processed by a new
-option to the wrapper, `--device-compiler=sycl:spir64_x86_64-unknown-unknown=<arg>`
+`-Xsycl-target-backend=spir64_x86_64 <opts>` command ride on the image's
+`compile-opts=`/`link-opts=` metadata (one image per `-fsycl-targets` entry,
+one `opencl-aot` call per image).
 
 Similar to SYCL offloading to Intel GPUs using `--offload-arch`, SYCL AOT for Intel CPUs
 will also leverage the `--offload-arch` option.

--- a/sycl/test-e2e/NewOffloadDriver/per-arch-backend-options.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/per-arch-backend-options.cpp
@@ -5,21 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// End-to-end test: build a SYCL program AOT-compiled for two Intel GPU archs
-// (pvc + dg2_g10) with distinct -Xsycl-target-backend options for each, and
-// verify that:
-//   1. The driver emits per-(triple, arch) --device-compiler entries and
-//      the wrapper routes each arch's tokens to its own ocloc invocation
-//      (compile-time check on -v output).
-//   2. The resulting fat binary runs correctly on a matching device
-//      (runtime check).
+// Build-only test that -Xsycl-target-backend options for two AOT Intel GPU
+// archs (pvc + dg2_g10) reach only their own arch's ocloc invocation.
 
-// REQUIRES: ocloc, target-spir
-// REQUIRES: arch-intel_gpu_pvc
-// One physical arch (pvc) is required so %{run} has an AOT image matching
-// the local device. The second arch (dg2_g10) is a build-only target that
-// exercises the routing logic; ocloc builds its image but the runtime never
-// executes it.
+// REQUIRES: ocloc
 
 // RUN: %clangxx -Wno-error=unused-command-line-argument \
 // RUN:   --offload-new-driver -fsycl \
@@ -27,17 +16,14 @@
 // RUN:   -Xsycl-target-backend=intel_gpu_pvc "-options -cl-mad-enable" \
 // RUN:   -Xsycl-target-backend=intel_gpu_dg2_g10 "-options -cl-unsafe-math-optimizations" \
 // RUN:   -v %s -o %t.out > %t.log 2>&1
-// RUN: FileCheck --input-file=%t.log --check-prefix=CHECK-PVC %s
-// RUN: FileCheck --input-file=%t.log --check-prefix=CHECK-ACM %s
-// RUN: %{run} %t.out
+// RUN: FileCheck --input-file=%t.log --check-prefix=CHECK-PVC \
+// RUN:   --implicit-check-not='-device pvc {{.*}}-cl-unsafe-math-optimizations' %s
+// RUN: FileCheck --input-file=%t.log --check-prefix=CHECK-ACM \
+// RUN:   --implicit-check-not='-device acm_g10 {{.*}}-cl-mad-enable' %s
 
-// pvc's ocloc call carries -cl-mad-enable, NOT -cl-unsafe-math-optimizations.
 // CHECK-PVC: ocloc{{.*}} -device pvc {{.*}}-cl-mad-enable
-// CHECK-PVC-NOT: ocloc{{.*}} -device pvc {{.*}}-cl-unsafe-math-optimizations
-
 // dg2_g10's canonical ocloc device name is acm_g10.
 // CHECK-ACM: ocloc{{.*}} -device acm_g10 {{.*}}-cl-unsafe-math-optimizations
-// CHECK-ACM-NOT: ocloc{{.*}} -device acm_g10 {{.*}}-cl-mad-enable
 
 // Regression: raw spir64_gen with an embedded "-device <arch>" in the
 // backend option value must also route per-arch without leakage.
@@ -47,56 +33,20 @@
 // RUN:   -Xsycl-target-backend=spir64_gen "-device pvc -options -cl-mad-enable" \
 // RUN:   -Xsycl-target-backend=intel_gpu_dg2_g10 "-options -cl-unsafe-math-optimizations" \
 // RUN:   -v %s -o %t_raw.out > %t_raw.log 2>&1
-// RUN: FileCheck --input-file=%t_raw.log --check-prefix=CHECK-RAW-PVC %s
-// RUN: FileCheck --input-file=%t_raw.log --check-prefix=CHECK-RAW-ACM %s
+// RUN: FileCheck --input-file=%t_raw.log --check-prefix=CHECK-RAW-PVC \
+// RUN:   --implicit-check-not='-device pvc {{.*}}-cl-unsafe-math-optimizations' %s
+// RUN: FileCheck --input-file=%t_raw.log --check-prefix=CHECK-RAW-ACM \
+// RUN:   --implicit-check-not='-device acm_g10 {{.*}}-cl-mad-enable' %s
 
 // CHECK-RAW-PVC: ocloc{{.*}} -device pvc {{.*}}-cl-mad-enable
-// CHECK-RAW-PVC-NOT: ocloc{{.*}} -device pvc {{.*}}-cl-unsafe-math-optimizations
 // CHECK-RAW-ACM: ocloc{{.*}} -device acm_g10 {{.*}}-cl-unsafe-math-optimizations
-// CHECK-RAW-ACM-NOT: ocloc{{.*}} -device acm_g10 {{.*}}-cl-mad-enable
 
 #include <sycl/detail/core.hpp>
 
-#include <array>
-#include <cstddef>
-#include <iostream>
-
-constexpr std::size_t N = 16;
-
-class VecAdd;
-
 int main() {
-  std::array<int, N> a{}, b{}, c{};
-  for (std::size_t i = 0; i < N; ++i) {
-    a[i] = static_cast<int>(i);
-    b[i] = static_cast<int>(2 * i);
-  }
-
-  {
-    sycl::queue q;
-    sycl::buffer<int, 1> bufA{a.data(), sycl::range<1>{N}};
-    sycl::buffer<int, 1> bufB{b.data(), sycl::range<1>{N}};
-    sycl::buffer<int, 1> bufC{c.data(), sycl::range<1>{N}};
-
-    q.submit([&](sycl::handler &h) {
-       sycl::accessor accA{bufA, h, sycl::read_only};
-       sycl::accessor accB{bufB, h, sycl::read_only};
-       sycl::accessor accC{bufC, h, sycl::write_only};
-       h.parallel_for<VecAdd>(sycl::range<1>{N}, [=](sycl::id<1> i) {
-         accC[i] = accA[i] + accB[i];
-       });
-     }).wait();
-  }
-
-  for (std::size_t i = 0; i < N; ++i) {
-    int expected = static_cast<int>(i) + static_cast<int>(2 * i);
-    if (c[i] != expected) {
-      std::cerr << "FAIL at i=" << i << ": got " << c[i] << ", expected "
-                << expected << "\n";
-      return 1;
-    }
-  }
-
-  std::cout << "PASS\n";
+  sycl::queue q;
+  q.submit([&](sycl::handler &h) {
+    h.parallel_for(sycl::range<1>{1}, [=](sycl::id<1>) {});
+  });
   return 0;
 }

--- a/sycl/test-e2e/NewOffloadDriver/per-arch-backend-options.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/per-arch-backend-options.cpp
@@ -1,0 +1,102 @@
+//==-- per-arch-backend-options.cpp ---------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// End-to-end test: build a SYCL program AOT-compiled for two Intel GPU archs
+// (pvc + dg2_g10) with distinct -Xsycl-target-backend options for each, and
+// verify that:
+//   1. The driver emits per-(triple, arch) --device-compiler entries and
+//      the wrapper routes each arch's tokens to its own ocloc invocation
+//      (compile-time check on -v output).
+//   2. The resulting fat binary runs correctly on a matching device
+//      (runtime check).
+
+// REQUIRES: ocloc, target-spir
+// REQUIRES: arch-intel_gpu_pvc
+// One physical arch (pvc) is required so %{run} has an AOT image matching
+// the local device. The second arch (dg2_g10) is a build-only target that
+// exercises the routing logic; ocloc builds its image but the runtime never
+// executes it.
+
+// RUN: %clangxx -Wno-error=unused-command-line-argument \
+// RUN:   --offload-new-driver -fsycl \
+// RUN:   -fsycl-targets=intel_gpu_pvc,intel_gpu_dg2_g10 \
+// RUN:   -Xsycl-target-backend=intel_gpu_pvc "-options -cl-mad-enable" \
+// RUN:   -Xsycl-target-backend=intel_gpu_dg2_g10 "-options -cl-unsafe-math-optimizations" \
+// RUN:   -v %s -o %t.out > %t.log 2>&1
+// RUN: FileCheck --input-file=%t.log --check-prefix=CHECK-PVC %s
+// RUN: FileCheck --input-file=%t.log --check-prefix=CHECK-ACM %s
+// RUN: %{run} %t.out
+
+// pvc's ocloc call carries -cl-mad-enable, NOT -cl-unsafe-math-optimizations.
+// CHECK-PVC: ocloc{{.*}} -device pvc {{.*}}-cl-mad-enable
+// CHECK-PVC-NOT: ocloc{{.*}} -device pvc {{.*}}-cl-unsafe-math-optimizations
+
+// dg2_g10's canonical ocloc device name is acm_g10.
+// CHECK-ACM: ocloc{{.*}} -device acm_g10 {{.*}}-cl-unsafe-math-optimizations
+// CHECK-ACM-NOT: ocloc{{.*}} -device acm_g10 {{.*}}-cl-mad-enable
+
+// Regression: raw spir64_gen with an embedded "-device <arch>" in the
+// backend option value must also route per-arch without leakage.
+// RUN: %clangxx -Wno-error=unused-command-line-argument \
+// RUN:   --offload-new-driver -fsycl \
+// RUN:   -fsycl-targets=intel_gpu_dg2_g10,spir64_gen \
+// RUN:   -Xsycl-target-backend=spir64_gen "-device pvc -options -cl-mad-enable" \
+// RUN:   -Xsycl-target-backend=intel_gpu_dg2_g10 "-options -cl-unsafe-math-optimizations" \
+// RUN:   -v %s -o %t_raw.out > %t_raw.log 2>&1
+// RUN: FileCheck --input-file=%t_raw.log --check-prefix=CHECK-RAW-PVC %s
+// RUN: FileCheck --input-file=%t_raw.log --check-prefix=CHECK-RAW-ACM %s
+
+// CHECK-RAW-PVC: ocloc{{.*}} -device pvc {{.*}}-cl-mad-enable
+// CHECK-RAW-PVC-NOT: ocloc{{.*}} -device pvc {{.*}}-cl-unsafe-math-optimizations
+// CHECK-RAW-ACM: ocloc{{.*}} -device acm_g10 {{.*}}-cl-unsafe-math-optimizations
+// CHECK-RAW-ACM-NOT: ocloc{{.*}} -device acm_g10 {{.*}}-cl-mad-enable
+
+#include <sycl/detail/core.hpp>
+
+#include <array>
+#include <cstddef>
+#include <iostream>
+
+constexpr std::size_t N = 16;
+
+class VecAdd;
+
+int main() {
+  std::array<int, N> a{}, b{}, c{};
+  for (std::size_t i = 0; i < N; ++i) {
+    a[i] = static_cast<int>(i);
+    b[i] = static_cast<int>(2 * i);
+  }
+
+  {
+    sycl::queue q;
+    sycl::buffer<int, 1> bufA{a.data(), sycl::range<1>{N}};
+    sycl::buffer<int, 1> bufB{b.data(), sycl::range<1>{N}};
+    sycl::buffer<int, 1> bufC{c.data(), sycl::range<1>{N}};
+
+    q.submit([&](sycl::handler &h) {
+       sycl::accessor accA{bufA, h, sycl::read_only};
+       sycl::accessor accB{bufB, h, sycl::read_only};
+       sycl::accessor accC{bufC, h, sycl::write_only};
+       h.parallel_for<VecAdd>(sycl::range<1>{N}, [=](sycl::id<1> i) {
+         accC[i] = accA[i] + accB[i];
+       });
+     }).wait();
+  }
+
+  for (std::size_t i = 0; i < N; ++i) {
+    int expected = static_cast<int>(i) + static_cast<int>(2 * i);
+    if (c[i] != expected) {
+      std::cerr << "FAIL at i=" << i << ": got " << c[i] << ", expected "
+                << expected << "\n";
+      return 1;
+    }
+  }
+
+  std::cout << "PASS\n";
+  return 0;
+}

--- a/sycl/test-e2e/NewOffloadDriver/per-arch-backend-options.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/per-arch-backend-options.cpp
@@ -17,29 +17,13 @@
 // RUN:   -Xsycl-target-backend=intel_gpu_dg2_g10 "-options -cl-unsafe-math-optimizations" \
 // RUN:   -v %s -o %t.out > %t.log 2>&1
 // RUN: FileCheck --input-file=%t.log --check-prefix=CHECK-PVC \
-// RUN:   --implicit-check-not='-device pvc {{.*}}-cl-unsafe-math-optimizations' %s
+// RUN:   --implicit-check-not='ocloc{{.*}} -device pvc {{.*}}-cl-unsafe-math-optimizations' %s
 // RUN: FileCheck --input-file=%t.log --check-prefix=CHECK-ACM \
 // RUN:   --implicit-check-not='-device acm_g10 {{.*}}-cl-mad-enable' %s
 
 // CHECK-PVC: ocloc{{.*}} -device pvc {{.*}}-cl-mad-enable
 // dg2_g10's canonical ocloc device name is acm_g10.
 // CHECK-ACM: ocloc{{.*}} -device acm_g10 {{.*}}-cl-unsafe-math-optimizations
-
-// Regression: raw spir64_gen with an embedded "-device <arch>" in the
-// backend option value must also route per-arch without leakage.
-// RUN: %clangxx -Wno-error=unused-command-line-argument \
-// RUN:   --offload-new-driver -fsycl \
-// RUN:   -fsycl-targets=intel_gpu_dg2_g10,spir64_gen \
-// RUN:   -Xsycl-target-backend=spir64_gen "-device pvc -options -cl-mad-enable" \
-// RUN:   -Xsycl-target-backend=intel_gpu_dg2_g10 "-options -cl-unsafe-math-optimizations" \
-// RUN:   -v %s -o %t_raw.out > %t_raw.log 2>&1
-// RUN: FileCheck --input-file=%t_raw.log --check-prefix=CHECK-RAW-PVC \
-// RUN:   --implicit-check-not='-device pvc {{.*}}-cl-unsafe-math-optimizations' %s
-// RUN: FileCheck --input-file=%t_raw.log --check-prefix=CHECK-RAW-ACM \
-// RUN:   --implicit-check-not='-device acm_g10 {{.*}}-cl-mad-enable' %s
-
-// CHECK-RAW-PVC: ocloc{{.*}} -device pvc {{.*}}-cl-mad-enable
-// CHECK-RAW-ACM: ocloc{{.*}} -device acm_g10 {{.*}}-cl-unsafe-math-optimizations
 
 #include <sycl/detail/core.hpp>
 


### PR DESCRIPTION
The clang-linker-wrapper --device-compiler=/--device-linker= channel did not distinguish between architectures sharing the same triple. So, with -fsycl-targets=spir64_gen,intel_gpu_skl plus per-target -Xsycl-target-backend, all options were emitted under a single spir64_gen-unknown-unknown entry and per-arch tokens leaked across ocloc invocations (e.g. skl's options ended up on the pvc call and vice versa). The driver now routes backend/linker tokens per fsycl-target entry via per-image compile-opts=/link-opts= metadata on the packager's --image= entries, so each ocloc/opencl-aot call receives only its own entry's tokens (one call per entry, no cross-entry merging even when two entries resolve to the same arch). Link-only invocations of pre-compiled .o inputs still emit triple-scoped --device-compiler=/--device-linker= on the wrapper CLI. This feature affects the new-offload-model only.
