### PR TITLE
[SYCL][test-e2e] Add tracking comment for issue #21873 to affected tests

### DIFF
--- a/sycl/test-e2e/Matrix/element_wise_all_ops.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops.cpp
@@ -14,3 +14,5 @@
 
 #include "common.hpp"
 #include "element_wise_all_ops_impl.hpp"
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_1d.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_1d.cpp
@@ -18,3 +18,5 @@
 
 #include "common.hpp"
 #include "element_wise_all_ops_impl.hpp"
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_scalar.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_scalar.cpp
@@ -14,3 +14,5 @@
 
 #include "common.hpp"
 #include "element_wise_all_ops_impl.hpp"
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/copy.cpp
+++ b/sycl/test-e2e/USM/copy.cpp
@@ -265,3 +265,5 @@ int main() {
 
   return 0;
 }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_shared.cpp
@@ -13,3 +13,5 @@
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::Shared>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_device.cpp
@@ -13,3 +13,5 @@
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::DirectHost, Alloc::Device>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
@@ -16,3 +16,5 @@
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::DirectHost, Alloc::Shared>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
@@ -16,3 +16,5 @@
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Host, Alloc::Shared>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_device.cpp
@@ -13,3 +13,5 @@
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Device>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
@@ -16,3 +16,5 @@
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::DirectHost>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
@@ -16,3 +16,5 @@
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Host>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_shared.cpp
@@ -13,3 +13,5 @@
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Shared>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_dhost.cpp
@@ -13,3 +13,5 @@
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::DirectHost>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_host.cpp
@@ -16,3 +16,5 @@
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::Host>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_shared.cpp
@@ -13,3 +13,5 @@
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::Shared>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_device.cpp
@@ -13,3 +13,5 @@
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Device>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
@@ -16,3 +16,5 @@
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Host>(); }
+
+// See https://github.com/intel/llvm/issues/21873

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_shared.cpp
@@ -13,3 +13,5 @@
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Shared>(); }
+
+// See https://github.com/intel/llvm/issues/21873


### PR DESCRIPTION
Add a comment referencing https://github.com/intel/llvm/issues/21873 to
the 18 tests observed to sporadically fail on Battlemage Graphics
(Matrix element-wise ops and USM/memops2d copy/memcpy variants), to
trigger CI re-evaluation without changing test behavior.