### PR TITLE
[SYCL] Skip free-function kernel global-info updates after runtime teardown

### DIFF
--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -87,6 +87,17 @@ public:
     RTGlobalObjHandler = new GlobalHandler();
   };
 
+  // Used in SYCL unit tests to simulate runtime teardown; pair with
+  // restoreGlobalHandler().
+  static GlobalHandler *detachGlobalHandler() {
+    GlobalHandler *Old = RTGlobalObjHandler;
+    RTGlobalObjHandler = nullptr;
+    return Old;
+  }
+  static void restoreGlobalHandler(GlobalHandler *Handler) {
+    RTGlobalObjHandler = Handler;
+  }
+
 private:
   // Constructor and destructor are declared out-of-line to allow incomplete
   // types as template arguments to unique_ptr.

--- a/sycl/source/detail/kernel_global_info.cpp
+++ b/sycl/source/detail/kernel_global_info.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <detail/global_handler.hpp>
 #include <detail/program_manager/program_manager.hpp>
 
 namespace sycl {
@@ -14,6 +15,9 @@ namespace detail::free_function_info_map {
 
 __SYCL_EXPORT void add(const char *const *FreeFunctionNames,
                        const unsigned *FreeFunctionNumArgs, unsigned Size) {
+  // Nothing to register if the runtime is already torn down.
+  if (!GlobalHandler::isInstanceAlive())
+    return;
   std::unordered_map<std::string_view, unsigned> GlobalInfoToCopy;
   for (size_t i = 0; i < Size; ++i) {
     GlobalInfoToCopy[std::string_view{FreeFunctionNames[i]}] =
@@ -25,6 +29,9 @@ __SYCL_EXPORT void add(const char *const *FreeFunctionNames,
 
 __SYCL_EXPORT void remove(const char *const *FreeFunctionNames,
                           const unsigned *FreeFunctionNumArgs, unsigned Size) {
+  // Avoid a use-after-free if the runtime is already torn down.
+  if (!GlobalHandler::isInstanceAlive())
+    return;
   std::unordered_map<std::string_view, unsigned> GlobalInfoToCopy;
   for (size_t i = 0; i < Size; ++i) {
     GlobalInfoToCopy[std::string_view{FreeFunctionNames[i]}] =

--- a/sycl/unittests/program_manager/CMakeLists.txt
+++ b/sycl/unittests/program_manager/CMakeLists.txt
@@ -14,6 +14,7 @@ add_sycl_unittest(ProgramManagerTests OBJECT
   LibraryCompilation.cpp
   SYCLBINSelector.cpp
   SYCLBINAOTLink.cpp
+  FreeFunctionKernelInfo.cpp
 )
 endif()
 

--- a/sycl/unittests/program_manager/FreeFunctionKernelInfo.cpp
+++ b/sycl/unittests/program_manager/FreeFunctionKernelInfo.cpp
@@ -52,8 +52,7 @@ TEST(FreeFunctionKernelInfo, AddRemoveAfterRuntimeTeardownIsNoop) {
   constexpr unsigned Count = 2;
 
   // Simulate the runtime having been torn down.
-  detail::GlobalHandler *Saved =
-      detail::GlobalHandler::detachGlobalHandler();
+  detail::GlobalHandler *Saved = detail::GlobalHandler::detachGlobalHandler();
   ASSERT_FALSE(detail::GlobalHandler::isInstanceAlive());
 
   // Must not touch the detached singleton (no crash / no use-after-free).

--- a/sycl/unittests/program_manager/FreeFunctionKernelInfo.cpp
+++ b/sycl/unittests/program_manager/FreeFunctionKernelInfo.cpp
@@ -1,0 +1,70 @@
+//==------------------- FreeFunctionKernelInfo.cpp -----------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for the free-function kernel global-info registration path
+// (sycl::detail::free_function_info_map::add / remove), which is driven by the
+// compiler-emitted GlobalMapUpdater object in the integration header.
+//
+//===----------------------------------------------------------------------===//
+
+#include <detail/global_handler.hpp>
+#include <detail/program_manager/program_manager.hpp>
+#include <sycl/detail/kernel_global_info.hpp>
+
+#include <optional>
+
+#include <gtest/gtest.h>
+
+using namespace sycl;
+
+// While the runtime is alive, add() then remove() must round-trip through the
+// ProgramManager's free-function global-info map.
+TEST(FreeFunctionKernelInfo, AddRemoveWhileRuntimeAlive) {
+  ASSERT_TRUE(detail::GlobalHandler::isInstanceAlive());
+
+  static const char *const Names[] = {"ffk_alive_kernel_a",
+                                      "ffk_alive_kernel_b"};
+  static const unsigned Sizes[] = {3u, 7u};
+  constexpr unsigned Count = 2;
+
+  auto &PM = detail::ProgramManager::getInstance();
+
+  detail::free_function_info_map::add(Names, Sizes, Count);
+  EXPECT_EQ(PM.getKernelGlobalInfoDesc(Names[0]), std::optional<unsigned>(3u));
+  EXPECT_EQ(PM.getKernelGlobalInfoDesc(Names[1]), std::optional<unsigned>(7u));
+
+  detail::free_function_info_map::remove(Names, Sizes, Count);
+  EXPECT_FALSE(PM.getKernelGlobalInfoDesc(Names[0]).has_value());
+  EXPECT_FALSE(PM.getKernelGlobalInfoDesc(Names[1]).has_value());
+}
+
+// add()/remove() must be a safe no-op (not a use-after-free) when the
+// GlobalMapUpdater destructor runs after the runtime is torn down.
+TEST(FreeFunctionKernelInfo, AddRemoveAfterRuntimeTeardownIsNoop) {
+  static const char *const Names[] = {"ffk_teardown_kernel_a",
+                                      "ffk_teardown_kernel_b"};
+  static const unsigned Sizes[] = {5u, 11u};
+  constexpr unsigned Count = 2;
+
+  // Simulate the runtime having been torn down.
+  detail::GlobalHandler *Saved =
+      detail::GlobalHandler::detachGlobalHandler();
+  ASSERT_FALSE(detail::GlobalHandler::isInstanceAlive());
+
+  // Must not touch the detached singleton (no crash / no use-after-free).
+  detail::free_function_info_map::remove(Names, Sizes, Count);
+  detail::free_function_info_map::add(Names, Sizes, Count);
+
+  // Restore the runtime and confirm nothing was registered while it was dead.
+  detail::GlobalHandler::restoreGlobalHandler(Saved);
+  ASSERT_TRUE(detail::GlobalHandler::isInstanceAlive());
+
+  auto &PM = detail::ProgramManager::getInstance();
+  EXPECT_FALSE(PM.getKernelGlobalInfoDesc(Names[0]).has_value());
+  EXPECT_FALSE(PM.getKernelGlobalInfoDesc(Names[1]).has_value());
+}


### PR DESCRIPTION
This is a SYCL runtime bug. Likely introduced by intel/llvm PR #20422 .

For each TU containing a SYCL free-function kernel, the compiler emits a static GlobalMapUpdater object in the integration header. Before #20422 it had only a constructor (registers kernel names). #20422 added a destructor that calls `sycl::detail::free_function_info_map::remove(...) → ProgramManager::unRegisterKernelGlobalInfo`, which mutates state owned by libsycl's `GlobalHandler` singleton.

The crash is a cross-shared-object static-destruction-order problem:

GlobalMapUpdater updater lives in liboneccl_v1.so with no destructor priority.
libsycl tears down its GlobalHandler (and the ProgramManager map) in shutdown_late(), run from __attribute__((destructor(110))) in `libsycl.so`.

Destructor priority only orders teardown within a single shared object. It does not order an independent .so (liboneccl) against libsycl. When libsycl is torn down before oneCCL's updater destructor runs, that destructor calls into an already-freed/unloaded libsycl → SIGBUS.

This triggers merely by linking libccl.so with a free-function kernel present; no oneCCL API call is needed, because updater is a static object whose destructor runs at process exit regardless.

On the workaround

`unRegisterKernelGlobalInfo/getInstance` should be robust to a torn-down runtime, and/or the map cleanup should be skipped at process termination (it's only meaningful for a true mid-process dlclose).