### PR TITLE
[XPTIFW][CMake] Set SONAME to the library major version (#23031)

### DIFF
--- a/xptifw/src/CMakeLists.txt
+++ b/xptifw/src/CMakeLists.txt
@@ -87,6 +87,7 @@ function(add_xpti_library LIB_NAME)
   # Set library version so the generated library is versioned.
   set_target_properties(${LIB_NAME} PROPERTIES
     VERSION ${XPTIFW_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
   )
 
   # Set the location of the library installation


### PR DESCRIPTION
xptifw sets only the library VERSION (1.0.1) and no SOVERSION, so the generated SONAME is libxptifw.so.1.0.1. This churns the SONAME on every point release, forcing needless rebuilds of consumers that link against libxptifw, and it does not follow the usual shared-library convention.

Set SOVERSION to the project major version so the SONAME becomes libxptifw.so.1, which stays stable across the 1.x series.

This is something I ran into while packaging v7.0.0 of the compiler for Ubuntu 26.10. I have this change in a patch for the packaging but wanted to go ahead and contribute it so ideally we don't need to maintain the patch for future releases.

cc @dvrogozh @sarnex

---
cherry-pick: 9dbd3e7e0d2de09053ae104fbb3b82c61da75c00