### PR TITLE
[SYCL] Fix native-cpu build after VPIntrinsic::getForOpcode removal

### DIFF
--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/transform/packetizer.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/transform/packetizer.cpp
@@ -3005,6 +3005,21 @@ ValuePacket Packetizer::Impl::packetizeGEP(GetElementPtrInst *GEP) {
   return results;
 }
 
+// VPIntrinsic::getForOpcode() was removed upstream (llvm/llvm-project#217861);
+// inline the equivalent opcode -> llvm.vp.* intrinsic ID lookup here.
+static Intrinsic::ID getVPIntrinsicForOpcode(unsigned IROPC) {
+  switch (IROPC) {
+  default:
+    break;
+
+#define BEGIN_REGISTER_VP_INTRINSIC(VPID, ...) break;
+#define VP_PROPERTY_FUNCTIONAL_OPC(OPC) case Instruction::OPC:
+#define END_REGISTER_VP_INTRINSIC(VPID) return Intrinsic::VPID;
+#include "llvm/IR/VPIntrinsics.def"
+  }
+  return Intrinsic::not_intrinsic;
+}
+
 ValuePacket Packetizer::Impl::packetizeBinaryOp(BinaryOperator *BinOp) {
   ValuePacket results;
   auto packetWidth = getPacketWidthForType(BinOp->getType());
@@ -3022,7 +3037,7 @@ ValuePacket Packetizer::Impl::packetizeBinaryOp(BinaryOperator *BinOp) {
     // operations in other cases. This support will improve over time.
     if (Ctx.targetInfo().isVPVectorLegal(F, VecTy)) {
       PACK_FAIL_IF(packetWidth != 1);
-      auto VPId = VPIntrinsic::getForOpcode(opcode);
+      auto VPId = getVPIntrinsicForOpcode(opcode);
       PACK_FAIL_IF(VPId == Intrinsic::not_intrinsic);
       auto *const Mask = createAllTrueMask(
           B, multi_llvm::getVectorElementCount(LHS[0]->getType()));

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/transform/packetizer.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/transform/packetizer.cpp
@@ -3005,8 +3005,6 @@ ValuePacket Packetizer::Impl::packetizeGEP(GetElementPtrInst *GEP) {
   return results;
 }
 
-// VPIntrinsic::getForOpcode() was removed upstream (llvm/llvm-project#217861);
-// inline the equivalent opcode -> llvm.vp.* intrinsic ID lookup here.
 static Intrinsic::ID getVPIntrinsicForOpcode(unsigned IROPC) {
   switch (IROPC) {
   default:


### PR DESCRIPTION
Upstream commit 6fa23cf17130 ("[IR] Remove VPIntrinsic::getFor{Opcode,Intrinsic}. NFC", #217861) removed VPIntrinsic::getForOpcode(). Inline the equivalent opcode -> llvm.vp.*intrinsic ID lookup locally in packetizer.cpp, mirroring how LoopUtils.cpp was updated in that same commit.