### PR TITLE
[SYCL] Fix id default ctor deleted with GCC 7.5.0

### DIFF
--- a/sycl/include/sycl/detail/array.hpp
+++ b/sycl/include/sycl/detail/array.hpp
@@ -30,27 +30,27 @@ public:
   /* The following constructor is only available in the array struct
    * specialization where: dimensions==1 */
   template <int N = dimensions>
-  array(typename std::enable_if_t<(N == 1), size_t> dim0 = 0)
+  array(typename std::enable_if_t<(N == 1), size_t> dim0 = 0) noexcept
       : common_array{dim0} {}
 
   /* The following constructors are only available in the array struct
    * specialization where: dimensions==2 */
   template <int N = dimensions>
-  array(typename std::enable_if_t<(N == 2), size_t> dim0, size_t dim1)
+  array(typename std::enable_if_t<(N == 2), size_t> dim0, size_t dim1) noexcept
       : common_array{dim0, dim1} {}
 
   template <int N = dimensions, std::enable_if_t<(N == 2), size_t> = 0>
-  array() : array(0, 0) {}
+  array() noexcept : array(0, 0) {}
 
   /* The following constructors are only available in the array struct
    * specialization where: dimensions==3 */
   template <int N = dimensions>
   array(typename std::enable_if_t<(N == 3), size_t> dim0, size_t dim1,
-        size_t dim2)
+        size_t dim2) noexcept
       : common_array{dim0, dim1, dim2} {}
 
   template <int N = dimensions, std::enable_if_t<(N == 3), size_t> = 0>
-  array() : array(0, 0, 0) {}
+  array() noexcept : array(0, 0, 0) {}
 
   // Conversion operators to derived classes
   operator sycl::id<dimensions>() const {


### PR DESCRIPTION
Add noexcept to detail::array constructors to match id() noexcept = default.