### PR TITLE
[UR][CMake] Use pkg-config include dirs for preinstalled Level Zero

### DIFF
--- a/unified-runtime/cmake/FetchLevelZero.cmake
+++ b/unified-runtime/cmake/FetchLevelZero.cmake
@@ -16,6 +16,12 @@ if(NOT UR_FORCE_FETCH_LEVEL_ZERO)
     pkg_check_modules(level-zero level-zero>=1.32.0)
     if(level-zero_FOUND)
       set(LEVEL_ZERO_INCLUDE_DIR "${level-zero_INCLUDEDIR}/level_zero")
+      # Level Zero publishes two include dirs: level-zero.pc gives
+      # -I${includedir}/level_zero and, via `Requires: libze_loader`,
+      # libze_loader.pc gives -I${includedir}. Keep them separate from
+      # LEVEL_ZERO_INCLUDE_DIR, which must stay a single directory that
+      # directly contains ze_api.h (consumers append /ze_api.h to it).
+      set(LEVEL_ZERO_EXTRA_INCLUDE_DIRS "${level-zero_INCLUDE_DIRS}")
       set(LEVEL_ZERO_LIBRARY_SRC "${level-zero_LIBDIR}")
       set(LEVEL_ZERO_LIB_NAME "${level-zero_LIBRARIES}")
       message(STATUS "Level Zero Adapter: Using preinstalled level zero loader at ${level-zero_LINK_LIBRARIES}")
@@ -126,6 +132,7 @@ target_link_libraries(LevelZeroLoader
 add_library(LevelZeroLoader-Headers INTERFACE)
 target_include_directories(LevelZeroLoader-Headers
     INTERFACE "$<BUILD_INTERFACE:${LEVEL_ZERO_INCLUDE_DIR}>"
+              "$<BUILD_INTERFACE:${LEVEL_ZERO_EXTRA_INCLUDE_DIRS}>"
               "$<INSTALL_INTERFACE:${LEVEL_ZERO_TARGET_INCLUDE_DIR}>"
 )
 find_path(L0_COMPUTE_RUNTIME_HEADERS


### PR DESCRIPTION
level-zero ships two pkg-config files: `level-zero.pc` has `-I${includedir}/level_zero` and requires `libze_loader.pc`, which adds `-I${includedir}`. We were ignoring the cflags and rebuilding the first path by hand from `includedir`, so the second one never reached the compiler.

That's fine when L0 is in `/usr`, since pkg-config drops `-I/usr/include` and the compiler finds the headers anyway. With L0 installed anywhere else, anything including `<level_zero/...>` either doesn't build, or quietly picks up an older system L0 and mixes headers from two versions, which is what #23045 hit.

I didn't just assign `level-zero_INCLUDE_DIRS` to `LEVEL_ZERO_INCLUDE_DIR`, because sycl-trace appends `/ze_api.h` to that variable and would break if it became a list. Put the extra dirs in their own variable instead.

Tested with L0 v1.33.1 installed to a custom prefix and no system L0: before the change the L0 conformance test that includes `<level_zero/ze_api.h>` fails with `No such file or directory`, after it builds. A `/usr` install is unaffected either way.

Closes: https://github.com/intel/llvm/issues/23045
