### PR TITLE
[L0][v2] Fix segfault from null zeDeviceGetVectorWidthPropertiesExt

### DIFF
--- a/unified-runtime/source/adapters/level_zero/common/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/common/device.cpp
@@ -2074,22 +2074,10 @@ ur_result_t ur_device_handle_t_::initialize(int SubSubDeviceOrdinal,
         Properties.native_vector_width_float = 1u;
         Properties.native_vector_width_half = 8u;
 
-        ze_result_t (*zeDeviceGetVectorWidthPropertiesExtFn)(
-            ze_device_handle_t, uint32_t *,
-            ze_device_vector_width_properties_ext_t *) = nullptr;
-
-        if (UrPlatform->zeDriverExtensionMap.count(
-                ZE_DEVICE_VECTOR_SIZES_EXT_NAME)) {
-          ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
-                          (UrPlatform->ZeDriver,
-                           "zeDeviceGetVectorWidthPropertiesExt",
-                           reinterpret_cast<void **>(
-                               &zeDeviceGetVectorWidthPropertiesExtFn)));
-        }
-
-        if (zeDeviceGetVectorWidthPropertiesExtFn != nullptr) {
+        if (UrPlatform->ZeDeviceVectorWidthExt.Supported) {
           uint32_t Count = 0;
-          ZE_CALL_NOCHECK(zeDeviceGetVectorWidthPropertiesExtFn,
+          ZE_CALL_NOCHECK(UrPlatform->ZeDeviceVectorWidthExt
+                              .zeDeviceGetVectorWidthPropertiesExt,
                           (ZeDevice, &Count, nullptr));
 
           std::vector<ZeStruct<ze_device_vector_width_properties_ext_t>>
@@ -2099,7 +2087,8 @@ ur_result_t ur_device_handle_t_::initialize(int SubSubDeviceOrdinal,
           ZeStruct<ze_device_vector_width_properties_ext_t>
               MaxVectorWidthProperties;
 
-          ZE_CALL_NOCHECK(zeDeviceGetVectorWidthPropertiesExtFn,
+          ZE_CALL_NOCHECK(UrPlatform->ZeDeviceVectorWidthExt
+                              .zeDeviceGetVectorWidthPropertiesExt,
                           (ZeDevice, &Count, PropertiesVector.data()));
           if (!PropertiesVector.empty()) {
             // Find the largest vector_width_size property

--- a/unified-runtime/source/adapters/level_zero/common/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/common/device.cpp
@@ -2074,10 +2074,22 @@ ur_result_t ur_device_handle_t_::initialize(int SubSubDeviceOrdinal,
         Properties.native_vector_width_float = 1u;
         Properties.native_vector_width_half = 8u;
 
+        ze_result_t (*zeDeviceGetVectorWidthPropertiesExtFn)(
+            ze_device_handle_t, uint32_t *,
+            ze_device_vector_width_properties_ext_t *) = nullptr;
+
         if (UrPlatform->zeDriverExtensionMap.count(
                 ZE_DEVICE_VECTOR_SIZES_EXT_NAME)) {
+          ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
+                          (UrPlatform->ZeDriver,
+                           "zeDeviceGetVectorWidthPropertiesExt",
+                           reinterpret_cast<void **>(
+                               &zeDeviceGetVectorWidthPropertiesExtFn)));
+        }
+
+        if (zeDeviceGetVectorWidthPropertiesExtFn != nullptr) {
           uint32_t Count = 0;
-          ZE_CALL_NOCHECK(zeDeviceGetVectorWidthPropertiesExt,
+          ZE_CALL_NOCHECK(zeDeviceGetVectorWidthPropertiesExtFn,
                           (ZeDevice, &Count, nullptr));
 
           std::vector<ZeStruct<ze_device_vector_width_properties_ext_t>>
@@ -2087,7 +2099,7 @@ ur_result_t ur_device_handle_t_::initialize(int SubSubDeviceOrdinal,
           ZeStruct<ze_device_vector_width_properties_ext_t>
               MaxVectorWidthProperties;
 
-          ZE_CALL_NOCHECK(zeDeviceGetVectorWidthPropertiesExt,
+          ZE_CALL_NOCHECK(zeDeviceGetVectorWidthPropertiesExtFn,
                           (ZeDevice, &Count, PropertiesVector.data()));
           if (!PropertiesVector.empty()) {
             // Find the largest vector_width_size property

--- a/unified-runtime/source/adapters/level_zero/common/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/common/platform.cpp
@@ -812,6 +812,14 @@ ur_result_t ur_platform_handle_t_::initialize() {
   ZeCopyOffloadListFlagSupported =
       this->isDriverVersionNewerOrSimilar(1, 15, 0);
 
+  ZE_CALL_NOCHECK(
+      zeDriverGetExtensionFunctionAddress,
+      (ZeDriver, "zeDeviceGetVectorWidthPropertiesExt",
+       reinterpret_cast<void **>(
+           &ZeDeviceVectorWidthExt.zeDeviceGetVectorWidthPropertiesExt)));
+
+  ZeDeviceVectorWidthExt.Supported =
+      ZeDeviceVectorWidthExt.zeDeviceGetVectorWidthPropertiesExt != nullptr;
   return UR_RESULT_SUCCESS;
 }
 

--- a/unified-runtime/source/adapters/level_zero/common/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/common/platform.hpp
@@ -284,6 +284,13 @@ struct ur_platform_handle_t_ : ur::level_zero::ur_object_t, public ur_platform {
   // Some platforms may not support this API due to frozen driver, eg. gen12 on
   // Windows. For details, see https://github.com/intel/llvm/issues/20927.
   bool ZeDeviceSynchronizeSupported{false};
+
+  struct ZeDeviceVectorWidthExtension {
+    bool Supported = false;
+    ze_result_t (*zeDeviceGetVectorWidthPropertiesExt)(
+        ze_device_handle_t, uint32_t *,
+        ze_device_vector_width_properties_ext_t *) = nullptr;
+  } ZeDeviceVectorWidthExt;
 };
 
 } // namespace ur::level_zero


### PR DESCRIPTION
Fall back to default vector-width properties,
when the function pointer is null.
Fixes: https://github.com/intel/llvm/issues/22834