### PR TITLE
[SYCL] Add default constructor for nd_range

### DIFF
--- a/sycl/include/sycl/nd_range.hpp
+++ b/sycl/include/sycl/nd_range.hpp
@@ -37,6 +37,8 @@ private:
                 "nd_range can only be 1, 2, or 3 Dimensional.");
 
 public:
+  nd_range() noexcept = default;
+
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL2020")
   nd_range(range<Dimensions> globalSize, range<Dimensions> localSize,
            id<Dimensions> offset) noexcept


### PR DESCRIPTION
https://github.com/KhronosGroup/SYCL-Docs/issues/1043
Note - we had it before, but it's not on the SYCL 2020 spec, so I removed it. Turned out some customers were using it, so I'm working on adding this to the spec and restoring it.