### PR TITLE
[SYCL] Fix native-cpu build PassInfoMixin error after 80a1e2125c7e

### DIFF
--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/define_mux_builtins_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/define_mux_builtins_pass.h
@@ -25,7 +25,7 @@ namespace compiler {
 namespace utils {
 
 class DefineMuxBuiltinsPass final
-    : public llvm::PassInfoMixin<DefineMuxBuiltinsPass> {
+    : public llvm::OptionalPassInfoMixin<DefineMuxBuiltinsPass> {
 public:
   llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);
 };

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/encode_kernel_metadata_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/encode_kernel_metadata_pass.h
@@ -32,7 +32,7 @@ namespace utils {
 /// @brief Sets up the per-function mux metadata used by later passes.
 /// Transfers per-module !opencl.kernel metadata to mux kernel metadata.
 struct TransferKernelMetadataPass
-    : public llvm::PassInfoMixin<TransferKernelMetadataPass> {
+    : public llvm::OptionalPassInfoMixin<TransferKernelMetadataPass> {
   explicit TransferKernelMetadataPass() {}
 
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
@@ -44,7 +44,7 @@ struct EncodeKernelMetadataPassOptions {
 };
 
 struct EncodeKernelMetadataPass
-    : public llvm::PassInfoMixin<EncodeKernelMetadataPass> {
+    : public llvm::OptionalPassInfoMixin<EncodeKernelMetadataPass> {
   EncodeKernelMetadataPass(EncodeKernelMetadataPassOptions Options)
       : KernelName(Options.KernelName), LocalSizes(Options.LocalSizes) {}
 

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/optimal_builtin_replacement_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/optimal_builtin_replacement_pass.h
@@ -49,7 +49,7 @@ namespace utils {
 /// * replaceAbacusFMinFMax
 /// * Invoking emitBuiltinInline from BuiltinInfo analysis
 class OptimalBuiltinReplacementPass
-    : public llvm::PassInfoMixin<OptimalBuiltinReplacementPass> {
+    : public llvm::OptionalPassInfoMixin<OptimalBuiltinReplacementPass> {
 public:
   using ReplacementFnTy = std::function<llvm::Value *(
       llvm::CallBase &, llvm::StringRef,

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/prepare_barriers_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/prepare_barriers_pass.h
@@ -35,7 +35,7 @@ namespace utils {
 ///
 /// Runs over all kernels with "kernel entry point" metadata.
 class PrepareBarriersPass final
-    : public llvm::PassInfoMixin<PrepareBarriersPass> {
+    : public llvm::OptionalPassInfoMixin<PrepareBarriersPass> {
 public:
   llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);
 };

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/replace_local_module_scope_variables_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/replace_local_module_scope_variables_pass.h
@@ -34,7 +34,7 @@ namespace utils {
 ///
 /// Runs over all kernels with "kernel" metadata.
 class ReplaceLocalModuleScopeVariablesPass final
-    : public llvm::PassInfoMixin<ReplaceLocalModuleScopeVariablesPass> {
+    : public llvm::OptionalPassInfoMixin<ReplaceLocalModuleScopeVariablesPass> {
 public:
   llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);
 };

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/sub_group_analysis.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/sub_group_analysis.h
@@ -100,7 +100,7 @@ private:
 /// @brief Helper pass to print out the contents of the SubgroupAnalysis
 /// analysis.
 class SubgroupAnalysisPrinterPass
-    : public llvm::PassInfoMixin<SubgroupAnalysisPrinterPass> {
+    : public llvm::OptionalPassInfoMixin<SubgroupAnalysisPrinterPass> {
   llvm::raw_ostream &OS;
 
 public:

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/unique_opaque_structs_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/unique_opaque_structs_pass.h
@@ -43,7 +43,7 @@ namespace utils {
 /// This pass can be used to  resolve this issue by searching for
 /// problematic types and replacing them with their unsuffixed version.
 class UniqueOpaqueStructsPass
-    : public llvm::PassInfoMixin<UniqueOpaqueStructsPass> {
+    : public llvm::OptionalPassInfoMixin<UniqueOpaqueStructsPass> {
 public:
   UniqueOpaqueStructsPass() = default;
   llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/work_item_loops_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/compiler_pipeline/include/compiler/utils/work_item_loops_pass.h
@@ -70,7 +70,8 @@ struct WorkItemLoopsPassOptions {
 ///
 /// Runs over all kernels with "kernel entry point" metadata. Work-item orders
 /// are sourced from the "work item order" function metadata on each kernel.
-class WorkItemLoopsPass final : public llvm::PassInfoMixin<WorkItemLoopsPass> {
+class WorkItemLoopsPass final
+    : public llvm::OptionalPassInfoMixin<WorkItemLoopsPass> {
 public:
   /// @brief Constructor.
   WorkItemLoopsPass(const WorkItemLoopsPassOptions &Options)

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/include/vecz/pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/include/vecz/pass.h
@@ -120,7 +120,7 @@ public:
 /// @brief A helper pass which can be used to inspect and test the
 /// vectorization options set on a per-function basis.
 class VeczPassOptionsPrinterPass
-    : public llvm::PassInfoMixin<VeczPassOptionsPrinterPass> {
+    : public llvm::OptionalPassInfoMixin<VeczPassOptionsPrinterPass> {
   llvm::raw_ostream &OS;
 
 public:
@@ -138,7 +138,7 @@ public:
 /// if you do not wish all kernels to be vectorized, you must ensure your pass
 /// manager's ModuleAnalysisManager is configured with a custom @ref
 /// `VeczShouldRunOnFunctionAnalysis`
-class RunVeczPass : public llvm::PassInfoMixin<RunVeczPass> {
+class RunVeczPass : public llvm::OptionalPassInfoMixin<RunVeczPass> {
 public:
   /// @brief llvm's entry point for the PassManager
   llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/analysis/stride_analysis.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/analysis/stride_analysis.h
@@ -126,7 +126,7 @@ private:
 /// @brief Helper pass to print out the contents of the StrideAnalysis
 /// analysis.
 class StrideAnalysisPrinterPass
-    : public llvm::PassInfoMixin<StrideAnalysisPrinterPass> {
+    : public llvm::OptionalPassInfoMixin<StrideAnalysisPrinterPass> {
   llvm::raw_ostream &OS;
 
 public:

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/common_gep_elimination_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/common_gep_elimination_pass.h
@@ -31,7 +31,7 @@ class VectorizationUnit;
 /// @brief This pass removes every duplicate GEP instruction before the
 /// packetization pass.
 class CommonGEPEliminationPass
-    : public llvm::PassInfoMixin<CommonGEPEliminationPass> {
+    : public llvm::OptionalPassInfoMixin<CommonGEPEliminationPass> {
 public:
   static void *ID() { return (void *)&PassID; };
 

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/control_flow_conversion_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/control_flow_conversion_pass.h
@@ -53,7 +53,7 @@ class Reachability;
 /// @brief Pass that convert performs control-flow to data-flow conversion for
 /// a function.
 class ControlFlowConversionPass
-    : public llvm::PassInfoMixin<ControlFlowConversionPass> {
+    : public llvm::OptionalPassInfoMixin<ControlFlowConversionPass> {
 public:
   /// @brief Unique identifier for the pass.
   static void *ID() { return (void *)&PassID; }

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/inline_post_vectorization_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/inline_post_vectorization_pass.h
@@ -29,7 +29,7 @@ namespace vecz {
 /// @brief This pass replaces calls to builtins that require special attention
 /// after vectorization.
 class InlinePostVectorizationPass
-    : public llvm::PassInfoMixin<InlinePostVectorizationPass> {
+    : public llvm::OptionalPassInfoMixin<InlinePostVectorizationPass> {
 public:
   /// @brief Create a new pass object.
   InlinePostVectorizationPass() {}

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/interleaved_group_combine_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/interleaved_group_combine_pass.h
@@ -36,7 +36,7 @@ class VectorizationUnit;
 
 /// @brief Combine groups of interleaved memory operations.
 class InterleavedGroupCombinePass
-    : public llvm::PassInfoMixin<InterleavedGroupCombinePass> {
+    : public llvm::OptionalPassInfoMixin<InterleavedGroupCombinePass> {
 public:
   /// @brief Create a new pass object.
   ///

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/packetization_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/packetization_pass.h
@@ -33,7 +33,8 @@ class VectorizationUnit;
 
 /// @brief Vectorization pass where scalar instructions that need it are
 /// packetized, starting from leaves.
-class PacketizationPass : public llvm::PassInfoMixin<PacketizationPass> {
+class PacketizationPass
+    : public llvm::OptionalPassInfoMixin<PacketizationPass> {
 public:
   /// @brief Create a new packetization pass object.
   PacketizationPass() = default;

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/passes.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/passes.h
@@ -32,7 +32,7 @@ class BuiltinInfo;
 
 namespace vecz {
 class SimplifyInfiniteLoopPass
-    : public llvm::PassInfoMixin<SimplifyInfiniteLoopPass> {
+    : public llvm::OptionalPassInfoMixin<SimplifyInfiniteLoopPass> {
 public:
   SimplifyInfiniteLoopPass() = default;
 
@@ -43,7 +43,8 @@ public:
 
 /// @brief This pass replaces calls to builtins that require special attention
 /// (e.g. there is no scalar or vector equivalent) with inline implementations.
-class BuiltinInliningPass : public llvm::PassInfoMixin<BuiltinInliningPass> {
+class BuiltinInliningPass
+    : public llvm::OptionalPassInfoMixin<BuiltinInliningPass> {
 public:
   /// @brief Create a new pass object.
   BuiltinInliningPass() = default;
@@ -72,7 +73,7 @@ private:
 /// @brief This pass tries to remove unecessary allocas that are not optimized
 /// away by LLVM's Mem2Reg pass, for example in the presence of bitcasts. It is
 /// however much simpler than LLVM's.
-class BasicMem2RegPass : public llvm::PassInfoMixin<BasicMem2RegPass> {
+class BasicMem2RegPass : public llvm::OptionalPassInfoMixin<BasicMem2RegPass> {
 public:
   BasicMem2RegPass() {};
 
@@ -103,7 +104,7 @@ private:
   bool promoteAlloca(llvm::AllocaInst *Alloca) const;
 };
 
-class PreLinearizePass : public llvm::PassInfoMixin<PreLinearizePass> {
+class PreLinearizePass : public llvm::OptionalPassInfoMixin<PreLinearizePass> {
 public:
   PreLinearizePass() = default;
 
@@ -115,7 +116,8 @@ public:
 
 /// @brief Wraps llvm's LoopRotatePass but retricts the range of loops on which
 /// it works.
-class VeczLoopRotatePass : public llvm::PassInfoMixin<VeczLoopRotatePass> {
+class VeczLoopRotatePass
+    : public llvm::OptionalPassInfoMixin<VeczLoopRotatePass> {
 public:
   VeczLoopRotatePass() {}
 
@@ -126,7 +128,7 @@ public:
   static llvm::StringRef name() { return "Vecz Loop Rotation Wrapper"; };
 };
 
-class RemoveIntPtrPass : public llvm::PassInfoMixin<RemoveIntPtrPass> {
+class RemoveIntPtrPass : public llvm::OptionalPassInfoMixin<RemoveIntPtrPass> {
 public:
   RemoveIntPtrPass() = default;
 
@@ -137,7 +139,7 @@ public:
 };
 
 class SquashSmallVectorsPass
-    : public llvm::PassInfoMixin<SquashSmallVectorsPass> {
+    : public llvm::OptionalPassInfoMixin<SquashSmallVectorsPass> {
 public:
   SquashSmallVectorsPass() = default;
 
@@ -150,7 +152,7 @@ public:
 /// @brief Try to replace or remove masked memory operations that are trivially
 /// not needed or can be converted to non-masked operations.
 class SimplifyMaskedMemOpsPass
-    : public llvm::PassInfoMixin<SimplifyMaskedMemOpsPass> {
+    : public llvm::OptionalPassInfoMixin<SimplifyMaskedMemOpsPass> {
 public:
   /// @brief Create a new pass object.
   SimplifyMaskedMemOpsPass() = default;
@@ -172,7 +174,7 @@ public:
 
 /// @brief reassociate uniform binary operators and split branches
 class UniformReassociationPass
-    : public llvm::PassInfoMixin<UniformReassociationPass> {
+    : public llvm::OptionalPassInfoMixin<UniformReassociationPass> {
 public:
   UniformReassociationPass() = default;
 
@@ -184,7 +186,7 @@ public:
 
 /// @brief Removes uniform divergence reductions created by CFG conversion
 class DivergenceCleanupPass
-    : public llvm::PassInfoMixin<DivergenceCleanupPass> {
+    : public llvm::OptionalPassInfoMixin<DivergenceCleanupPass> {
 public:
   /// @brief Create a new pass object.
   DivergenceCleanupPass() = default;

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/scalarization_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/scalarization_pass.h
@@ -38,7 +38,8 @@ class VectorizationUnit;
 
 /// @brief Scalarization pass where vector instructions that need it are
 /// scalarized, starting from leaves.
-class ScalarizationPass : public llvm::PassInfoMixin<ScalarizationPass> {
+class ScalarizationPass
+    : public llvm::OptionalPassInfoMixin<ScalarizationPass> {
 public:
   /// @brief Create a new scalarizaation pass.
   ScalarizationPass();

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/ternary_transform_pass.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/transform/ternary_transform_pass.h
@@ -28,7 +28,8 @@ namespace vecz {
 
 /// @brief This pass tries to transform selects with pointer operands,
 /// transforms to individual GEPs followed by masked memory operations.
-class TernaryTransformPass : public llvm::PassInfoMixin<TernaryTransformPass> {
+class TernaryTransformPass
+    : public llvm::OptionalPassInfoMixin<TernaryTransformPass> {
 public:
   TernaryTransformPass() = default;
 

--- a/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/vectorization_context.h
+++ b/llvm/lib/SYCLNativeCPUUtils/compiler_passes/vecz/source/include/vectorization_context.h
@@ -359,7 +359,7 @@ private:
 
 /// @brief Implement internal builtins.
 class DefineInternalBuiltinsPass
-    : public llvm::PassInfoMixin<DefineInternalBuiltinsPass> {
+    : public llvm::OptionalPassInfoMixin<DefineInternalBuiltinsPass> {
 public:
   /// @brief Create a new pass object.
   DefineInternalBuiltinsPass() {}


### PR DESCRIPTION
Upstream commit 80a1e2125c7e moved PassInfoMixin to detail namespace. Fix by using OptionalPassInfoMixin.