### PR TITLE
[SYCL] Change return type of frexp(float) to float

### DIFF
--- a/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
+++ b/sycl/include/sycl/stl_wrappers/__sycl_cmath_wrapper_impl.hpp
@@ -389,7 +389,7 @@ __SYCL_DEVICE float nearbyint(float x) { return __builtin_nearbyintf(x); }
 // Floating-point manipulation functions
 using ::frexp;
 using ::frexpf;
-__SYCL_DEVICE double frexp(float x, int *exp) {
+__SYCL_DEVICE float frexp(float x, int *exp) {
   return __spirv_ocl_frexp(x, exp);
 }
 template <typename T> __SYCL_DEVICE __sycl_promote_t<T> frexp(T x, int *exp) {


### PR DESCRIPTION
Change return type of frexp(float) and add test with static assertions for frexp return types.

Fixes #23041 
 