### PR TITLE
[SYCL] Make sub_group non-user-constructible in preview mode

### DIFF
--- a/sycl/include/sycl/ext/oneapi/free_function_queries.hpp
+++ b/sycl/include/sycl/ext/oneapi/free_function_queries.hpp
@@ -36,7 +36,11 @@ template <int Dimensions> group<Dimensions> get_work_group() {
 
 inline sycl::sub_group get_sub_group() {
 #ifdef __SYCL_DEVICE_ONLY__
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  return sycl::sub_group(sycl::sub_group::private_tag{});
+#else
   return sycl::sub_group();
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 #else
   throw sycl::exception(
       sycl::make_error_code(sycl::errc::feature_not_supported),

--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -18,18 +18,14 @@ inline namespace _V1 {
 namespace ext::oneapi {
 struct __SYCL_DEPRECATED("use sycl::sub_group() instead") sub_group
     : sycl::sub_group {
-  // These two constructors are intended to keep the correctness of such code
-  // after the sub_group class migration from ext::oneapi to the sycl namespace:
+  // This converting constructor is intended to keep the correctness of such
+  // code after the sub_group class migration from ext::oneapi to the sycl
+  // namespace:
   // sycl::ext::oneapi::sub_group sg =
   //    sycl::ext::oneapi::experimental::this_sub_group();
   // ...
   // sycl::ext::oneapi::sub_group sg = item.get_sub_group();
-  // Note: this constructor is used for implicit conversion. Since the
-  // sub_group class doesn't have any members, just ignore the arg.
-  sub_group(const sycl::sub_group &sg) : sub_group() { (void)sg; }
-
-private:
-  sub_group() = default;
+  sub_group(const sycl::sub_group &sg) : sycl::sub_group(sg) {}
 };
 } // namespace ext::oneapi
 } // namespace _V1

--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -41,6 +41,10 @@ struct sub_group {
   static constexpr sycl::memory_scope fence_scope =
       sycl::memory_scope::sub_group;
 
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  sub_group() = delete;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+
   /* --- common interface members --- */
 
   id_type get_local_id() const {
@@ -194,12 +198,31 @@ struct sub_group {
 protected:
   template <int dimensions> friend class sycl::nd_item;
   friend sub_group ext::oneapi::this_work_item::get_sub_group();
+
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  // Tag used by the implementation to construct a sub_group. It also makes the
+  // constructor below user-provided, and hence sub_group a non-aggregate:
+  // otherwise `sycl::sub_group{}` would be a well-formed aggregate
+  // initialization in C++17, bypassing the deleted default constructor above.
+  struct private_tag {
+    explicit private_tag() = default;
+  };
+  sub_group(private_tag) {}
+#else
+  // Deprecated: the default constructor is merely inaccessible instead of
+  // deleted, which still lets `sycl::sub_group{}` through as an aggregate
+  // initialization in C++17. Kept for API compatibility.
   sub_group() = default;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
 
 template <int Dimensions>
 sub_group nd_item<Dimensions>::get_sub_group() const noexcept {
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  return sub_group(sub_group::private_tag{});
+#else
   return sub_group();
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 }
 
 } // namespace _V1

--- a/sycl/test/basic_tests/sub_group_interface.cpp
+++ b/sycl/test/basic_tests/sub_group_interface.cpp
@@ -3,7 +3,7 @@
 // RUN: %clangxx -fsycl -fpreview-breaking-changes -fsyntax-only -std=c++17 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 // RUN: %clangxx -fsycl -fpreview-breaking-changes -fsyntax-only -std=c++20 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
-//==--- sub_group_interface.cpp - SYCL sub_group interface conformance test -==//
+//==-- sub_group_interface.cpp - SYCL sub_group interface conformance test -==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/test/basic_tests/sub_group_interface.cpp
+++ b/sycl/test/basic_tests/sub_group_interface.cpp
@@ -1,0 +1,56 @@
+// RUN: %clangxx -fsycl -fsyntax-only -std=c++17 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+// RUN: %clangxx -fsycl -fsyntax-only -std=c++20 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+// RUN: %clangxx -fsycl -fpreview-breaking-changes -fsyntax-only -std=c++17 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+// RUN: %clangxx -fsycl -fpreview-breaking-changes -fsyntax-only -std=c++20 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+
+//==--- sub_group_interface.cpp - SYCL sub_group interface conformance test -==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Checks that sycl::sub_group matches the synopsis in SYCL 2020 section 4.9.1.8
+// and that it cannot be constructed by an application.
+
+#include <sycl/sub_group.hpp>
+
+#include <cstdint>
+#include <type_traits>
+
+using SG = sycl::sub_group;
+
+// Member types and static members.
+static_assert(std::is_same_v<SG::id_type, sycl::id<1>>);
+static_assert(std::is_same_v<SG::range_type, sycl::range<1>>);
+static_assert(std::is_same_v<SG::linear_id_type, std::uint32_t>);
+static_assert(SG::dimensions == 1);
+static_assert(SG::fence_scope == sycl::memory_scope::sub_group);
+
+// Common by-value semantics, SYCL 2020 section 4.5.3.
+static_assert(std::is_copy_constructible_v<SG>);
+static_assert(std::is_copy_assignable_v<SG>);
+static_assert(std::is_move_constructible_v<SG>);
+static_assert(std::is_move_assignable_v<SG>);
+static_assert(std::is_destructible_v<SG>);
+
+// Applications must not be able to construct a sub_group. Note that the class
+// must not be an aggregate either, otherwise `sycl::sub_group{}` would be
+// well-formed aggregate initialization in C++17. Since making the default
+// constructor unusable is an API break, this is only enforced in preview mode.
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+static_assert(!std::is_default_constructible_v<SG>);
+static_assert(!std::is_aggregate_v<SG>);
+
+void cannot_be_constructed() {
+  // expected-error@+1 {{call to deleted constructor of 'sycl::sub_group'}}
+  sycl::sub_group Default;
+  // expected-error@+1 {{call to deleted constructor of 'sycl::sub_group'}}
+  auto BracedInit = sycl::sub_group{};
+  // expected-error@+1 {{call to deleted constructor of 'sycl::sub_group'}}
+  auto ParenInit = sycl::sub_group();
+}
+#else
+// expected-no-diagnostics
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES


### PR DESCRIPTION
SYCL 2020 section 4.9.1.8 specifies `sycl::sub_group` with a deleted default
constructor, but the implementation declared it `protected` and defaulted
instead. That is not equivalent: a constructor that is defaulted on its first
declaration is not *user-provided*, so in C++17 `sub_group` remained an
aggregate and `sycl::sub_group{}` was a well-formed aggregate initialization
that bypassed the access check altogether:

```c++
// Compiles today with -std=c++17, which is the default:
auto sg = sycl::sub_group{};
```

This patch deletes the default constructor and adds a `protected` one taking a
private tag. Being user-provided, it also makes the class a non-aggregate,
which closes the C++17 loophole. `sub_group` objects are now created through
that constructor in `nd_item::get_sub_group()` and
`ext::oneapi::this_work_item::get_sub_group()`, both of which are already
friends.

Applications may rely on the current permissive behavior, so the change is
guarded by `__INTEL_PREVIEW_BREAKING_CHANGES`.

The deprecated `ext::oneapi::sub_group` also stops initializing its base
through a private default constructor: copy-initializing the base works in
both modes and needs no guard.

### Testing

New `sycl/test/basic_tests/sub_group_interface.cpp` checks the SYCL 2020
synopsis, the common by-value semantics, and that the class can be constructed
neither directly nor as an aggregate. It runs in four configurations:
{C++17, C++20} x {default, `-fpreview-breaking-changes`}.

Verified that legitimate ways of obtaining a sub-group still compile in all
four configurations (`nd_item::get_sub_group()`, the free function queries,
`khr::this_sub_group()`, copy/assign/compare, implicit conversion to the
deprecated `ext::oneapi::sub_group`, group algorithms), and that
`sycl::sub_group{}` still compiles outside of preview mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
