### PR TITLE
[TEST][CI] Restrict E2E test run to Basic/stream/stream.cpp

### DIFF
--- a/devops/actions/run-tests/linux/e2e/action.yml
+++ b/devops/actions/run-tests/linux/e2e/action.yml
@@ -72,7 +72,7 @@ runs:
     continue-on-error: true
     shell: bash
     env:
-      LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time 3600 --time-tests --param print_features=True --param test-mode=${{ inputs.testing_mode }} --param sycl_devices=${{ inputs.target_devices }} ${{ inputs.extra_lit_opts }}
+      LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time 3600 --time-tests --param print_features=True --param test-mode=${{ inputs.testing_mode }} --param sycl_devices=${{ inputs.target_devices }} --filter='Basic/stream/stream\.cpp$' ${{ inputs.extra_lit_opts }}
     run: |
       ninja -C build-e2e check-sycl-e2e > e2e.log 2>&1
   # Two steps below are duplicated between Lin/Win actions, updates must change both

--- a/devops/actions/run-tests/windows/e2e/action.yml
+++ b/devops/actions/run-tests/windows/e2e/action.yml
@@ -76,7 +76,7 @@ runs:
     continue-on-error: true
     shell: bash
     env:
-      LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time ${{ inputs.testing_mode == 'run-only' && 1200 || 3600 }} --time-tests --param print_features=True --param test-mode=${{ inputs.testing_mode }} --param sycl_devices=${{ inputs.target_devices }} ${{ inputs.extra_lit_opts }}
+      LIT_OPTS: -v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time ${{ inputs.testing_mode == 'run-only' && 1200 || 3600 }} --time-tests --param print_features=True --param test-mode=${{ inputs.testing_mode }} --param sycl_devices=${{ inputs.target_devices }} --filter='Basic/stream/stream\.cpp$' ${{ inputs.extra_lit_opts }}
     run: |
       cmake --build build-e2e --target check-sycl-e2e > e2e.log 2>&1
   # Two steps below are duplicated between Lin/Win actions, updates must change both

--- a/sycl/test-e2e/Basic/stream/stream.cpp
+++ b/sycl/test-e2e/Basic/stream/stream.cpp
@@ -1,8 +1,6 @@
 // UNSUPPORTED: cuda
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19214
-
-// REQUIRES-INTEL-DRIVER: lin: 39395
-
+// _REQUIRES-INTEL-DRIVER_: lin: -39395-
 // RUN: %{build} -fsycl-device-code-split=per_kernel -Wno-error=deprecated-declarations -o %t.out
 // RUN: %{run} %t.out %if !gpu || linux %{ | FileCheck %s %}
 


### PR DESCRIPTION
Add a LIT_FILTER-equivalent --filter option to LIT_OPTS in the shared
Linux and Windows E2E composite actions so that only
sycl/test-e2e/Basic/stream/stream.cpp is executed instead of the full
sycl/test-e2e/* suite. This affects all workflows that reuse these
actions (precommit, post-commit, nightly, weekly, AWS, benchmarking).