### PR TITLE
[SYCL][E2E] Re-enable tests disabled by issue #22405

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/barrier_optimization.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/barrier_optimization.cpp
@@ -5,9 +5,6 @@
 // UNSUPPORTED: windows && (gpu-intel-gen12 || gpu-intel-dg2 || arch-intel_gpu_bmg_g21)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22033
 
-// UNSUPPORTED: linux && (arch-intel_gpu_pvc || arch-intel_gpu_bmg_g21 || arch-intel_gpu_mtl_u)
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
-
 // Test to check that we don't insert unnecessary L0 commands for
 // queue::ext_oneapi_submit_barrier() when we have in-order queue.
 #include <iostream>

--- a/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-buffer.cpp
@@ -7,8 +7,6 @@
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
 // UNSUPPORTED: windows && run-mode
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22284
-// UNSUPPORTED: linux && run-mode
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
 // RUN: %{build} -Wno-error=deprecated-declarations %level_zero_options -o %t.out
 // RUN: env UR_L0_DEBUG=1 %{run} %t.out
 

--- a/sycl/test-e2e/Basic/alloc_pinned_host_memory.cpp
+++ b/sycl/test-e2e/Basic/alloc_pinned_host_memory.cpp
@@ -6,9 +6,6 @@
 // UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22287
 
-// UNSUPPORTED: linux && level_zero
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
-
 // RUN: %{build} -o %t2.out
 // RUN: env SYCL_UR_TRACE=2 UR_L0_DEBUG=1 %{run} %t2.out %if level_zero %{ 2>&1 | FileCheck %s %}
 // RUN: %{run} %t2.out

--- a/sycl/test-e2e/Basic/buffer/buffer_create.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_create.cpp
@@ -12,9 +12,6 @@
 // UNSUPPORTED: windows && (gpu-intel-gen12 || gpu-intel-dg2 || arch-intel_gpu_bmg_g21)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21954
 
-// UNSUPPORTED: linux && arch-intel_gpu_mtl_u
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
-
 #include <CL/cl.h>
 #include <iostream>
 #include <level_zero/ze_api.h>

--- a/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
+++ b/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
@@ -5,9 +5,6 @@
 // UNSUPPORTED: windows && (gpu-intel-gen12 || gpu-intel-dg2 || arch-intel_gpu_bmg_g21)
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/21556
 
-// UNSUPPORTED: linux && run-mode
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
-
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_UR_TRACE=2 UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 //

--- a/sycl/test-e2e/Properties/cache_config.cpp
+++ b/sycl/test-e2e/Properties/cache_config.cpp
@@ -6,9 +6,6 @@
 // UNSUPPORTED: windows && arch-intel_gpu_bmg_g21
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22099
 
-// UNSUPPORTED: linux && run-mode
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
-
 // RUN: %{build} -Wno-deprecated-declarations -o %t.out
 // RUN: env SYCL_UR_TRACE=-1 UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/SpecConstants/2020/non_native/gpu.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/non_native/gpu.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: ocloc, gpu, target-spir
 
-// UNSUPPORTED: linux && arch-intel_gpu_pvc
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
-
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts %S/Inputs/common.cpp -o %t.out -fsycl-dead-args-optimization
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/XPTI/mem_alloc_events_linux.cpp
+++ b/sycl/test-e2e/XPTI/mem_alloc_events_linux.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: xptifw, level_zero, gpu, linux
-// UNSUPPORTED: linux && arch-intel_gpu_pvc
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
 // RUN: %build_collector
 // RUN: %{build} -o %t.out
 // RUN: env XPTI_TRACE_ENABLE=1 env XPTI_FRAMEWORK_DISPATCHER=%xptifw_dispatcher env XPTI_SUBSCRIBERS=%t_collector.dll %{run} %t.out | FileCheck %s

--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_buffer_binary_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_buffer_binary_semaphore.cpp
@@ -5,9 +5,6 @@
 // Linux fix tracked by GSD-12371, landed in driver 38362.
 // REQUIRES-INTEL-DRIVER: lin: 38362 win: 101.9999
 
-// UNSUPPORTED: linux && gpu-intel-gen12
-// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/22405
-
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 // RUN: %{run} %t.out --no-sem
 // RUN: %{run} %t.out --dual-sem


### PR DESCRIPTION
Removes the UNSUPPORTED/UNSUPPORTED-TRACKER directives referencing
https://github.com/intel/llvm/issues/22405 in the following e2e tests:

- Adapters/level_zero/barrier_optimization.cpp
- Adapters/level_zero/interop-buffer.cpp
- Basic/alloc_pinned_host_memory.cpp
- Basic/buffer/buffer_create.cpp
- KernelAndProgram/level-zero-static-link-flow.cpp
- Properties/cache_config.cpp
- SpecConstants/2020/non_native/gpu.cpp
- XPTI/mem_alloc_events_linux.cpp
- bindless_images/vulkan_interop/vulkan_sycl_buffer_binary_semaphore.cpp

CI verification (PR #22987): all 9 tests passed on the affected
platforms - GEN12, BMG, ARL, and PVC (Linux, Preview Mode included) -
confirming the underlying driver issue is resolved. The only
exception was vulkan_sycl_buffer_binary_semaphore.cpp on PVC, which
was Unsupported due to an unrelated REQUIRES-INTEL-DRIVER minimum
version gate on that runner.

Fixes: #22405