### PR TITLE
[SYCL] switching out XFAIL for driver requirement

### DIFF
--- a/sycl/test-e2e/Basic/stream/stream.cpp
+++ b/sycl/test-e2e/Basic/stream/stream.cpp
@@ -1,7 +1,8 @@
 // UNSUPPORTED: cuda
 // UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/19214
-// XFAIL: linux && (gpu-intel-gen12 || gpu-intel-dg2 || arch-intel_gpu_pvc || arch-intel_gpu_bmg_g21 || arch-intel_gpu_mtl_u)
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/22055
+
+// REQUIRES-INTEL-DRIVER: lin: 39395
+
 // RUN: %{build} -fsycl-device-code-split=per_kernel -Wno-error=deprecated-declarations -o %t.out
 // RUN: %{run} %t.out %if !gpu || linux %{ | FileCheck %s %}
 


### PR DESCRIPTION
solutino for https://github.com/intel/llvm/issues/22055  introduced XFAIL, but apparently the issue is fixed in driver  `[v26.31.39395.0]`.   Switching to driver requirement to help ameliorate a downstream issue. 