### PR TITLE
[Clang][Test] Fix riscv-mangle-vls-cc.cpp after 538df387f522

### DIFF
--- a/clang/test/CodeGenCXX/riscv-mangle-vls-cc.cpp
+++ b/clang/test/CodeGenCXX/riscv-mangle-vls-cc.cpp
@@ -56,7 +56,7 @@ template void template_<int>(int);
 // CHECK-DAG: @_Z9vector_ccv
 __attribute__((riscv_vector_cc)) void vector_cc() {}
 
-// CHECK-DAG: @"_ZNK3$_0clB16riscv_vls_cc_128Ev"
+// CHECK-DAG: @"_ZNK3lamM3$_0clB16riscv_vls_cc_128Ev"
 auto lam = []() __attribute__((riscv_vls_cc(128))) {};
 void use_lam() { lam(); }
 


### PR DESCRIPTION
Upstream commit 538df387f522 ("[Clang][RISCV] Mangle the ABI tag of
a standard calling convention variant") added a test for a lambda
declared as a namespace-scope variable initializer with a
riscv_vls_cc attribute, using upstream's default mangling for the
closure type.

intel/llvm intentionally diverges from upstream in
Sema::getCurrentMangleNumberContext(): commit 478c20546816 ("[SYCL]
Fix Lambda Mangling in Namespace-Scope Variable Initializers",
#20176) cherry-picks community PR llvm/llvm-project#159115, which
mangles the closure type with a closure-prefix for the enclosing
variable. That divergence predates 538df387f522, so the new test's
expected mangling (`_ZNK3$_0cl...`) does not match intel/llvm's
output (`_ZNK3lamM3$_0cl...`); update the FileCheck line to match.

CMPLRLLVM-77820