### PR TITLE
[SYCL][CMake] Enable LLVM_LINK_LLVM_DYLIB builds of the SYCL toolchain

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -81,6 +81,19 @@ jobs:
       toolchain_artifact: sycl_linux_sprod_shared
       toolchain_artifact_filename: sycl_linux_shared.tar.zst
 
+  linux_dylib_build:
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl-linux-build.yml
+    secrets: inherit
+    with:
+      build_cache_root: "/__w/"
+      build_cache_suffix: sprod_dylib
+      build_configure_extra_args: '--llvm-link-dylib'
+      build_target: all
+
+      toolchain_artifact: sycl_linux_sprod_dylib
+      toolchain_artifact_filename: sycl_linux_dylib.tar.zst
+
   ubuntu2404_oneapi_build:
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl-linux-build.yml

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -58,6 +58,7 @@ def do_configure(args, passthrough_args):
     llvm_enable_sphinx = "OFF"
     llvm_build_shared_libs = "OFF"
     llvm_enable_lld = "OFF"
+    llvm_link_dylib = "OFF"
     sycl_enabled_backends = ["opencl"]
     sycl_preview_lib = "ON"
 
@@ -126,6 +127,9 @@ def do_configure(args, passthrough_args):
     if args.use_lld:
         llvm_enable_lld = "ON"
 
+    if args.llvm_link_dylib:
+        llvm_link_dylib = "ON"
+
     if args.use_zstd:
         llvm_enable_zstd = "FORCE_ON"
 
@@ -189,6 +193,8 @@ def do_configure(args, passthrough_args):
         "-DLLVM_ENABLE_DOXYGEN={}".format(llvm_enable_doxygen),
         "-DLLVM_ENABLE_SPHINX={}".format(llvm_enable_sphinx),
         "-DBUILD_SHARED_LIBS={}".format(llvm_build_shared_libs),
+        "-DLLVM_LINK_LLVM_DYLIB={}".format(llvm_link_dylib),
+        "-DCLANG_LINK_CLANG_DYLIB={}".format(llvm_link_dylib),
         "-DSYCL_ENABLE_XPTI_TRACING={}".format(sycl_enable_xpti_tracing),
         "-DLLVM_ENABLE_LLD={}".format(llvm_enable_lld),
         "-DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS={}".format(spirv_enable_dis),
@@ -404,6 +410,12 @@ def main():
     parser.add_argument("--use-libcxx", action="store_true", help="build with libcxx")
     parser.add_argument(
         "--use-lld", action="store_true", help="Use LLD linker for build"
+    )
+    parser.add_argument(
+        "--llvm-link-dylib",
+        action="store_true",
+        help="Build/link against the shared libLLVM.so and libclang-cpp.so "
+        "(sets LLVM_LINK_LLVM_DYLIB=ON and CLANG_LINK_CLANG_DYLIB=ON)",
     )
     parser.add_argument(
         "--llvm-external-projects",

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -414,8 +414,7 @@ def main():
     parser.add_argument(
         "--llvm-link-dylib",
         action="store_true",
-        help="Build/link against the shared libLLVM.so and libclang-cpp.so "
-        "(sets LLVM_LINK_LLVM_DYLIB=ON and CLANG_LINK_CLANG_DYLIB=ON)",
+        help="Build/link against the shared libLLVM.so and libclang-cpp.so ",
     )
     parser.add_argument(
         "--llvm-external-projects",

--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -6,7 +6,7 @@ if (NOT TARGET LLVMGenXIntrinsics)
   if (NOT LLVMGenXIntrinsics_FOUND)
     set(LLVMGenXIntrinsics_GIT_REPO https://github.com/intel/vc-intrinsics.git)
 
-    set(LLVMGenXIntrinsics_GIT_TAG 546cf38639d042a860e44f22508d58788188f8c8)
+    set(LLVMGenXIntrinsics_GIT_TAG 0c3296b5fe7ab5a8392197478d0bbd35649dc924)
     if(NOT FETCHCONTENT_SOURCE_DIR_VC-INTRINSICS)
       message(STATUS "vc-intrinsics repo is missing. Will try to download "
         "${LLVMGenXIntrinsics_GIT_TAG} from ${LLVMGenXIntrinsics_GIT_REPO}")

--- a/llvm/tools/spirv-to-ir-wrapper/CMakeLists.txt
+++ b/llvm/tools/spirv-to-ir-wrapper/CMakeLists.txt
@@ -12,3 +12,10 @@ include_directories(
 add_llvm_tool(spirv-to-ir-wrapper
   spirv-to-ir-wrapper.cpp
   )
+
+# LLVMSPIRVLib is not part of libLLVM.so, so in LLVM_LINK_LLVM_DYLIB builds the
+# SPIRVLib component listed above resolves to the dylib (which lacks its
+# symbols). Link the static library explicitly, matching llvm-spirv.
+if (LLVM_LINK_LLVM_DYLIB)
+  target_link_libraries(spirv-to-ir-wrapper PRIVATE LLVMSPIRVLib)
+endif()

--- a/llvm/tools/sycl-post-link/CMakeLists.txt
+++ b/llvm/tools/sycl-post-link/CMakeLists.txt
@@ -20,5 +20,15 @@ add_llvm_tool(sycl-post-link
   intrinsics_gen
   )
 
+# sycl-post-link.cpp includes SYCLLowerIR's ESIMDUtils.h, which pulls in a
+# vc-intrinsics header (GenXMetadata.h). In LLVM_LINK_LLVM_DYLIB builds this
+# tool links libLLVM.so rather than the LLVMSYCLLowerIR component, so it does
+# not inherit the LLVMGenXIntrinsics INTERFACE include directories. Add them
+# explicitly so the header is found.
+if (LLVM_LINK_LLVM_DYLIB)
+  target_include_directories(sycl-post-link PRIVATE
+    $<TARGET_PROPERTY:LLVMGenXIntrinsics,INTERFACE_INCLUDE_DIRECTORIES>)
+endif()
+
 setup_host_tool(sycl-post-link SYCL_POST_LINK
   sycl-post-link_exe sycl-post-link_target)

--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -240,6 +240,19 @@ target_link_libraries(sycl-jit
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
+# In LLVM_LINK_LLVM_DYLIB builds sycl-jit links libLLVM.so rather than the LLVM
+# component libraries, so it does not inherit their INTERFACE properties:
+#  - LLVMSPIRVLib is not part of libLLVM.so, so the SPIRVLib component listed
+#    above resolves to the dylib (which lacks its symbols); link it explicitly.
+#  - rtc/ESIMD.cpp includes a vc-intrinsics header (GenXSPIRVWriterAdaptor.h),
+#    so add the LLVMGenXIntrinsics INTERFACE include directories explicitly.
+# Both mirror the handling in llvm-spirv / sycl-post-link.
+if (LLVM_LINK_LLVM_DYLIB)
+  target_link_libraries(sycl-jit PRIVATE LLVMSPIRVLib)
+  target_include_directories(sycl-jit PRIVATE
+    $<TARGET_PROPERTY:LLVMGenXIntrinsics,INTERFACE_INCLUDE_DIRECTORIES>)
+endif()
+
 add_dependencies(sycl-jit sycl-headers)
 
 if("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)

--- a/sycl-jit/jit-compiler/CMakeLists.txt
+++ b/sycl-jit/jit-compiler/CMakeLists.txt
@@ -246,7 +246,7 @@ target_link_libraries(sycl-jit
 #    above resolves to the dylib (which lacks its symbols); link it explicitly.
 #  - rtc/ESIMD.cpp includes a vc-intrinsics header (GenXSPIRVWriterAdaptor.h),
 #    so add the LLVMGenXIntrinsics INTERFACE include directories explicitly.
-# Both mirror the handling in llvm-spirv / sycl-post-link.
+# The first mirrors llvm-spirv; the second mirrors sycl-post-link.
 if (LLVM_LINK_LLVM_DYLIB)
   target_link_libraries(sycl-jit PRIVATE LLVMSPIRVLib)
   target_include_directories(sycl-jit PRIVATE


### PR DESCRIPTION
Enable building the SYCL toolchain with -DLLVM_LINK_LLVM_DYLIB=ON
(-DCLANG_LINK_CLANG_DYLIB=ON), previously unsupported.

This is a needed change to allow clang plugins to be loaded during compilation 
of sycl code.

Under dylib, tools link libLLVM.so instead of the LLVM component
libraries and so don't inherit their INTERFACE properties. Fixes:

- Bump the vc-intrinsics pin to 0c3296b, which drops a spurious LLVMGenXIntrinsics 
dependency on LLVMSPIRVLib that formed an illegal   cross-dylib cycle
 (LLVM -> SYCLLowerIR -> GenXIntrinsics -> SPIRVLib
  -> LLVM) and broke CMake configuration.
- LLVMSPIRVLib is not part of libLLVM.so: link it explicitly in
  spirv-to-ir-wrapper and sycl-jit (matching llvm-spirv).
- sycl-post-link and sycl-jit include vc-intrinsics headers; add the
  LLVMGenXIntrinsics INTERFACE include directories explicitly.

All changes are guarded by LLVM_LINK_LLVM_DYLIB; static builds are
unchanged. 