### PR TITLE
[SYCL] Unconditionally provide the nd_range default constructor

### DIFF
--- a/sycl/include/sycl/nd_range.hpp
+++ b/sycl/include/sycl/nd_range.hpp
@@ -29,6 +29,8 @@ template <int Dimensions = 1> class nd_range {
 public:
   static constexpr int dimensions = Dimensions;
 
+  nd_range() = default;
+
 private:
   range<Dimensions> globalSize;
   range<Dimensions> localSize;
@@ -62,11 +64,6 @@ public:
   nd_range(nd_range<Dimensions> &&rhs) = default;
   nd_range<Dimensions> &operator=(const nd_range<Dimensions> &rhs) = default;
   nd_range<Dimensions> &operator=(nd_range<Dimensions> &&rhs) = default;
-
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-  nd_range() = default;
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
-
   ~nd_range() = default;
 
   // Common hidden friend functions for by-value semantics

--- a/sycl/test/basic_tests/nd_range.cpp
+++ b/sycl/test/basic_tests/nd_range.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <iostream>
 #include <sycl/sycl.hpp>
+#include <type_traits>
 
 using namespace std;
 int main() {
@@ -59,12 +60,11 @@ int main() {
   assert(three_dim_nd_range.get_offset() == sycl::id<3>(0, 0, 0));
   cout << "three_dim_nd_range passed " << endl;
 
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   // Check that a default-constructed nd_range has zeroed ranges and offset.
+  static_assert(std::is_default_constructible_v<sycl::nd_range<3>>);
   sycl::nd_range<3> default_nd_range;
   assert(default_nd_range.get_global_range() == sycl::range<3>(0, 0, 0));
   assert(default_nd_range.get_local_range() == sycl::range<3>(0, 0, 0));
   assert(default_nd_range.get_offset() == sycl::id<3>(0, 0, 0));
   cout << "default nd_range passed " << endl;
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 }


### PR DESCRIPTION
PR #22908 removed nd_range's default constructor to align the class with the SYCL 2020 specification, and PR #22949 restored it only outside of preview mode, since the specification does not declare one.

KhronosGroup/SYCL-Docs#1043 adds nd_range() to the specification, for the same reason range and id already have one: an nd_range often has to be declared before its global and local ranges are known. With that resolved, there is no reason to keep the constructor and its test behind __INTEL_PREVIEW_BREAKING_CHANGES, so take both out of the guard.

All three members (globalSize, localSize, offset) are range/id objects with zero-initializing default constructors, so a default constructed nd_range has the value 0 for every component of its global range, local range and offset.