### PR TITLE
[SYCL] Restore the nd_range default constructor

### DIFF
--- a/sycl/include/sycl/nd_range.hpp
+++ b/sycl/include/sycl/nd_range.hpp
@@ -62,6 +62,12 @@ public:
   nd_range(nd_range<Dimensions> &&rhs) = default;
   nd_range<Dimensions> &operator=(const nd_range<Dimensions> &rhs) = default;
   nd_range<Dimensions> &operator=(nd_range<Dimensions> &&rhs) = default;
+
+  // nd_range has no default constructor in SYCL 2020, but one is kept as an
+  // extension for backwards compatibility with code that default-constructs
+  // and later assigns an nd_range.
+  nd_range() = default;
+
   ~nd_range() = default;
 
   // Common hidden friend functions for by-value semantics

--- a/sycl/include/sycl/nd_range.hpp
+++ b/sycl/include/sycl/nd_range.hpp
@@ -63,7 +63,9 @@ public:
   nd_range<Dimensions> &operator=(const nd_range<Dimensions> &rhs) = default;
   nd_range<Dimensions> &operator=(nd_range<Dimensions> &&rhs) = default;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   nd_range() = default;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
   ~nd_range() = default;
 

--- a/sycl/include/sycl/nd_range.hpp
+++ b/sycl/include/sycl/nd_range.hpp
@@ -63,9 +63,6 @@ public:
   nd_range<Dimensions> &operator=(const nd_range<Dimensions> &rhs) = default;
   nd_range<Dimensions> &operator=(nd_range<Dimensions> &&rhs) = default;
 
-  // nd_range has no default constructor in SYCL 2020, but one is kept as an
-  // extension for backwards compatibility with code that default-constructs
-  // and later assigns an nd_range.
   nd_range() = default;
 
   ~nd_range() = default;

--- a/sycl/test/basic_tests/nd_range.cpp
+++ b/sycl/test/basic_tests/nd_range.cpp
@@ -58,4 +58,12 @@ int main() {
   assert(three_dim_nd_range.get_group_range() == sycl::range<3>(2, 2, 2));
   assert(three_dim_nd_range.get_offset() == sycl::id<3>(0, 0, 0));
   cout << "three_dim_nd_range passed " << endl;
+
+  // nd_range keeps a default constructor (not in SYCL 2020) for backwards
+  // compatibility. Check that it zero-initializes the constituent ranges.
+  sycl::nd_range<3> default_nd_range;
+  assert(default_nd_range.get_global_range() == sycl::range<3>(0, 0, 0));
+  assert(default_nd_range.get_local_range() == sycl::range<3>(0, 0, 0));
+  assert(default_nd_range.get_offset() == sycl::id<3>(0, 0, 0));
+  cout << "default nd_range passed " << endl;
 }

--- a/sycl/test/basic_tests/nd_range.cpp
+++ b/sycl/test/basic_tests/nd_range.cpp
@@ -59,8 +59,7 @@ int main() {
   assert(three_dim_nd_range.get_offset() == sycl::id<3>(0, 0, 0));
   cout << "three_dim_nd_range passed " << endl;
 
-  // nd_range keeps a default constructor (not in SYCL 2020) for backwards
-  // compatibility. Check that it zero-initializes the constituent ranges.
+  // Check that a default-constructed nd_range has zeroed ranges and offset.
   sycl::nd_range<3> default_nd_range;
   assert(default_nd_range.get_global_range() == sycl::range<3>(0, 0, 0));
   assert(default_nd_range.get_local_range() == sycl::range<3>(0, 0, 0));

--- a/sycl/test/basic_tests/nd_range.cpp
+++ b/sycl/test/basic_tests/nd_range.cpp
@@ -59,10 +59,12 @@ int main() {
   assert(three_dim_nd_range.get_offset() == sycl::id<3>(0, 0, 0));
   cout << "three_dim_nd_range passed " << endl;
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   // Check that a default-constructed nd_range has zeroed ranges and offset.
   sycl::nd_range<3> default_nd_range;
   assert(default_nd_range.get_global_range() == sycl::range<3>(0, 0, 0));
   assert(default_nd_range.get_local_range() == sycl::range<3>(0, 0, 0));
   assert(default_nd_range.get_offset() == sycl::id<3>(0, 0, 0));
   cout << "default nd_range passed " << endl;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 }


### PR DESCRIPTION
Fixes #22940

## Problem

PR #22908 removed `nd_range`'s default constructor (`nd_range() = default;`)
to align the class with the SYCL 2020 specification, which does not declare
one. That broke code which default-constructs an `nd_range` and assigns it
later. The most visible casualty is CuTe's `launch_policy`
(`include/cute/util/compat/launch_policy.hpp`), used by PyTorch's XPU
flash-attention kernels, which holds an `nd_range<3>` member that gets
default-initialized:

```
error: constructor for 'compat::experimental::launch_policy<sycl::nd_range<3>, ...>'
must explicitly initialize the member '_range' which does not have a default constructor
```

## Change

Restore `nd_range() = default;`. All three members (`globalSize`, `localSize`,
`offset`) are `range`/`id` objects, both of which keep zero-initializing
default constructors, so a default-constructed `nd_range` is well-defined and
produces zeroed ranges and offset.

## Test plan

- Extended `sycl/test/basic_tests/nd_range.cpp` to default-construct an
  `nd_range<3>` and assert the constituent ranges and offset are
  zero-initialized.