### PR TITLE
[SYCL] Fix native-cpu GlobalVariable::getAlignment build after b71ce8f90bdc

### DIFF
--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/source/replace_local_module_scope_variables_pass.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/source/replace_local_module_scope_variables_pass.cpp
@@ -308,7 +308,8 @@ PreservedAnalyses compiler::utils::ReplaceLocalModuleScopeVariablesPass::run(
     // global. This is also needed if '__attribute__(aligned)' was used to
     // set a specific alignment.
     const unsigned int alignment =
-        std::max(global->getAlignment(), calculateTypeAlign(memberType, dl));
+        std::max(global->getAlign().valueOrOne().value(),
+                 calculateTypeAlign(memberType, dl));
     assert(alignment > 0 && "'0' is an impossible alignment");
 
     // check if this is the largest alignment seen so far

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/transform/printf_scalarizer.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/transform/printf_scalarizer.cpp
@@ -103,7 +103,7 @@ GetNewFormatStringAsGlobalVar(Module &module,
       new_format_string_const, Twine(string_value->getName() + "_"),
       string_value, thread_local_mode, addr_space, is_externally_initialized);
 
-  new_var->setAlignment(MaybeAlign(string_value->getAlignment()));
+  new_var->setAlignment(string_value->getAlign());
   new_var->setUnnamedAddr(string_value->getUnnamedAddr());
 
   return new_var;


### PR DESCRIPTION
Upstream commit b71ce8f90bdc dropped GlobalVariable::getAlignment.