### PR TITLE
[sycl-ls] Print GPU family only for GPUs

### DIFF
--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -255,7 +255,8 @@ static void printDeviceInfo(const device &Device, bool Verbose,
     auto Arch = Device.get_info<syclex::info::device::architecture>();
     auto CanonicalArch = getCanonicalArchitectureName(Arch);
     std::cout << Prepend << "Architecture: " << CanonicalArch << std::endl;
-    std::cout << Prepend << "GPU Family: " << getGPUFamily(Arch) << std::endl;
+    if (Device.get_info<info::device::device_type>() == info::device_type::gpu)
+      std::cout << Prepend << "GPU Family: " << getGPUFamily(Arch) << std::endl;
   } else {
     std::cout << Prepend << ", " << DeviceName << " " << DeviceVersion << " ["
               << DeviceDriverVersion << "]" << std::endl;

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -206,8 +206,8 @@ static void printDeviceInfo(const device &Device, bool Verbose,
   auto DeviceDriverVersion = Device.get_info<info::device::driver_version>();
 
   if (Verbose) {
-    std::cout << Prepend << "Type              : " << getDeviceTypeName(Device)
-              << std::endl;
+    std::string DeviceTypeName = getDeviceTypeName(Device);
+    std::cout << Prepend << "Type              : " << DeviceTypeName << std::endl;
     std::cout << Prepend << "Version           : " << DeviceVersion
               << std::endl;
     std::cout << Prepend << "Name              : " << DeviceName << std::endl;
@@ -255,7 +255,7 @@ static void printDeviceInfo(const device &Device, bool Verbose,
     auto Arch = Device.get_info<syclex::info::device::architecture>();
     auto CanonicalArch = getCanonicalArchitectureName(Arch);
     std::cout << Prepend << "Architecture: " << CanonicalArch << std::endl;
-    if (Device.get_info<info::device::device_type>() == info::device_type::gpu)
+    if (DeviceTypeName == "gpu")
       std::cout << Prepend << "GPU Family: " << getGPUFamily(Arch) << std::endl;
   } else {
     std::cout << Prepend << ", " << DeviceName << " " << DeviceVersion << " ["

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -207,7 +207,8 @@ static void printDeviceInfo(const device &Device, bool Verbose,
 
   if (Verbose) {
     std::string DeviceTypeName = getDeviceTypeName(Device);
-    std::cout << Prepend << "Type              : " << DeviceTypeName << std::endl;
+    std::cout << Prepend << "Type              : " << DeviceTypeName
+              << std::endl;
     std::cout << Prepend << "Version           : " << DeviceVersion
               << std::endl;
     std::cout << Prepend << "Name              : " << DeviceName << std::endl;


### PR DESCRIPTION
Previous patch added the gpu family string to the sycl-ls output. However it prints this line for all devices. Restrict to GPUs.