### PR TITLE
[SYCL][Bindless Images] Disable vulkan_sycl_image_interop_write_1d_unsampled e2e test on BMG

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_image_interop_write_1d_unsampled.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: cuda-ge-13
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21808
 
-// UNSUPPORTED: linux && arch-intel_gpu_mtl_u
+// UNSUPPORTED: linux && (arch-intel_gpu_mtl_u || arch-intel_gpu_bmg_g21)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22858
 
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/22858