### PR TITLE
[SYCL][E2E] Gate L0 1.14+ API tests on Level Zero headers version

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/default_context_reuse.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/default_context_reuse.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero_v2_adapter
+// REQUIRES: level_zero_v2_adapter, level-zero-headers-ge-1.14
 
 // API 1.14+ is required for zeDriverGetDefaultContext
 // REQUIRES-INTEL-DRIVER: lin: 36300, win: 101.7080

--- a/sycl/test-e2e/E2EExpr.py
+++ b/sycl/test-e2e/E2EExpr.py
@@ -52,6 +52,20 @@ class E2EExpr(BooleanExpression):
         "new-offload-model",
     }
 
+    # Prefixes for build-environment features that are parametrized by a
+    # detected version (e.g. cuda-ge-12, level-zero-headers-ge-1.14) and
+    # therefore can't be enumerated as exact strings above.
+    build_specific_feature_prefixes = (
+        "cuda-ge-",
+        "level-zero-headers-ge-",
+    )
+
+    @staticmethod
+    def is_build_specific(token):
+        return token in E2EExpr.build_specific_features or token.startswith(
+            E2EExpr.build_specific_feature_prefixes
+        )
+
     def __init__(self, string, variables, build_only_mode, final_unknown_value):
         BooleanExpression.__init__(self, string, variables)
         self.build_only_mode = build_only_mode
@@ -77,7 +91,7 @@ class E2EExpr(BooleanExpression):
     def parseMATCH(self):
         token = self.token
         BooleanExpression.parseMATCH(self)
-        if token not in E2EExpr.build_specific_features and self.build_only_mode:
+        if not E2EExpr.is_build_specific(token) and self.build_only_mode:
             self.unknown = True
         else:
             self.unknown = False
@@ -122,7 +136,7 @@ class E2EExpr(BooleanExpression):
 
     @staticmethod
     def check_build_features(variables):
-        rt_features = [x for x in variables if x not in E2EExpr.build_specific_features]
+        rt_features = [x for x in variables if not E2EExpr.is_build_specific(x)]
         if rt_features:
             raise ValueError(
                 "Runtime features: "

--- a/sycl/test-e2e/Graph/RecordReplay/NativeRecording/ze_launch_kernel_with_args.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/NativeRecording/ze_launch_kernel_with_args.cpp
@@ -1,5 +1,7 @@
 // REQUIRES: level_zero_v2_adapter && arch-intel_gpu_bmg_g21
 // REQUIRES: level_zero_dev_kit
+// API 1.14+ is required for zeCommandListAppendLaunchKernelWithArguments
+// REQUIRES: level-zero-headers-ge-1.14
 
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out %S/../../Inputs/Kernels/saxpy.spv

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -389,6 +389,34 @@ config.level_zero_include = quote_path(
     )
 )
 
+# Detect the Level Zero *headers* API version and add ge-features for
+# conditional test execution, mirroring the cuda-ge-<N> features above.
+# This is independent of REQUIRES-INTEL-DRIVER, which only checks the
+# runtime driver build and can't catch a test using an L0 API that the
+# headers used to build it don't declare at all.
+ze_api_header = os.path.join(
+    config.level_zero_include.strip('"'), "level_zero", "ze_api.h"
+)
+if os.path.exists(ze_api_header):
+    with open(ze_api_header, "r") as f:
+        ze_api_header_text = f.read()
+    ze_api_versions = [
+        tuple(int(p) for p in m.groups())
+        for m in re.finditer(
+            r"ZE_API_VERSION_(\d+)_(\d+)\s*=\s*ZE_MAKE_VERSION",
+            ze_api_header_text,
+        )
+    ]
+    if ze_api_versions:
+        major, minor = max(ze_api_versions)
+        MIN_ZE_API_MINOR = 0  # Earliest L0 minor version tracked by these features
+        for m in range(MIN_ZE_API_MINOR, minor + 1):
+            config.available_features.add(f"level-zero-headers-ge-{major}.{m}")
+        lit_config.note(
+            f"Level Zero headers API {major}.{minor}: added features "
+            f"level-zero-headers-ge-{major}.{MIN_ZE_API_MINOR}..level-zero-headers-ge-{major}.{minor}"
+        )
+
 level_zero_options = level_zero_options = (
     (" -L" + config.level_zero_libs_dir if config.level_zero_libs_dir else "")
     + " -lze_loader "


### PR DESCRIPTION
zeDriverGetDefaultContext (default_context_reuse.cpp) and zeCommandListAppendLaunchKernelWithArguments/ze_group_size_t (ze_launch_kernel_with_args.cpp) require L0 API 1.14+, but the existing REQUIRES-INTEL-DRIVER only checks the runtime driver build, not the headers used to compile the test. On configs pinned to older L0 headers (e.g. spec 1.13), these tests fail to build with "use of undeclared identifier" instead of being skipped.

Add a level-zero-headers-ge-<major>.<minor> feature, detected from ZE_API_VERSION_CURRENT in ze_api.h at lit config time (mirroring the existing cuda-ge-<N> feature), and gate both tests on level-zero-headers-ge-1.14 (confirmed as the exact version boundary across all available oclgpu ref packages).

Since this feature is parametrized by a detected version rather than a fixed string, extend E2EExpr.check_build_features/parseMATCH to recognize build-specific feature prefixes (cuda-ge-, level-zero- headers-ge-) instead of only exact-string matches, which previously raised "Runtime features ... evaluated to True in build-only" for any such value.

CMPLRLLVM-77825