### PR TITLE
[SYCL] Fix native-cpu llvm::Any build after fa23198d685b

### DIFF
--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/vecz_pass_builder.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/vecz_pass_builder.cpp
@@ -123,12 +123,11 @@ void VeczPassMachinery::addClassToPassNames() {
 
   // Register a callback which skips all passes once we've failed to vectorize
   // a function.
-  PIC.registerShouldRunOptionalPassCallback([&](StringRef, llvm::Any IR) {
-    const Function *const *FPtr = any_cast<const Function *>(&IR);
-    const Function *F = FPtr ? *FPtr : nullptr;
+  PIC.registerShouldRunOptionalPassCallback([&](StringRef, llvm::IRUnitRef IR) {
+    const Function *F = dyn_cast<Function>(IR);
     if (!F) {
-      if (const auto *const *L = any_cast<const Loop *>(&IR)) {
-        F = (*L)->getHeader()->getParent();
+      if (const auto *const L = dyn_cast<Loop>(IR)) {
+        F = L->getHeader()->getParent();
       } else {
         // Always run module passes
         return true;


### PR DESCRIPTION
upstream commit fa23198d685b replaced llvm::Any with a tagged IRUnitRef.