### PR TITLE
[offload-arch] Print Intel GPU architecture names instead of device names

### DIFF
--- a/clang/tools/offload-arch/IntelGPUArch.def
+++ b/clang/tools/offload-arch/IntelGPUArch.def
@@ -1,0 +1,69 @@
+//===--- IntelGPUArch.def - Intel GPU architecture names --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file lists the human-friendly names of the Intel GPU architectures,
+// keyed by the architecture and release components of the GMDID that the
+// device reports. The revision component is deliberately not part of the key:
+// every stepping of an architecture shares one name.
+//
+// Several devices can share an architecture and release. The entries are
+// ordered so that the name to print for such a group comes first, which lets
+// this file be generated from a device list without having to pick a
+// representative device. Groups that cover more than one release, such as
+// xe-dg2 or xe-mtl, have no GMDID of their own and are therefore not listed.
+//
+// The intent is for this table to be generated from the data published by the
+// GPU driver, so keep it free of anything a generator cannot produce.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INTEL_GPU_ARCH
+#error "Define INTEL_GPU_ARCH prior to including this file!"
+#endif
+
+// INTEL_GPU_ARCH(ARCHITECTURE, RELEASE, NAME)
+INTEL_GPU_ARCH(35, 11, "xe-cri")
+INTEL_GPU_ARCH(35, 10, "xe-nvl-p")
+INTEL_GPU_ARCH(30, 5, "xe-nvl-u")
+INTEL_GPU_ARCH(30, 5, "xe-nvl-h")
+INTEL_GPU_ARCH(30, 4, "xe-nvl-s")
+INTEL_GPU_ARCH(30, 4, "xe-nvl-hx")
+INTEL_GPU_ARCH(30, 4, "xe-nvl-ul")
+INTEL_GPU_ARCH(30, 3, "xe-wcl")
+INTEL_GPU_ARCH(30, 1, "xe-ptl-u")
+INTEL_GPU_ARCH(30, 0, "xe-ptl-h")
+INTEL_GPU_ARCH(20, 4, "xe-lnl-m")
+INTEL_GPU_ARCH(20, 2, "xe-bmg-g31")
+INTEL_GPU_ARCH(20, 1, "xe-bmg-g21")
+INTEL_GPU_ARCH(12, 74, "xe-arl-h")
+INTEL_GPU_ARCH(12, 71, "xe-mtl-h")
+INTEL_GPU_ARCH(12, 70, "xe-mtl-u")
+INTEL_GPU_ARCH(12, 70, "xe-arl-u")
+INTEL_GPU_ARCH(12, 70, "xe-arl-s")
+INTEL_GPU_ARCH(12, 61, "xe-pvc-vg")
+INTEL_GPU_ARCH(12, 60, "xe-pvc")
+INTEL_GPU_ARCH(12, 60, "xe-pvc-sdv")
+INTEL_GPU_ARCH(12, 57, "xe-acm-g12")
+INTEL_GPU_ARCH(12, 57, "xe-dg2-g12")
+INTEL_GPU_ARCH(12, 56, "xe-acm-g11")
+INTEL_GPU_ARCH(12, 56, "xe-dg2-g11")
+INTEL_GPU_ARCH(12, 56, "xe-ats-m75")
+INTEL_GPU_ARCH(12, 55, "xe-acm-g10")
+INTEL_GPU_ARCH(12, 55, "xe-dg2-g10")
+INTEL_GPU_ARCH(12, 55, "xe-ats-m150")
+INTEL_GPU_ARCH(12, 10, "xe-dg1")
+INTEL_GPU_ARCH(12, 4, "xe-adl-n")
+INTEL_GPU_ARCH(12, 3, "xe-adl-p")
+INTEL_GPU_ARCH(12, 3, "xe-rpl-p")
+INTEL_GPU_ARCH(12, 2, "xe-adl-s")
+INTEL_GPU_ARCH(12, 2, "xe-rpl-s")
+INTEL_GPU_ARCH(12, 1, "xe-rkl")
+INTEL_GPU_ARCH(12, 0, "xe-tgllp")
+INTEL_GPU_ARCH(12, 0, "xe-tgl")
+
+#undef INTEL_GPU_ARCH

--- a/clang/tools/offload-arch/LevelZeroArch.cpp
+++ b/clang/tools/offload-arch/LevelZeroArch.cpp
@@ -11,10 +11,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/Error.h"
 #include <cstdio>
+#include <string>
 
 #define ZE_MAX_DEVICE_NAME 256
 #define ZE_MAX_DEVICE_UUID_SIZE 16
@@ -30,6 +32,7 @@ enum ze_result_t {
 enum ze_structure_type_t {
   ZE_STRUCTURE_TYPE_INIT_DRIVER_TYPE_DESC = 0x00020021,
   ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES = 0x3,
+  ZE_STRUCTURE_TYPE_DEVICE_IP_VERSION_EXT = 0x1000f,
   ZE_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
 };
 
@@ -70,6 +73,13 @@ struct ze_device_properties_t {
   uint32_t kernelTimestampValidBits;
   ze_device_uuid_t uuid;
   char name[ZE_MAX_DEVICE_NAME];
+};
+
+// Chained onto ze_device_properties_t::pNext to request the device IP version.
+struct ze_device_ip_version_ext_t {
+  ze_structure_type_t stype;
+  const void *pNext;
+  uint32_t ipVersion;
 };
 
 ze_result_t zeInitDrivers(uint32_t *pCount, ze_driver_handle_t *phDrivers,
@@ -144,6 +154,48 @@ static bool loadLevelZero() {
     }                                                                          \
   } while (0)
 
+// A GMDID packs the architecture, release and revision of the GPU IP.
+static constexpr uint32_t GMDIDArchitectureShift = 22;
+static constexpr uint32_t GMDIDReleaseShift = 14;
+static constexpr uint32_t GMDIDReleaseMask = 0xff;
+static constexpr uint32_t GMDIDRevisionMask = 0x3f;
+
+// Human-friendly names of the known Intel GPU architectures, keyed by the
+// architecture and release components of the GMDID.  Several devices can share
+// an architecture and a release, in which case the first of them names the
+// whole group.
+static constexpr struct {
+  uint32_t Architecture;
+  uint32_t Release;
+  const char *Name;
+} IntelGPUArchNames[] = {
+#define INTEL_GPU_ARCH(ARCHITECTURE, RELEASE, NAME)                            \
+  {ARCHITECTURE, RELEASE, NAME},
+#include "IntelGPUArch.def"
+};
+
+// Translate a GMDID into an architecture name that is a legal --offload-arch
+// parameter.  Known architectures get a human-friendly name, which covers
+// almost every device a user is likely to have; anything else gets a numeric
+// name built from all three components of the GMDID.
+std::string getIntelGPUArchName(uint32_t IPVersion) {
+  uint32_t Architecture = IPVersion >> GMDIDArchitectureShift;
+  uint32_t Release = (IPVersion >> GMDIDReleaseShift) & GMDIDReleaseMask;
+  uint32_t Revision = IPVersion & GMDIDRevisionMask;
+
+  for (const auto &Entry : IntelGPUArchNames)
+    if (Entry.Architecture == Architecture && Entry.Release == Release)
+      return Entry.Name;
+
+  // A device this build has never heard of still has to be named, so that it
+  // can be used with a compiler that predates it.  The numeric name spells out
+  // the revision as well, because it is the only thing left to distinguish two
+  // steppings of an architecture that has no entry above.
+  return ("xe_" + Twine(Architecture) + "." + Twine(Release) + "." +
+          Twine(Revision))
+      .str();
+}
+
 int printGPUsByLevelZero() {
   if (!loadLevelZero())
     return 1;
@@ -169,11 +221,28 @@ int printGPUsByLevelZero() {
     CALL_ZE_AND_CHECK(zeDeviceGet, Driver, &DeviceCount, Devices.data());
 
     for (auto Device : Devices) {
+      ze_device_ip_version_ext_t IPVersion = {};
+      IPVersion.stype = ZE_STRUCTURE_TYPE_DEVICE_IP_VERSION_EXT;
+      IPVersion.pNext = nullptr;
+
       ze_device_properties_t DeviceProperties = {};
       DeviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
-      DeviceProperties.pNext = nullptr;
+      DeviceProperties.pNext = &IPVersion;
       CALL_ZE_AND_CHECK(zeDeviceGetProperties, Device, &DeviceProperties);
-      llvm::outs() << DeviceProperties.name << '\n';
+
+      // A driver that does not support the extension leaves the chained
+      // structure untouched, in which case there is no architecture to name.
+      if (IPVersion.ipVersion == 0) {
+        if (Verbose)
+          llvm::errs() << "Unable to query the IP version of device '"
+                       << DeviceProperties.name << "'\n";
+        continue;
+      }
+
+      if (Verbose)
+        llvm::errs() << "Found device '" << DeviceProperties.name << "'\n";
+
+      llvm::outs() << getIntelGPUArchName(IPVersion.ipVersion) << '\n';
     }
   }
 

--- a/clang/unittests/offload-arch/CMakeLists.txt
+++ b/clang/unittests/offload-arch/CMakeLists.txt
@@ -1,10 +1,17 @@
+set(OffloadArchTestSources
+  OffloadArchTest.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/offload-arch/LevelZeroArch.cpp
+  )
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  add_distinct_clang_unittest(OffloadArchTests
-    OffloadArchTest.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/offload-arch/AMDGPUArchByHIP.cpp
-    CLANG_LIBS
-      clangBasic
-    LLVM_COMPONENTS
-      Support
-    )
+  list(APPEND OffloadArchTestSources
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../tools/offload-arch/AMDGPUArchByHIP.cpp)
 endif()
+
+add_distinct_clang_unittest(OffloadArchTests
+  ${OffloadArchTestSources}
+  CLANG_LIBS
+    clangBasic
+  LLVM_COMPONENTS
+    Support
+  )

--- a/clang/unittests/offload-arch/OffloadArchTest.cpp
+++ b/clang/unittests/offload-arch/OffloadArchTest.cpp
@@ -19,6 +19,9 @@ bool compareVersions(llvm::StringRef A, llvm::StringRef B);
 llvm::SmallVector<std::string, 8> getCandidateBinPaths(llvm::StringRef ExeDir);
 #endif
 
+// Defined in LevelZeroArch.cpp (non-static, compiled into this test).
+std::string getIntelGPUArchName(uint32_t IPVersion);
+
 using namespace llvm;
 
 cl::opt<bool> Verbose("offload-arch-test-verbose", cl::Hidden, cl::init(false));
@@ -112,3 +115,47 @@ TEST(CandidateBinPaths, NoDriveRootBin) {
 }
 
 #endif // _WIN32
+
+// --- getIntelGPUArchName ---
+
+namespace {
+// Build a GMDID the way the Level Zero driver reports it.
+constexpr uint32_t gmdid(uint32_t Architecture, uint32_t Release,
+                         uint32_t Revision) {
+  return (Architecture << 22) | (Release << 14) | Revision;
+}
+} // namespace
+
+TEST(IntelGPUArchName, KnownArchitecturesGetAFriendlyName) {
+  EXPECT_EQ(getIntelGPUArchName(gmdid(12, 60, 7)), "xe-pvc");
+  EXPECT_EQ(getIntelGPUArchName(gmdid(20, 1, 4)), "xe-bmg-g21");
+  EXPECT_EQ(getIntelGPUArchName(gmdid(35, 10, 0)), "xe-nvl-p");
+  EXPECT_EQ(getIntelGPUArchName(gmdid(12, 0, 0)), "xe-tgllp");
+}
+
+// When several devices share an architecture and a release, the first one
+// listed in IntelGPUArch.def names the whole group.
+TEST(IntelGPUArchName, FirstNameOfAGroupWins) {
+  EXPECT_EQ(getIntelGPUArchName(gmdid(30, 5, 0)), "xe-nvl-u");
+  EXPECT_EQ(getIntelGPUArchName(gmdid(12, 55, 0)), "xe-acm-g10");
+}
+
+// The revision is not part of the lookup: every stepping of an architecture
+// shares one name.
+TEST(IntelGPUArchName, RevisionDoesNotAffectTheName) {
+  EXPECT_EQ(getIntelGPUArchName(gmdid(12, 60, 0)), "xe-pvc");
+  EXPECT_EQ(getIntelGPUArchName(gmdid(12, 60, 63)), "xe-pvc");
+}
+
+// An architecture that is not in the table still has to be named, so that a
+// newer device is usable with a compiler that predates it.
+TEST(IntelGPUArchName, UnknownArchitecturesGetANumericName) {
+  EXPECT_EQ(getIntelGPUArchName(gmdid(40, 11, 0)), "xe_40.11.0");
+  EXPECT_EQ(getIntelGPUArchName(gmdid(12, 99, 3)), "xe_12.99.3");
+}
+
+// Pre-Xe devices report a GMDID too, and none of them are in the table.
+TEST(IntelGPUArchName, LegacyArchitecture) {
+  EXPECT_EQ(getIntelGPUArchName(gmdid(9, 0, 9)), "xe_9.0.9");
+}
+

--- a/clang/unittests/offload-arch/OffloadArchTest.cpp
+++ b/clang/unittests/offload-arch/OffloadArchTest.cpp
@@ -158,4 +158,3 @@ TEST(IntelGPUArchName, UnknownArchitecturesGetANumericName) {
 TEST(IntelGPUArchName, LegacyArchitecture) {
   EXPECT_EQ(getIntelGPUArchName(gmdid(9, 0, 9)), "xe_9.0.9");
 }
-

--- a/clang/unittests/offload-arch/OffloadArchTest.cpp
+++ b/clang/unittests/offload-arch/OffloadArchTest.cpp
@@ -19,7 +19,7 @@ bool compareVersions(llvm::StringRef A, llvm::StringRef B);
 llvm::SmallVector<std::string, 8> getCandidateBinPaths(llvm::StringRef ExeDir);
 #endif
 
-// Defined in LevelZeroArch.cpp (non-static, compiled into this test).
+// Defined in LevelZeroArch.cpp.
 std::string getIntelGPUArchName(uint32_t IPVersion);
 
 using namespace llvm;


### PR DESCRIPTION
The output of `offload-arch` is expected to be a list of names that are legal `--offload-arch` parameters, because the driver runs the utility for `--offload-arch=native` and feeds every line it prints to `StringToOffloadArch`. For Intel GPUs the utility printed the name of the device instead, e.g. `Intel(R) Data Center GPU Max 1100`, which is not a legal parameter.

The utility now queries the GMDID of each device with `zeDeviceGetProperties` and the device IP version extension (`ZE_STRUCTURE_TYPE_DEVICE_IP_VERSION_EXT`), and translates the architecture and release components of it into an architecture name:

* A device listed in the new `IntelGPUArch.def` gets a human-friendly name, which covers almost every device a user is likely to have. The revision is deliberately not part of the lookup, so a new stepping of a known architecture keeps the same name.
* Anything else is named after all three components of its GMDID, e.g. `xe_40.11.0`, so that a GPU newer than the compiler is still usable.

The table lives in its own `.def` file so that it can later be generated from the data published by the GPU driver — `ocloc query SUPPORTED_DEVICES` reports exactly these pairs. Where several devices share an architecture and a release, the first entry in the file names the whole group, which keeps the generator from having to pick a representative device.

Verified on an Intel Data Center GPU Max 1100 (GMDID 12.60.7): `offload-arch` prints `xe-pvc` where it used to print the device name.

Note that the driver does not accept these names yet: `StringToOffloadArch` currently knows only `bmg_g21` among Intel GPUs, and `OffloadArchToTriple` returns an empty triple for Intel, so `--offload-arch=native` still fails after the utility prints a correct name. Wiring that up is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)