### PR TITLE
[SYCL] Fix RequiredPassInfoMixin/OptionalPassInfoMixin mismatches from 28ff76e11c7d

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/CleanupSYCLMetadata.h
+++ b/llvm/include/llvm/SYCLLowerIR/CleanupSYCLMetadata.h
@@ -19,7 +19,7 @@
 namespace llvm {
 
 class CleanupSYCLMetadataPass
-    : public RequiredPassInfoMixin<CleanupSYCLMetadataPass> {
+    : public OptionalPassInfoMixin<CleanupSYCLMetadataPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
@@ -32,7 +32,7 @@ public:
 /// of a compilation stage and the references to the kernels callable from
 /// host must not have users.
 class CleanupSYCLMetadataFromLLVMUsed
-    : public RequiredPassInfoMixin<CleanupSYCLMetadataFromLLVMUsed> {
+    : public OptionalPassInfoMixin<CleanupSYCLMetadataFromLLVMUsed> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
@@ -46,7 +46,7 @@ public:
 /// variables, we remove them from llvm.compiler.used and erase them if they
 /// have no further uses.
 class RemoveDeviceGlobalFromLLVMCompilerUsed
-    : public RequiredPassInfoMixin<RemoveDeviceGlobalFromLLVMCompilerUsed> {
+    : public OptionalPassInfoMixin<RemoveDeviceGlobalFromLLVMCompilerUsed> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };

--- a/llvm/include/llvm/SYCLLowerIR/CompileTimePropertiesPass.h
+++ b/llvm/include/llvm/SYCLLowerIR/CompileTimePropertiesPass.h
@@ -28,7 +28,7 @@ class GlobalVariable;
 class IntrinsicInst;
 
 class CompileTimePropertiesPass
-    : public RequiredPassInfoMixin<CompileTimePropertiesPass> {
+    : public OptionalPassInfoMixin<CompileTimePropertiesPass> {
 public:
   // Enriches the module with metadata that describes the found variables for
   // the SPIRV-LLVM Translator.

--- a/llvm/include/llvm/SYCLLowerIR/ConvertToMuxBuiltinsSYCLNativeCPU.h
+++ b/llvm/include/llvm/SYCLLowerIR/ConvertToMuxBuiltinsSYCLNativeCPU.h
@@ -21,7 +21,7 @@ namespace llvm {
 class ModulePass;
 
 class ConvertToMuxBuiltinsSYCLNativeCPUPass
-    : public RequiredPassInfoMixin<ConvertToMuxBuiltinsSYCLNativeCPUPass> {
+    : public OptionalPassInfoMixin<ConvertToMuxBuiltinsSYCLNativeCPUPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };

--- a/llvm/include/llvm/SYCLLowerIR/ESIMD/ESIMDVerifier.h
+++ b/llvm/include/llvm/SYCLLowerIR/ESIMD/ESIMDVerifier.h
@@ -23,7 +23,6 @@ struct ESIMDVerifierPass : public RequiredPassInfoMixin<ESIMDVerifierPass> {
   ESIMDVerifierPass(bool MayNeedForceStatelessMemModeAPI = true)
       : MayNeedForceStatelessMemModeAPI(MayNeedForceStatelessMemModeAPI) {}
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
-  static bool isRequired() { return true; }
 
   // The verifier pass allows more SYCL classes/methods when stateless
   // memory accesses are not explicitly disabled by compilation switches.

--- a/llvm/include/llvm/SYCLLowerIR/ESIMD/LowerESIMD.h
+++ b/llvm/include/llvm/SYCLLowerIR/ESIMD/LowerESIMD.h
@@ -32,7 +32,7 @@ class PassRegistry;
 
 /// SPIRV (ESIMD) target specific pass to transform ESIMD specific constructs
 /// like intrinsics to a form parsable by the ESIMD-aware SPIRV translator.
-class SYCLLowerESIMDPass : public RequiredPassInfoMixin<SYCLLowerESIMDPass> {
+class SYCLLowerESIMDPass : public OptionalPassInfoMixin<SYCLLowerESIMDPass> {
 public:
   SYCLLowerESIMDPass(bool ModuleContainsScalar = true)
       : ModuleContainsScalarCode(ModuleContainsScalar) {}
@@ -48,7 +48,7 @@ ModulePass *createSYCLLowerESIMDPass();
 void initializeSYCLLowerESIMDLegacyPassPass(PassRegistry &);
 
 class ESIMDLowerLoadStorePass
-    : public RequiredPassInfoMixin<ESIMDLowerLoadStorePass> {
+    : public OptionalPassInfoMixin<ESIMDLowerLoadStorePass> {
 public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 };
@@ -62,33 +62,33 @@ void initializeESIMDLowerLoadStorePass(PassRegistry &);
 // - Converts globals of type simd* to simd::raw_vector_t* globals (llvm vector
 // type pointer)
 class ESIMDOptimizeVecArgCallConvPass
-    : public RequiredPassInfoMixin<ESIMDOptimizeVecArgCallConvPass> {
+    : public OptionalPassInfoMixin<ESIMDOptimizeVecArgCallConvPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
 
 // Lowers calls to __esimd_set_kernel_properties
 class SYCLLowerESIMDKernelPropsPass
-    : public RequiredPassInfoMixin<SYCLLowerESIMDKernelPropsPass> {
+    : public OptionalPassInfoMixin<SYCLLowerESIMDKernelPropsPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
 
 // Fixes ESIMD Kernel attributes for wrapper functions for ESIMD kernels
 class SYCLFixupESIMDKernelWrapperMDPass
-    : public RequiredPassInfoMixin<SYCLFixupESIMDKernelWrapperMDPass> {
+    : public OptionalPassInfoMixin<SYCLFixupESIMDKernelWrapperMDPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
 
 class ESIMDRemoveHostCodePass
-    : public RequiredPassInfoMixin<ESIMDRemoveHostCodePass> {
+    : public OptionalPassInfoMixin<ESIMDRemoveHostCodePass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
 
 class ESIMDRemoveOptnoneNoinlinePass
-    : public RequiredPassInfoMixin<ESIMDRemoveOptnoneNoinlinePass> {
+    : public OptionalPassInfoMixin<ESIMDRemoveOptnoneNoinlinePass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
@@ -96,7 +96,7 @@ public:
 // Lowers calls __esimd_slm_alloc, __esimd_slm_free and __esimd_slm_init APIs.
 // See more details in the .cpp file.
 class ESIMDLowerSLMReservationCalls
-    : public RequiredPassInfoMixin<ESIMDLowerSLMReservationCalls> {
+    : public OptionalPassInfoMixin<ESIMDLowerSLMReservationCalls> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -25,7 +25,7 @@ class PassRegistry;
 /// `_Z27__spirv_BuiltInGlobalOffseti`). These uses are replaced with an
 /// explicit offset parameter which is threaded through from the kernel
 /// entry point.
-class GlobalOffsetPass : public RequiredPassInfoMixin<GlobalOffsetPass> {
+class GlobalOffsetPass : public OptionalPassInfoMixin<GlobalOffsetPass> {
 public:
   explicit GlobalOffsetPass()
       : GlobalVMap(std::make_unique<llvm::ValueToValueMapTy>()) {}

--- a/llvm/include/llvm/SYCLLowerIR/LocalAccessorToSharedMemory.h
+++ b/llvm/include/llvm/SYCLLowerIR/LocalAccessorToSharedMemory.h
@@ -24,7 +24,7 @@ class PassRegistry;
 /// runtime is expected to provide offsets rather than pointers to these
 /// functions.
 class LocalAccessorToSharedMemoryPass
-    : public RequiredPassInfoMixin<LocalAccessorToSharedMemoryPass> {
+    : public OptionalPassInfoMixin<LocalAccessorToSharedMemoryPass> {
 public:
   explicit LocalAccessorToSharedMemoryPass() {}
 

--- a/llvm/include/llvm/SYCLLowerIR/LowerInvokeSimd.h
+++ b/llvm/include/llvm/SYCLLowerIR/LowerInvokeSimd.h
@@ -18,7 +18,7 @@
 
 namespace llvm {
 class SYCLLowerInvokeSimdPass
-    : public RequiredPassInfoMixin<SYCLLowerInvokeSimdPass> {
+    : public OptionalPassInfoMixin<SYCLLowerInvokeSimdPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };

--- a/llvm/include/llvm/SYCLLowerIR/LowerWGLocalMemory.h
+++ b/llvm/include/llvm/SYCLLowerIR/LowerWGLocalMemory.h
@@ -39,7 +39,7 @@ class ModulePass;
 class PassRegistry;
 
 class SYCLLowerWGLocalMemoryPass
-    : public RequiredPassInfoMixin<SYCLLowerWGLocalMemoryPass> {
+    : public OptionalPassInfoMixin<SYCLLowerWGLocalMemoryPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };

--- a/llvm/include/llvm/SYCLLowerIR/LowerWGScope.h
+++ b/llvm/include/llvm/SYCLLowerIR/LowerWGScope.h
@@ -22,7 +22,7 @@ class FunctionPass;
 /// SPIRV target specific pass to transform work group-scope code to match SIMT
 /// execution model semantics - this code must be executed once per work group.
 class SYCLLowerWGScopePass
-    : public RequiredPassInfoMixin<SYCLLowerWGScopePass> {
+    : public OptionalPassInfoMixin<SYCLLowerWGScopePass> {
 public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 };

--- a/llvm/include/llvm/SYCLLowerIR/MutatePrintfAddrspace.h
+++ b/llvm/include/llvm/SYCLLowerIR/MutatePrintfAddrspace.h
@@ -24,7 +24,7 @@ namespace llvm {
 class ModulePass;
 
 class SYCLMutatePrintfAddrspacePass
-    : public RequiredPassInfoMixin<SYCLMutatePrintfAddrspacePass> {
+    : public OptionalPassInfoMixin<SYCLMutatePrintfAddrspacePass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };

--- a/llvm/include/llvm/SYCLLowerIR/PrepareSYCLNativeCPU.h
+++ b/llvm/include/llvm/SYCLLowerIR/PrepareSYCLNativeCPU.h
@@ -22,7 +22,7 @@ namespace llvm {
 class ModulePass;
 
 class PrepareSYCLNativeCPUPass
-    : public RequiredPassInfoMixin<PrepareSYCLNativeCPUPass> {
+    : public OptionalPassInfoMixin<PrepareSYCLNativeCPUPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };

--- a/llvm/include/llvm/SYCLLowerIR/RecordSYCLAspectNames.h
+++ b/llvm/include/llvm/SYCLLowerIR/RecordSYCLAspectNames.h
@@ -26,7 +26,7 @@
 namespace llvm {
 
 class RecordSYCLAspectNamesPass
-    : public RequiredPassInfoMixin<RecordSYCLAspectNamesPass> {
+    : public OptionalPassInfoMixin<RecordSYCLAspectNamesPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };

--- a/llvm/include/llvm/SYCLLowerIR/RenameKernelSYCLNativeCPU.h
+++ b/llvm/include/llvm/SYCLLowerIR/RenameKernelSYCLNativeCPU.h
@@ -21,7 +21,7 @@ namespace llvm {
 class ModulePass;
 
 class RenameKernelSYCLNativeCPUPass
-    : public RequiredPassInfoMixin<RenameKernelSYCLNativeCPUPass> {
+    : public OptionalPassInfoMixin<RenameKernelSYCLNativeCPUPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };

--- a/llvm/include/llvm/SYCLLowerIR/SYCLAddOptLevelAttribute.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLAddOptLevelAttribute.h
@@ -19,7 +19,7 @@
 namespace llvm {
 
 class SYCLAddOptLevelAttributePass
-    : public RequiredPassInfoMixin<SYCLAddOptLevelAttributePass> {
+    : public OptionalPassInfoMixin<SYCLAddOptLevelAttributePass> {
 public:
   SYCLAddOptLevelAttributePass(int OptLevel = -1) : OptLevel{OptLevel} {};
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);

--- a/llvm/include/llvm/SYCLLowerIR/SYCLConditionalCallOnDevice.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLConditionalCallOnDevice.h
@@ -22,7 +22,7 @@
 namespace llvm {
 
 class SYCLConditionalCallOnDevicePass
-    : public RequiredPassInfoMixin<SYCLConditionalCallOnDevicePass> {
+    : public OptionalPassInfoMixin<SYCLConditionalCallOnDevicePass> {
 public:
   SYCLConditionalCallOnDevicePass(std::string SYCLUniquePrefix = "")
       : UniquePrefix(SYCLUniquePrefix) {}

--- a/llvm/include/llvm/SYCLLowerIR/SYCLCreateNVVMAnnotations.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLCreateNVVMAnnotations.h
@@ -21,8 +21,6 @@ class SYCLCreateNVVMAnnotationsPass
     : public RequiredPassInfoMixin<SYCLCreateNVVMAnnotationsPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
-
-  static bool isRequired() { return true; }
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/SYCLLowerIR/SYCLJointMatrixTransform.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLJointMatrixTransform.h
@@ -22,8 +22,6 @@ class SYCLJointMatrixTransformPass
     : public RequiredPassInfoMixin<SYCLJointMatrixTransformPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
-
-  static bool isRequired() { return true; }
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/SYCLLowerIR/SYCLOptimizeBarriers.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLOptimizeBarriers.h
@@ -20,8 +20,6 @@ class SYCLOptimizeBarriersPass
     : public RequiredPassInfoMixin<SYCLOptimizeBarriersPass> {
 public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
-
-  static bool isRequired() { return true; }
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/SYCLLowerIR/SYCLPropagateAspectsUsage.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLPropagateAspectsUsage.h
@@ -20,7 +20,7 @@
 namespace llvm {
 
 class SYCLPropagateAspectsUsagePass
-    : public RequiredPassInfoMixin<SYCLPropagateAspectsUsagePass> {
+    : public OptionalPassInfoMixin<SYCLPropagateAspectsUsagePass> {
 public:
   SYCLPropagateAspectsUsagePass(bool FP64ConvEmu = false,
                                 std::set<StringRef> ExcludeAspects = {},

--- a/llvm/include/llvm/SYCLLowerIR/SYCLPropagateJointMatrixUsage.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLPropagateJointMatrixUsage.h
@@ -20,7 +20,7 @@
 namespace llvm {
 
 class SYCLPropagateJointMatrixUsagePass
-    : public RequiredPassInfoMixin<SYCLPropagateJointMatrixUsagePass> {
+    : public OptionalPassInfoMixin<SYCLPropagateJointMatrixUsagePass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };

--- a/llvm/include/llvm/SYCLLowerIR/SYCLRemangleLibspirv.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLRemangleLibspirv.h
@@ -18,7 +18,7 @@
 namespace llvm {
 
 class SYCLRemangleLibspirvPass
-    : public RequiredPassInfoMixin<SYCLRemangleLibspirvPass> {
+    : public OptionalPassInfoMixin<SYCLRemangleLibspirvPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };

--- a/llvm/include/llvm/SYCLLowerIR/SYCLVirtualFunctionsAnalysis.h
+++ b/llvm/include/llvm/SYCLLowerIR/SYCLVirtualFunctionsAnalysis.h
@@ -18,7 +18,7 @@
 namespace llvm {
 
 class SYCLVirtualFunctionsAnalysisPass
-    : public RequiredPassInfoMixin<SYCLVirtualFunctionsAnalysisPass> {
+    : public OptionalPassInfoMixin<SYCLVirtualFunctionsAnalysisPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };

--- a/llvm/include/llvm/SYCLLowerIR/SanitizerPostOptimizer.h
+++ b/llvm/include/llvm/SYCLLowerIR/SanitizerPostOptimizer.h
@@ -16,7 +16,7 @@
 namespace llvm {
 
 class SanitizerPostOptimizerPass
-    : public RequiredPassInfoMixin<SanitizerPostOptimizerPass> {
+    : public OptionalPassInfoMixin<SanitizerPostOptimizerPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };

--- a/llvm/include/llvm/SYCLLowerIR/SpecConstants.h
+++ b/llvm/include/llvm/SYCLLowerIR/SpecConstants.h
@@ -48,7 +48,7 @@ struct SpecConstantDescriptor {
 
 using SpecIDMapTy = MapVector<StringRef, std::vector<SpecConstantDescriptor>>;
 
-class SpecConstantsPass : public RequiredPassInfoMixin<SpecConstantsPass> {
+class SpecConstantsPass : public OptionalPassInfoMixin<SpecConstantsPass> {
 public:
   // HandlingMode parameter controls spec constant handling:
   // - default_values: spec constant uses are replaced by default values.

--- a/llvm/include/llvm/Transforms/IPO/DeadArgumentElimination.h
+++ b/llvm/include/llvm/Transforms/IPO/DeadArgumentElimination.h
@@ -152,7 +152,7 @@ private:
 };
 
 class DeadArgumentEliminationSYCLPass
-    : public RequiredPassInfoMixin<DeadArgumentEliminationSYCLPass> {
+    : public OptionalPassInfoMixin<DeadArgumentEliminationSYCLPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM) {
     return Impl.run(M, MAM);

--- a/llvm/include/llvm/Transforms/Instrumentation/CopyProf.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/CopyProf.h
@@ -24,8 +24,6 @@ class CopyProfPass : public RequiredPassInfoMixin<CopyProfPass> {
 public:
   CopyProfPass() = default;
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
-
-  static bool isRequired() { return true; }
 };
 
 // Module-level pass that inserts the CopyProf runtime initialization
@@ -34,8 +32,6 @@ class ModuleCopyProfPass : public RequiredPassInfoMixin<ModuleCopyProfPass> {
 public:
   ModuleCopyProfPass() = default;
   LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
-
-  static bool isRequired() { return true; }
 };
 
 // Late-stage pass that instruments store instructions to detect whether an
@@ -44,8 +40,6 @@ class CopyProfStoresPass : public RequiredPassInfoMixin<CopyProfStoresPass> {
 public:
   CopyProfStoresPass() = default;
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
-
-  static bool isRequired() { return true; }
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Instrumentation/SPIRITTAnnotations.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/SPIRITTAnnotations.h
@@ -20,7 +20,7 @@ namespace llvm {
 class ModulePass;
 
 class SPIRITTAnnotationsPass
-    : public RequiredPassInfoMixin<SPIRITTAnnotationsPass> {
+    : public OptionalPassInfoMixin<SPIRITTAnnotationsPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 };

--- a/llvm/include/llvm/Transforms/Scalar/FPBuiltinFnSelection.h
+++ b/llvm/include/llvm/Transforms/Scalar/FPBuiltinFnSelection.h
@@ -20,7 +20,7 @@ namespace llvm {
 class Module;
 
 struct FPBuiltinFnSelectionPass
-    : RequiredPassInfoMixin<FPBuiltinFnSelectionPass> {
+    : OptionalPassInfoMixin<FPBuiltinFnSelectionPass> {
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 

--- a/sycl-jit/passes/materializer/SYCLSpecConstMaterializer.h
+++ b/sycl-jit/passes/materializer/SYCLSpecConstMaterializer.h
@@ -19,7 +19,7 @@ class Function;
 /// Utility pass to insert specialization constants values into the module as a
 /// metadata node.
 class SYCLSpecConstDataInserter
-    : public RequiredPassInfoMixin<SYCLSpecConstDataInserter> {
+    : public OptionalPassInfoMixin<SYCLSpecConstDataInserter> {
 public:
   SYCLSpecConstDataInserter(ArrayRef<unsigned char> SpecConstData)
       : SpecConstData(SpecConstData) {};
@@ -40,7 +40,7 @@ private:
 /// CSE), we do not track instructions that can be removed as a result of
 /// materialization, as the pipeline runs DCE pass afterwords.
 class SYCLSpecConstMaterializer
-    : public RequiredPassInfoMixin<SYCLSpecConstMaterializer> {
+    : public OptionalPassInfoMixin<SYCLSpecConstMaterializer> {
 public:
   SYCLSpecConstMaterializer() : SpecConstData(nullptr), SpecConstDataSize(0) {}
 


### PR DESCRIPTION
Passes without isRequired() returning true now use OptionalPassInfoMixin instead of RequiredPassInfoMixin. Passes that do return true from isRequired() keep RequiredPassInfoMixin and drop the now-redundant isRequired() override, since RequiredPassInfoMixin already provides it.
Fixes bad merge 28ff76e11c7d.