### PR TITLE
[Bindless][E2E] Fix addressing mode in 1D sampled fetch test

### DIFF
--- a/sycl/test-e2e/bindless_images/sampled_fetch/fetch_1D.hpp
+++ b/sycl/test-e2e/bindless_images/sampled_fetch/fetch_1D.hpp
@@ -2,6 +2,9 @@
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>
 
+// Uncomment to print additional test information
+// #define VERBOSE_PRINT
+
 class kernel_sampled_fetch;
 namespace syclexp = sycl::ext::oneapi::experimental;
 
@@ -19,7 +22,7 @@ int test() {
 
   try {
     syclexp::bindless_image_sampler samp(
-        sycl::addressing_mode::repeat,
+        sycl::addressing_mode::clamp,
         sycl::coordinate_normalization_mode::unnormalized,
         sycl::filtering_mode::nearest);
 


### PR DESCRIPTION
Change repeat -> clamp addressing mode. Repeat is UB with unnormalized coordinates per the OpenCL spec (§6.15.15.1). Also adds the VERBOSE_PRINT define for debugging, matching the style of the other bindless test files.