### PR TITLE
[SYCL] Stop deriving ext::oneapi::filter_selector from device_selector

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_filter_selector.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_filter_selector.asciidoc
@@ -55,6 +55,35 @@ Multiple filters may be specified in the string passed to the selector by using 
 Backend0:DeviceType0:RelativeDeviceNumber0,Backend1:DeviceType1:RelativeDeviceNumber1,...
 --
 
+=== Class Definition
+
+`filter_selector` is a SYCL 2020 callable device selector: it may be passed to any
+API that accepts a device selector, and it may also be invoked directly with a
+device to obtain that device's score.
+
+[source,c++]
+--
+namespace sycl::ext::oneapi {
+
+class filter_selector {
+public:
+  filter_selector(const std::string &filter);
+
+  int operator()(const device &dev) const;
+};
+
+} // namespace sycl::ext::oneapi
+--
+
+The set of devices matching the filter(s) is determined when the `filter_selector`
+is constructed.  `operator()` rejects any device outside of that set by returning
+a negative score, and ranks the remaining ones with `sycl::default_selector_v`.
+Consequently a `filter_selector` may be invoked any number of times, in any order,
+and the same filter string always selects the same device.
+
+Invoking a `filter_selector` whose filter(s) no device matches throws a
+synchronous `exception` with the `errc::runtime` error code.
+
 == Examples
 
 [source,c++]

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -48,9 +48,6 @@ auto getDeviceComparisonLambda();
 } // namespace detail
 
 namespace ext::oneapi {
-// Forward declaration
-class filter_selector;
-
 enum class peer_access {
   access_supported = 0x0,
   atomics_supported = 0x1,

--- a/sycl/include/sycl/device_selector.hpp
+++ b/sycl/include/sycl/device_selector.hpp
@@ -25,10 +25,6 @@ inline namespace _V1 {
 class device;
 class context;
 
-namespace ext::oneapi {
-class filter_selector;
-} // namespace ext::oneapi
-
 /// The SYCL 1.2.1 device_selector class provides ability to choose the
 /// best SYCL device based on heuristics specified by the user.
 ///
@@ -120,14 +116,12 @@ void fill_aspect_vector(std::vector<aspect> &V, FirstT F, OtherTs... O) {
   fill_aspect_vector(V, O...);
 }
 
-// Enable if DeviceSelector callable has matching signature, but
-// exclude if descended from filter_selector which is not purely callable or
-// if descended from it is descended from SYCL 1.2.1 device_selector.
-// See [FilterSelector not Callable] in device_selector.cpp
+// Enable if DeviceSelector callable has matching signature, but exclude if it
+// is descended from the SYCL 1.2.1 device_selector, which has its own
+// (deprecated) overloads.
 template <typename DeviceSelector>
 using EnableIfSYCL2020DeviceSelectorInvocable = std::enable_if_t<
     std::is_invocable_r_v<int, DeviceSelector &, const device &> &&
-    !std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector> &&
     !std::is_base_of_v<device_selector, DeviceSelector>>;
 
 __SYCL_EXPORT device

--- a/sycl/include/sycl/ext/oneapi/filter_selector.hpp
+++ b/sycl/include/sycl/ext/oneapi/filter_selector.hpp
@@ -8,21 +8,25 @@
 
 #pragma once
 
-#include <sycl/detail/export.hpp>   // for __SYCL_EXPORT
-#include <sycl/device.hpp>          // for device
+#include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED
+#include <sycl/detail/export.hpp>             // for __SYCL_EXPORT
+#include <sycl/detail/string_view.hpp>        // for string_view
+#include <sycl/device.hpp>                    // for device
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 #include <sycl/device_selector.hpp> // for device_selector
+#endif                              // __INTEL_PREVIEW_BREAKING_CHANGES
 
 #include <memory> // for shared_ptr
 #include <string> // for string
-
-// 4.6.1 Device selection class
 
 namespace sycl {
 inline namespace _V1 {
 
 // Forward declarations
 class device;
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 class device_selector;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 #ifdef __SYCL_INTERNAL_API
 namespace ONEAPI {
 class filter_selector;
@@ -34,13 +38,38 @@ namespace detail {
 class filter_selector_impl;
 } // namespace detail
 
-class __SYCL_EXPORT filter_selector : public device_selector {
+/// Selects a device matching one or more filters of the form
+/// `Backend:DeviceType:RelativeDeviceNumber`, see
+/// sycl_ext_oneapi_filter_selector.
+///
+/// This is a SYCL 2020 callable device selector: it can be passed to the
+/// `device`, `platform` and `queue` constructors, and it may be invoked
+/// directly as many times as needed. The set of devices matching the filters is
+/// determined when the selector is constructed.
+class __SYCL_EXPORT filter_selector
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+    // Nothing in this class needs the deprecated SYCL 1.2.1 device_selector.
+    // The base class is only kept to preserve the ABI of the non-preview
+    // library.
+    : public device_selector
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+{
 public:
   filter_selector(const std::string &filter)
       : filter_selector(sycl::detail::string_view{filter}) {}
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
+#else
+  int operator()(const device &dev) const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+  /// \deprecated The selector keeps no state between the invocations of
+  /// `operator()`, so there is nothing to reset.
   void reset() const;
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   device select_device() const override;
+#else
+  device select_device() const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 #ifdef __SYCL_INTERNAL_API
   friend class sycl::ONEAPI::filter_selector;
 #endif
@@ -58,9 +87,17 @@ class __SYCL_EXPORT filter_selector : public ext::oneapi::filter_selector {
 public:
   filter_selector(const std::string &filter)
       : filter_selector(sycl::detail::string_view{filter}) {}
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   int operator()(const device &dev) const override;
+#else
+  int operator()(const device &dev) const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
   void reset() const;
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   device select_device() const override;
+#else
+  device select_device() const;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
 
 private:
   filter_selector(sycl::detail::string_view filter);

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -60,10 +60,6 @@ class platform_impl;
 void __SYCL_EXPORT enable_ext_oneapi_default_context(bool Val);
 
 } // namespace detail
-namespace ext::oneapi {
-// Forward declaration
-class filter_selector;
-} // namespace ext::oneapi
 
 /// Encapsulates a SYCL platform on which kernels may be executed.
 ///

--- a/sycl/source/detail/filter_selector_impl.cpp
+++ b/sycl/source/detail/filter_selector_impl.cpp
@@ -12,7 +12,9 @@
 #include <sycl/device.hpp>
 #include <sycl/device_selector.hpp>
 #include <sycl/exception.hpp>
+#include <sycl/ext/oneapi/filter_selector.hpp>
 
+#include <algorithm>
 #include <cctype>
 #include <regex>
 #include <string>
@@ -87,82 +89,102 @@ filter create_filter(const std::string &Input) {
   return Result;
 }
 
-filter_selector_impl::filter_selector_impl(const std::string &Input)
-    : mFilters(), mNumDevicesSeen(0), mMatchFound(false) {
-  std::vector<std::string> Filters = detail::tokenize(Input, ",");
-  mNumTotalDevices = device::get_devices().size();
+filter_selector_impl::filter_selector_impl(const std::string &Input) {
+  std::vector<filter> Filters;
+  for (const std::string &Filter : detail::tokenize(Input, ","))
+    Filters.push_back(detail::create_filter(Filter));
 
-  for (const std::string &Filter : Filters) {
-    detail::filter F = detail::create_filter(Filter);
-    mFilters.push_back(std::move(F));
+  // Matching the filters requires state to be kept between the devices (to
+  // track the relative device number), so do it once here instead of doing it
+  // in operator().
+  for (const device &Dev : device::get_devices()) {
+    for (filter &Filter : Filters) {
+      bool BackendOK = true;
+      bool DeviceTypeOK = true;
+      bool DeviceNumOK = true;
+
+      if (Filter.Backend) {
+        // Backend is okay if the filter BE is set 'all'.
+        BackendOK = Filter.Backend.value() == backend::all ||
+                    sycl::detail::getSyclObjImpl(Dev)->getBackend() ==
+                        Filter.Backend.value();
+      }
+      if (Filter.DeviceType) {
+        // DeviceType is okay if the filter is set 'all'.
+        DeviceTypeOK =
+            Filter.DeviceType.value() == sycl::info::device_type::all ||
+            Dev.get_info<sycl::info::device::device_type>() ==
+                Filter.DeviceType.value();
+      }
+      if (Filter.DeviceNum) {
+        // Only check device number if we're good on the previous matches
+        if (BackendOK && DeviceTypeOK) {
+          // Do we match?
+          DeviceNumOK = (Filter.MatchesSeen == Filter.DeviceNum.value());
+          // Safe to increment matches even if we find it
+          Filter.MatchesSeen++;
+        }
+      }
+      if (BackendOK && DeviceTypeOK && DeviceNumOK) {
+        mMatchingDevices.push_back(Dev);
+        break;
+      }
+    }
   }
 }
 
 int filter_selector_impl::operator()(const device &Dev) const {
-  int Score = REJECT_DEVICE_SCORE;
-
-  for (auto &Filter : mFilters) {
-    bool BackendOK = true;
-    bool DeviceTypeOK = true;
-    bool DeviceNumOK = true;
-
-    if (Filter.Backend) {
-      backend BE = sycl::detail::getSyclObjImpl(Dev)->getBackend();
-      // Backend is okay if the filter BE is set 'all'.
-      if (Filter.Backend.value() == backend::all)
-        BackendOK = true;
-      else
-        BackendOK = (BE == Filter.Backend.value());
-    }
-    if (Filter.DeviceType) {
-      sycl::info::device_type DT =
-          Dev.get_info<sycl::info::device::device_type>();
-      // DeviceType is okay if the filter is set 'all'.
-      if (Filter.DeviceType == sycl::info::device_type::all)
-        DeviceTypeOK = true;
-      else
-        DeviceTypeOK = (DT == Filter.DeviceType);
-    }
-    if (Filter.DeviceNum) {
-      // Only check device number if we're good on the previous matches
-      if (BackendOK && DeviceTypeOK) {
-        // Do we match?
-        DeviceNumOK = (Filter.MatchesSeen == Filter.DeviceNum.value());
-        // Safe to increment matches even if we find it
-        Filter.MatchesSeen++;
-      }
-    }
-    if (BackendOK && DeviceTypeOK && DeviceNumOK) {
-      Score = default_selector_v(Dev);
-      mMatchFound = true;
-      break;
-    }
-  }
-
-  mNumDevicesSeen++;
-  if ((mNumDevicesSeen == mNumTotalDevices) && !mMatchFound) {
+  if (mMatchingDevices.empty())
     throw exception(
         make_error_code(errc::runtime),
         "Could not find a device that matches the specified filter(s)!");
-  }
 
-  return Score;
-}
+  if (std::find(mMatchingDevices.begin(), mMatchingDevices.end(), Dev) ==
+      mMatchingDevices.end())
+    return REJECT_DEVICE_SCORE;
 
-void filter_selector_impl::reset() const {
-  // This is a bit of an abuse of "const" method...
-  // Reset state if you want to reuse this selector.
-  for (auto &Filter : mFilters) {
-    Filter.MatchesSeen = 0;
-  }
-  mMatchFound = false;
-  mNumDevicesSeen = 0;
+  // Let the default selector rank the devices that passed the filters.
+  return default_selector_v(Dev);
 }
 
 } // namespace ext::oneapi::detail
 
+namespace ext::oneapi {
+
+filter_selector::filter_selector(sycl::detail::string_view Input)
+    : impl(std::make_shared<detail::filter_selector_impl>(
+          std::string(std::string_view(Input)))) {}
+
+int filter_selector::operator()(const device &Dev) const {
+  return impl->operator()(Dev);
+}
+
+void filter_selector::reset() const {
+  // The selector keeps no state between the invocations of operator(), so
+  // there is nothing to reset. Kept for backwards compatibility.
+}
+
+device filter_selector::select_device() const {
+  return sycl::detail::select_device(*this);
+}
+
+} // namespace ext::oneapi
+
 namespace __SYCL2020_DEPRECATED("use 'ext::oneapi' instead") ONEAPI {
 using namespace ext::oneapi;
+
+filter_selector::filter_selector(sycl::detail::string_view Input)
+    : ext::oneapi::filter_selector(Input) {}
+
+int filter_selector::operator()(const device &Dev) const {
+  return ext::oneapi::filter_selector::operator()(Dev);
 }
+
+void filter_selector::reset() const { ext::oneapi::filter_selector::reset(); }
+
+device filter_selector::select_device() const {
+  return ext::oneapi::filter_selector::select_device();
+}
+} // namespace __SYCL2020_DEPRECATED("use 'ext::oneapi' instead")ONEAPI
 } // namespace _V1
 } // namespace sycl

--- a/sycl/source/detail/filter_selector_impl.hpp
+++ b/sycl/source/detail/filter_selector_impl.hpp
@@ -8,16 +8,15 @@
 
 #pragma once
 
+#include <sycl/detail/defines_elementary.hpp>
 #include <sycl/detail/device_filter.hpp>
-#include <sycl/device_selector.hpp>
+#include <sycl/device.hpp>
 
+#include <string>
 #include <vector>
 
 namespace sycl {
 inline namespace _V1 {
-
-// Forward declarations
-class device;
 
 namespace ext {
 namespace oneapi {
@@ -25,18 +24,17 @@ namespace detail {
 
 using filter = sycl::detail::ods_target;
 
+/// The set of devices matching the filter string is computed once, when the
+/// selector is created. That keeps operator() a pure function, so that the
+/// selector can be used as a SYCL 2020 callable device selector.
 class filter_selector_impl {
 public:
   filter_selector_impl(const std::string &filter);
   int operator()(const device &dev) const;
-  void reset() const;
 
 private:
   static constexpr int REJECT_DEVICE_SCORE = -1;
-  mutable std::vector<filter> mFilters;
-  mutable int mNumDevicesSeen;
-  int mNumTotalDevices;
-  mutable bool mMatchFound;
+  std::vector<device> mMatchingDevices;
 };
 } // namespace detail
 } // namespace oneapi

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -190,11 +190,6 @@ std::mutex &GlobalHandler::getPlatformMapMutex() {
   return PlatformMapMutex;
 }
 
-std::mutex &GlobalHandler::getFilterMutex() {
-  static std::mutex &FilterMutex = getOrCreate(MFilterMutex);
-  return FilterMutex;
-}
-
 std::vector<adapter_impl *> &GlobalHandler::getAdapters() {
   static std::vector<adapter_impl *> &adapters = getOrCreate(MAdapters);
   enableOnCrashStackPrinting();

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -63,7 +63,6 @@ public:
 
   std::mutex &getPlatformToDefaultContextCacheMutex();
   std::mutex &getPlatformMapMutex();
-  std::mutex &getFilterMutex();
   std::vector<adapter_impl *> &getAdapters();
   ods_target_list &getOneapiDeviceSelectorTargets(const std::string &InitValue);
   XPTIRegistry &getXPTIRegistry();
@@ -128,7 +127,6 @@ private:
       MPlatformToDefaultContextCache;
   InstWithLock<std::mutex> MPlatformToDefaultContextCacheMutex;
   InstWithLock<std::mutex> MPlatformMapMutex;
-  InstWithLock<std::mutex> MFilterMutex;
   InstWithLock<std::vector<adapter_impl *>> MAdapters;
   InstWithLock<ods_target_list> MOneapiDeviceSelectorTargets;
   InstWithLock<XPTIRegistry> MXPTIRegistry;

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -8,7 +8,6 @@
 
 #include <detail/config.hpp>
 #include <detail/device_impl.hpp>
-#include <detail/filter_selector_impl.hpp>
 #include <detail/global_handler.hpp>
 #include <detail/program_manager/program_manager.hpp>
 #include <sycl/backend_types.hpp>
@@ -16,12 +15,9 @@
 #include <sycl/device.hpp>
 #include <sycl/device_selector.hpp>
 #include <sycl/exception.hpp>
-#include <sycl/ext/oneapi/filter_selector.hpp>
 // 4.6.1 Device selection class
 
 #include <algorithm>
-#include <cctype>
-#include <regex>
 
 namespace sycl {
 inline namespace _V1 {
@@ -269,54 +265,5 @@ int accelerator_selector::operator()(const device &dev) const {
   return accelerator_selector_v(dev);
 }
 
-namespace ext::oneapi {
-
-filter_selector::filter_selector(sycl::detail::string_view Input)
-    : impl(std::make_shared<detail::filter_selector_impl>(
-          std::string(std::string_view(Input)))) {}
-
-int filter_selector::operator()(const device &Dev) const {
-  return impl->operator()(Dev);
-}
-
-void filter_selector::reset() const { impl->reset(); }
-
-// filter_selectors not "Callable"
-// because of the requirement that the filter_selector "reset()" itself
-// between invocations, the filter_selector operator() is not purely callable
-// and cannot be used interchangeably as a SYCL2020 callable device selector.
-// TODO: replace the FilterSelector subclass with something that
-// doesn't pretend to be a device_selector, and instead is something that
-// just returns a device (rather than a score).
-// Then remove ! std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>
-// from device/platform/queue constructors
-device filter_selector::select_device() const {
-  std::lock_guard<std::mutex> Guard(
-      sycl::detail::GlobalHandler::instance().getFilterMutex());
-
-  device Result = device_selector::select_device();
-
-  reset();
-
-  return Result;
-}
-
-} // namespace ext::oneapi
-
-namespace __SYCL2020_DEPRECATED("use 'ext::oneapi' instead") ONEAPI {
-using namespace ext::oneapi;
-filter_selector::filter_selector(sycl::detail::string_view Input)
-    : ext::oneapi::filter_selector(Input) {}
-
-int filter_selector::operator()(const device &Dev) const {
-  return ext::oneapi::filter_selector::operator()(Dev);
-}
-
-void filter_selector::reset() const { ext::oneapi::filter_selector::reset(); }
-
-device filter_selector::select_device() const {
-  return ext::oneapi::filter_selector::select_device();
-}
-} // namespace __SYCL2020_DEPRECATED("use 'ext::oneapi' instead")ONEAPI
 } // namespace _V1
 } // namespace sycl


### PR DESCRIPTION
`device_selector` is a deprecated SYCL 1.2.1 class that is going to be removed, so `ext::oneapi::filter_selector` shouldn't be tied to it.

It only derived from `device_selector` because its `operator()` wasn't reentrant: `filter_selector_impl` accumulated per-invocation state (the number of devices seen and the relative device number matched so far), so the selector had to `reset()` itself between the invocations. That is exactly what the `device_selector::select_device()` override was for, and it is what the pre-existing TODO in `device_selector.cpp` asked to get rid of:

```
// TODO: replace the FilterSelector subclass with something that
// doesn't pretend to be a device_selector, and instead is something that
// just returns a device (rather than a score).
// Then remove ! std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>
// from device/platform/queue constructors
```

This PR computes the set of matching devices once, when the selector is constructed, using the very same matching algorithm as before. `operator()` becomes a pure function: it rejects any device outside of that set and ranks the rest with `default_selector_v`. As a result:

* `filter_selector` is an ordinary SYCL 2020 callable device selector, so the `!std::is_base_of_v<ext::oneapi::filter_selector, DeviceSelector>` special case is dropped from `EnableIfSYCL2020DeviceSelectorInvocable` and the `device`/`platform`/`queue` constructors accept it through the regular callable path;
* `GlobalHandler::getFilterMutex()` (a global mutex that guarded the mutable state during `select_device()`) is removed;
* `reset()` is kept as a no-op for source compatibility;
* `filter_selector` definitions move out of `device_selector.cpp` into `filter_selector_impl.cpp`, so the legacy translation unit no longer knows about the extension.

The extension spec only ever described `filter_selector` as "a new device selector class", so a class synopsis is added to it.

## ABI

Dropping the base class changes the class layout and the vtable, so it is done under `__INTEL_PREVIEW_BREAKING_CHANGES`. The non-preview library keeps the base class and the virtual overrides, so its ABI is unchanged. Everything else (the stateless impl, the removed mutex, the moved definitions) is ABI-neutral: `filter_selector_impl` is an internal class held behind a `shared_ptr`, and the mangling of `operator()`/`reset()`/`select_device()` doesn't change as long as they stay virtual in the non-preview library.

Verified for the non-preview library:

* `sycl_symbols_linux.dump` regenerated from the built `libsycl.so` — byte-identical to the reference, and `sycl_symbols_windows.dump` is untouched;
* vtable layouts dumped with `-Xclang -fdump-vtable-layouts` before and after the change — identical for both `ext::oneapi::filter_selector` and `ONEAPI::filter_selector` (6 entries, same order);
* `static_assert`s confirm `is_polymorphic_v` and `sizeof == sizeof(void*) + sizeof(shared_ptr)` in the non-preview mode, and the opposite in the preview mode.

## Testing

Both `libsycl.so` and `libsycl-preview.so` build. All entry points (`device`, `platform`, all five `queue` overloads, direct invocation, `select_device()`, `reset()`) compile in four configurations: non-preview/preview x with and without `__SYCL_INTERNAL_API`. `FilterSelector/select.cpp` and `FilterSelector/reuse.cpp` compile in both modes; they were not run, as no devices are available in the environment the change was developed in.

## Behavior notes

* `reset()` no longer does anything. Nothing should break — there is no state left to reset — but the method is formally a no-op now, and it is documented as deprecated.
* In the preview mode `queue(context, filter_selector)` now goes through `detail::select_device(sel, ctx)` instead of the legacy `queue(const context &, const device_selector &, ...)` overload. The latter scored only the devices of the context and, unlike `select_device()`, never reset the selector. The new path scores all devices and then throws `errc::invalid` if the selected one is outside the context, consistently with every other SYCL 2020 selector.