### PR TITLE
[UR][Sanitizer] Handle zero global work size

### DIFF
--- a/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -331,6 +331,10 @@ ur_result_t AsanInterceptor::preLaunchKernel(ur_kernel_handle_t Kernel,
 ur_result_t AsanInterceptor::postLaunchKernel(ur_kernel_handle_t Kernel,
                                               ur_queue_handle_t Queue,
                                               LaunchInfo &LaunchInfo) {
+  if (hasZeroGlobalWorkSize(LaunchInfo.WorkDim, LaunchInfo.GlobalWorkSize)) {
+    return UR_RESULT_SUCCESS;
+  }
+
   // FIXME: We must use block operation here, until we support
   // urEventSetCallback
   auto Result = getContext()->urDdiTable.Queue.pfnFinish(Queue);
@@ -866,6 +870,11 @@ ur_result_t AsanInterceptor::prepareLaunch(
         ArgNums - 1,
         sizeof(void *),
         {LaunchInfo.Data.getDevicePtr()}});
+  }
+
+  if (hasZeroGlobalWorkSize(LaunchInfo.WorkDim, LaunchInfo.GlobalWorkSize)) {
+    LaunchInfo.LocalWorkSize.assign(LaunchInfo.WorkDim, 1);
+    return UR_RESULT_SUCCESS;
   }
 
   if (LaunchInfo.LocalWorkSize.empty()) {

--- a/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
@@ -172,6 +172,10 @@ ur_result_t MsanInterceptor::preLaunchKernel(ur_kernel_handle_t Kernel,
 ur_result_t MsanInterceptor::postLaunchKernel(ur_kernel_handle_t Kernel,
                                               ur_queue_handle_t Queue,
                                               LaunchInfo &LaunchInfo) {
+  if (hasZeroGlobalWorkSize(LaunchInfo.WorkDim, LaunchInfo.GlobalWorkSize)) {
+    return UR_RESULT_SUCCESS;
+  }
+
   // FIXME: We must use block operation here, until we support
   // urEventSetCallback
   auto Result = getContext()->urDdiTable.Queue.pfnFinish(Queue);
@@ -513,6 +517,11 @@ ur_result_t MsanInterceptor::prepareLaunch(
   std::shared_lock<ur_shared_mutex> Guard(KernelInfo.Mutex);
 
   if (!KernelInfo.IsInstrumented) {
+    return UR_RESULT_SUCCESS;
+  }
+
+  if (hasZeroGlobalWorkSize(LaunchInfo.WorkDim, LaunchInfo.GlobalWorkSize)) {
+    LaunchInfo.LocalWorkSize.assign(LaunchInfo.WorkDim, 1);
     return UR_RESULT_SUCCESS;
   }
 

--- a/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.hpp
+++ b/unified-runtime/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.hpp
@@ -93,6 +93,16 @@ size_t GetKernelPrivateMemorySize(ur_kernel_handle_t Kernel,
 size_t GetVirtualMemGranularity(ur_context_handle_t Context,
                                 ur_device_handle_t Device);
 
+inline bool hasZeroGlobalWorkSize(uint32_t WorkDim,
+                                  const size_t *GlobalWorkSize) {
+  for (uint32_t Dim = 0; Dim < WorkDim; ++Dim) {
+    if (GlobalWorkSize[Dim] == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 ur_result_t GetProgramMetadataNames(ur_program_handle_t Program,
                                     std::string_view Prefix,
                                     std::vector<std::string> &MetadataNames);

--- a/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_interceptor.cpp
+++ b/unified-runtime/source/loader/layers/sanitizer/tsan/tsan_interceptor.cpp
@@ -392,6 +392,10 @@ ur_result_t TsanInterceptor::preLaunchKernel(ur_kernel_handle_t Kernel,
 ur_result_t TsanInterceptor::postLaunchKernel(ur_kernel_handle_t Kernel,
                                               ur_queue_handle_t Queue,
                                               LaunchInfo &LaunchInfo) {
+  if (hasZeroGlobalWorkSize(LaunchInfo.WorkDim, LaunchInfo.GlobalWorkSize)) {
+    return UR_RESULT_SUCCESS;
+  }
+
   // FIXME: We must use block operation here, until we support
   // urEventSetCallback
   UR_CALL(getContext()->urDdiTable.Queue.pfnFinish(Queue));
@@ -415,6 +419,11 @@ ur_result_t TsanInterceptor::prepareLaunch(std::shared_ptr<ContextInfo> &,
                                            ur_kernel_handle_t Kernel,
                                            LaunchInfo &LaunchInfo) {
   auto &KernelInfo = getKernelInfo(Kernel);
+
+  if (hasZeroGlobalWorkSize(LaunchInfo.WorkDim, LaunchInfo.GlobalWorkSize)) {
+    LaunchInfo.LocalWorkSize.assign(LaunchInfo.WorkDim, 1);
+    return UR_RESULT_SUCCESS;
+  }
 
   // Get suggested local work size if user doesn't determine it.
   if (LaunchInfo.LocalWorkSize.empty()) {


### PR DESCRIPTION
Skip ASAN, MSAN, and TSAN launch preparation when any global work dimension is zero. Use a unit local size when forwarding the no-op launch to avoid querying a suggested local size.