### PR TITLE
[Clang][Test] Fix optnone-pragma-optimize-off.cpp after 4a8b9399eb9c

### DIFF
--- a/clang/test/CodeGenCXX/optnone-pragma-optimize-off.cpp
+++ b/clang/test/CodeGenCXX/optnone-pragma-optimize-off.cpp
@@ -21,7 +21,7 @@ __attribute__((always_inline)) void bar() {}
 // CHECK: define {{.*}}void @_Z3barv() #[[ALWAYSINLINE:[0-9]+]]
 
 auto lambda = []() __attribute__((always_inline)) { return 42; };
-// CHECK: define {{.*}} @"_ZNK3$_1clEv"({{.*}}) #[[ALWAYSINLINE]]
+// CHECK: define {{.*}} @"_ZNK6lambdaM3$_1clEv"({{.*}}) #[[ALWAYSINLINE]]
 
 int caller() {
   bar();


### PR DESCRIPTION
Upstream commit 4a8b9399eb9c ("[Clang][Sema] Fix lambda attribute processing order with clang optimize off") added a check for an always_inline lambda declared in the initializer of a namespace-scope variable under `#pragma clang optimize off`.

intel/llvm intentionally diverges from upstream in Sema::getCurrentMangleNumberContext(): commit 478c20546816 ("[SYCL] Fix Lambda Mangling in Namespace-Scope Variable Initializers", #20176) cherry-picks community PR llvm/llvm-project#159115, which mangles the the closure type with a closure-prefix for the enclosing variable.

CMPLRLLVM-77788