### PR TITLE
[UR] Correctly set static UMF dependency

### DIFF
--- a/unified-runtime/source/common/CMakeLists.txt
+++ b/unified-runtime/source/common/CMakeLists.txt
@@ -75,13 +75,15 @@ target_include_directories(ur_common PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
 
+set(UR_USE_EXTERNAL_UMF ON CACHE BOOL "Use a pre-built UMF if available")
 
-# Only a statically-embedded Level Zero adapter that is actually built pulls UMF
-# in statically. UR_STATIC_ADAPTER_L0 defaults ON even when L0 is not built, so
-# gate on the adapter being built too; otherwise non-L0 builds (e.g. macOS)
-# would needlessly force static UMF and its hwloc dependency.
+# Static adapters require a statically-linked UMF.
 if ((UR_STATIC_ADAPTER_L0 AND UR_BUILD_ADAPTER_L0) OR
     (UR_STATIC_ADAPTER_L0_V2 AND UR_BUILD_ADAPTER_L0_V2))
+    set(UR_STATIC_UMF_REQUIRED ON)
+endif()
+
+if (UR_STATIC_UMF_REQUIRED)
     if (UMF_BUILD_SHARED_LIBRARY)
         message(STATUS "Static adapter is not compatible with shared UMF, switching to fully statically linked UMF")
         set(UMF_BUILD_SHARED_LIBRARY OFF)
@@ -90,9 +92,10 @@ if ((UR_STATIC_ADAPTER_L0 AND UR_BUILD_ADAPTER_L0) OR
         # macOS), breaking the link.
         set(UMF_LINK_HWLOC_STATICALLY ON CACHE INTERNAL "static HWLOC")
     endif()
+    # Ignore any external UMF so that it's always built statically and linked
+    # into the static adapters. FORCE overrides the default set above.
+    set(UR_USE_EXTERNAL_UMF OFF CACHE BOOL "Use a pre-built UMF if available" FORCE)
 endif()
-
-set(UR_USE_EXTERNAL_UMF ON CACHE BOOL "Use a pre-built UMF if available")
 
 # Only fetch/build UMF when some adapter actually links against it
 # (UR_UMF_REQUIRED, computed above from the enabled adapters). On builds where


### PR DESCRIPTION
Previously, the UMF wouldn't be linked statically if it was found on the platform.