### PR TITLE
[Bindless] Fix fetch_image on sampled handles to use sampled image path

### DIFF
--- a/sycl/include/sycl/ext/oneapi/bindless_images.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images.hpp
@@ -1036,19 +1036,15 @@ DataT fetch_image(const sampled_image_handle &imageHandle [[maybe_unused]],
                 "HintT must always be a recognized standard type");
 
 #ifdef __SYCL_DEVICE_ONLY__
-  // Convert the raw handle to an image and use FETCH_UNSAMPLED_IMAGE since
-  // fetch_image should not use the sampler
   if constexpr (detail::is_recognized_standard_type<DataT>()) {
-    return FETCH_UNSAMPLED_IMAGE(
+    return FETCH_SAMPLED_IMAGE(
         DataT,
-        CONVERT_HANDLE_TO_IMAGE(imageHandle.raw_handle,
-                                detail::OCLImageTyRead<coordSize>),
+        CONVERT_HANDLE_TO_SAMPLED_IMAGE(imageHandle.raw_handle, coordSize),
         coords);
   } else {
-    return sycl::bit_cast<DataT>(FETCH_UNSAMPLED_IMAGE(
+    return sycl::bit_cast<DataT>(FETCH_SAMPLED_IMAGE(
         HintT,
-        CONVERT_HANDLE_TO_IMAGE(imageHandle.raw_handle,
-                                detail::OCLImageTyRead<coordSize>),
+        CONVERT_HANDLE_TO_SAMPLED_IMAGE(imageHandle.raw_handle, coordSize),
         coords));
   }
 #else


### PR DESCRIPTION
fetch_image on a sampled_image_handle was incorrectly going through FETCH_UNSAMPLED_IMAGE + CONVERT_HANDLE_TO_IMAGE. Correct to FETCH_SAMPLED_IMAGE + CONVERT_HANDLE_TO_SAMPLED_IMAGE.

Previously, these fetch_image calls would translate to an [OpImageRead](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpImageRead) which is incorrect for a sampled image and instead should translate to an [OpImageFetch](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpImageFetch).