### PR TITLE
[SYCL] Emit vtables of classes with indirectly_callable virtual functions in every translation unit that references the vtable

### DIFF
--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -539,6 +539,21 @@ public:
   static OffloadArch getOffloadArch(const TargetInfo &TI);
   static bool hasDependentExpr(Expr **Exprs, const size_t ExprsSize);
 
+  /// Returns true if \p D carries an 'add_ir_attributes_function' attribute
+  /// which contains \p Attr as one of the attribute names. Returns false if the
+  /// attribute arguments are still dependent, i.e. if the check cannot be
+  /// performed yet.
+  static bool hasSYCLAddIRAttributesFunctionAttr(const Decl *D, StringRef Attr);
+
+  /// Returns true if \p RD or any of its base classes declares a virtual member
+  /// function annotated with the SYCL 'indirectly_callable' compile-time
+  /// property, i.e. a virtual function which is meant to be callable from
+  /// device code. Base classes have to be taken into account because a derived
+  /// class does not have to override (nor annotate) an inherited virtual
+  /// function for its vtable to still refer to the annotated base class
+  /// version of it.
+  static bool hasSYCLIndirectlyCallableVirtualMethod(const CXXRecordDecl *RD);
+
   /// Emit a diagnostic about the given attribute having a deprecated name, and
   /// also emit a fixit hint to generate the new attribute name.
   void diagnoseDeprecatedAttribute(const ParsedAttr &A, StringRef NewScope,

--- a/clang/lib/CodeGen/CGVTables.cpp
+++ b/clang/lib/CodeGen/CGVTables.cpp
@@ -20,6 +20,7 @@
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/CodeGen/CGFunctionInfo.h"
 #include "clang/CodeGen/ConstantInitBuilder.h"
+#include "clang/Sema/SemaSYCL.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Intrinsics.h"
@@ -1155,18 +1156,38 @@ CodeGenModule::getVTableLinkage(const CXXRecordDecl *RD) {
         IsInNamedModule ? RD->getTemplateSpecializationKind()
                         : keyFunction->getTemplateSpecializationKind();
 
+    // For SYCL device compilation we force-emit vtables of polymorphic classes
+    // with 'indirectly_callable' virtual functions in every translation unit
+    // which references them, so that middle-end analyses can see the vtable
+    // initializer regardless of where the key function is defined. That means
+    // the vtable can no longer have external linkage - it has to be mergeable
+    // instead, otherwise we would end up with multiple definitions once all
+    // device code is linked together.
+    bool IsSYCLIndirectlyCallableVTable =
+        getLangOpts().SYCLIsDevice &&
+        SemaSYCL::hasSYCLIndirectlyCallableVirtualMethod(RD);
+
     switch (Kind) {
     case TSK_Undeclared:
     case TSK_ExplicitSpecialization:
       // Under OpenMP offloading we force-emit vtable definitions for classes
       // mapped into target regions even when the key function is defined in
-      // another TU, so the linkage may legitimately be queried here.
+      // another TU, so the linkage may legitimately be queried here. The same
+      // applies to SYCL device compilation.
       assert(
           (IsInNamedModule || def || CodeGenOpts.OptimizationLevel > 0 ||
            CodeGenOpts.getDebugInfo() != llvm::codegenoptions::NoDebugInfo ||
-           getLangOpts().OpenMP) &&
+           getLangOpts().OpenMP || IsSYCLIndirectlyCallableVTable) &&
           "Shouldn't query vtable linkage without the class in module units, "
           "key function, optimizations, or debug info");
+
+      // Note that this has to be checked before the AvailableExternally case
+      // below: available_externally definitions may be dropped by the
+      // optimizer, which would leave us with an unresolved reference to the
+      // vtable in the device image.
+      if (IsSYCLIndirectlyCallableVTable)
+        return llvm::GlobalVariable::LinkOnceODRLinkage;
+
       if (IsExternalDefinition && CodeGenOpts.OptimizationLevel > 0)
         return llvm::GlobalVariable::AvailableExternallyLinkage;
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3992,6 +3992,25 @@ void CodeGenModule::SetFunctionAttributes(GlobalDecl GD, llvm::Function *F,
   if (const auto *A = FD->getAttr<SYCLUsesAspectsAttr>())
     applySYCLAspectsMD(A, getContext(), getLLVMContext(), F,
                        "sycl_used_aspects");
+
+  // Compile-time properties are also applied to definitions in
+  // CodeGenFunction::StartFunction, but they have to be present on declarations
+  // as well: a translation unit which only sees a declaration of an
+  // 'indirectly_callable' virtual function still needs that information in
+  // order for SYCLVirtualFunctionsAnalysisPass to propagate the
+  // "calls-indirectly" attribute onto kernels which reference the corresponding
+  // vtable.
+  if (getLangOpts().SYCLIsDevice) {
+    if (const auto *A = FD->getAttr<SYCLAddIRAttributesFunctionAttr>()) {
+      SmallVector<std::pair<std::string, std::string>, 4> NameValuePairs =
+          A->getFilteredAttributeNameValuePairs(getContext());
+
+      llvm::AttrBuilder FnAttrBuilder(F->getContext());
+      for (const auto &NameValuePair : NameValuePairs)
+        FnAttrBuilder.addAttribute(NameValuePair.first, NameValuePair.second);
+      F->addFnAttrs(FnAttrBuilder);
+    }
+  }
 }
 
 void CodeGenModule::addUsedGlobal(llvm::GlobalValue *GV) {

--- a/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -21,6 +21,7 @@
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/Sema/SemaSYCL.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/LLVMContext.h"
@@ -347,8 +348,14 @@ namespace {
       if (Diags.hasUnrecoverableErrorOccurred())
         return;
 
-      // No VTable usage is legal in SYCL, so don't bother marking them used.
-      if (Ctx->getLangOpts().SYCLIsDevice)
+      // The only vtables which are meaningful in SYCL device code are those of
+      // classes with 'indirectly_callable' virtual functions: they are
+      // inspected by SYCLVirtualFunctionsAnalysisPass to determine which
+      // virtual functions a kernel may end up calling. Emitting vtables for any
+      // other polymorphic class would only add unused globals to the device
+      // image.
+      if (Ctx->getLangOpts().SYCLIsDevice &&
+          !SemaSYCL::hasSYCLIndirectlyCallableVirtualMethod(RD))
         return;
 
       Builder->EmitVTable(RD);

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -7508,6 +7508,19 @@ void Sema::CheckCompletedCXXClass(Scope *S, CXXRecordDecl *Record) {
     SYCL().CheckSYCLScopeAttr(Record);
   }
 
+  // A kernel which merely constructs an object of a polymorphic class is
+  // detected by SYCLVirtualFunctionsAnalysisPass through the vtable it
+  // references, which requires the vtable definition (and not just a
+  // declaration) to be present in the module. The vtable of a class with a key
+  // function is normally only emitted in the translation unit defining that key
+  // function, which may be a different one from the one containing the kernel,
+  // so force its emission here for every translation unit that completes such a
+  // class.
+  if (getLangOpts().SYCLIsDevice &&
+      SemaSYCL::hasSYCLIndirectlyCallableVirtualMethod(Record))
+    MarkVTableUsed(Record->getInnerLocStart(), Record,
+                   /*DefinitionRequired=*/true);
+
   llvm::SmallDenseMap<OverloadedOperatorKind,
                       llvm::SmallVector<const FunctionDecl *, 2>, 4>
       TypeAwareDecls{{OO_New, {}},
@@ -19367,7 +19380,17 @@ bool Sema::DefineUsedVTables() {
     const CXXMethodDecl *KeyFunction = Context.getCurrentKeyFunction(Class);
     // V-tables for non-template classes with an owning module are always
     // uniquely emitted in that module.
-    if (Class->isInCurrentModuleUnit()) {
+    // For SYCL device compilation vtables of classes with 'indirectly_callable'
+    // virtual functions are emitted in every translation unit which references
+    // them, regardless of where the key function is defined: middle-end
+    // analyses of virtual functions (see SYCLVirtualFunctionsAnalysisPass) need
+    // to see the vtable initializer in order to figure out which virtual
+    // functions a kernel may reference. Such vtables are given linkonce_odr
+    // linkage by CodeGenModule::getVTableLinkage so that emitting them more
+    // than once is not a problem.
+    if (Class->isInCurrentModuleUnit() ||
+        (getLangOpts().SYCLIsDevice &&
+         SemaSYCL::hasSYCLIndirectlyCallableVirtualMethod(Class))) {
       DefineVTable = true;
     } else if (KeyFunction && !KeyFunction->hasBody()) {
       // If this class has a key function, but that key function is

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -7515,7 +7515,11 @@ void Sema::CheckCompletedCXXClass(Scope *S, CXXRecordDecl *Record) {
   // function is normally only emitted in the translation unit defining that key
   // function, which may be a different one from the one containing the kernel,
   // so force its emission here for every translation unit that completes such a
-  // class.
+  // class. Note that this may end up emitting the vtable global in translation
+  // units where it is not needed since this semantic action is triggered by the
+  // mere inclusion of the class in a translation unit rather than a use of one
+  // of its virtual functions. In such cases however, the vtable will typically
+  // be discarded by optimizers if not referenced within the unit.
   if (getLangOpts().SYCLIsDevice &&
       SemaSYCL::hasSYCLIndirectlyCallableVirtualMethod(Record))
     MarkVTableUsed(Record->getInnerLocStart(), Record,

--- a/clang/lib/Sema/SemaSYCLDeclAttr.cpp
+++ b/clang/lib/Sema/SemaSYCLDeclAttr.cpp
@@ -831,6 +831,45 @@ void SemaSYCL::addSYCLAddIRAttributesFunctionAttr(
   }
 }
 
+bool SemaSYCL::hasSYCLAddIRAttributesFunctionAttr(const Decl *D,
+                                                  StringRef Attr) {
+  const auto *A = D->getAttr<SYCLAddIRAttributesFunctionAttr>();
+  if (!A)
+    return false;
+
+  // SYCL headers use template magic to pass key=value pairs to the attribute,
+  // so we can't inspect its arguments until all template instantiations are
+  // done.
+  if (hasDependentExpr(A->args_begin(), A->args_size()))
+    return false;
+
+  SmallVector<std::pair<std::string, std::string>, 4> Pairs =
+      A->getFilteredAttributeNameValuePairs(D->getASTContext());
+  return llvm::any_of(Pairs, [Attr](const auto &Pair) {
+    return StringRef(Pair.first) == Attr;
+  });
+}
+
+/// Returns true if \p RD itself declares an 'indirectly_callable' virtual
+/// member function, without looking at its base classes.
+static bool declaresIndirectlyCallableVirtualMethod(const CXXRecordDecl *RD) {
+  return llvm::any_of(RD->methods(), [](const CXXMethodDecl *MD) {
+    return MD->isVirtual() && SemaSYCL::hasSYCLAddIRAttributesFunctionAttr(
+                                  MD, "indirectly-callable");
+  });
+}
+
+bool SemaSYCL::hasSYCLIndirectlyCallableVirtualMethod(const CXXRecordDecl *RD) {
+  if (declaresIndirectlyCallableVirtualMethod(RD))
+    return true;
+
+  // forallBases returns false as soon as the callback does, i.e. as soon as we
+  // find a base class which declares such a function.
+  return !RD->forallBases([](const CXXRecordDecl *Base) {
+    return !declaresIndirectlyCallableVirtualMethod(Base);
+  });
+}
+
 void SemaSYCL::addSYCLAddIRAttributesKernelParameterAttr(
     Decl *D, const AttributeCommonInfo &CI, MutableArrayRef<Expr *> Args) {
   ASTContext &Context = getASTContext();

--- a/clang/lib/Sema/SemaSYCLDeclAttr.cpp
+++ b/clang/lib/Sema/SemaSYCLDeclAttr.cpp
@@ -837,10 +837,7 @@ bool SemaSYCL::hasSYCLAddIRAttributesFunctionAttr(const Decl *D,
   if (!A)
     return false;
 
-  // SYCL headers use template magic to pass key=value pairs to the attribute,
-  // so we can't inspect its arguments until all template instantiations are
-  // done.
-  if (hasDependentExpr(A->args_begin(), A->args_size()))
+  if (D->isTemplated())
     return false;
 
   SmallVector<std::pair<std::string, std::string>, 4> Pairs =

--- a/clang/test/CodeGenSYCL/virtual-functions-vtable-emission.cpp
+++ b/clang/test/CodeGenSYCL/virtual-functions-vtable-emission.cpp
@@ -1,0 +1,61 @@
+// Virtual functions annotated with the 'indirectly_callable' property may be
+// defined in a different translation unit than the one which constructs objects
+// of the corresponding polymorphic class. Middle-end analyses of virtual
+// functions (SYCLVirtualFunctionsAnalysisPass) work by inspecting the vtable
+// initializer and the attributes of the functions it references, so both have to
+// be available in every translation unit which references the vtable:
+//
+// - the vtable definition must be emitted even though the key function is
+//   defined elsewhere, and it has to be mergeable (linkonce_odr) so that we
+//   don't get multiple definitions once all device code is linked together;
+// - declarations of virtual functions must carry the "indirectly-callable"
+//   attribute, not just their definitions.
+//
+// Vtables of polymorphic classes without such virtual functions keep the old
+// behaviour of not being defined in device code at all.
+//
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -fsycl-is-device \
+// RUN:     -emit-llvm %s -o - | FileCheck %s
+
+using size_t = __SIZE_TYPE__;
+void *operator new(size_t, void *Ptr) { return Ptr; }
+
+class Base {
+public:
+  [[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "set-a")]]
+  virtual void increment(int *Data);
+};
+
+// 'Derived' neither overrides nor annotates 'increment', but its vtable still
+// refers to 'Base::increment', so it has to be emitted as well. It also declares
+// its own non-inline virtual function, i.e. it has a key function of its own
+// which is defined in another translation unit.
+class Derived : public Base {
+public:
+  virtual void hostOnly();
+};
+
+// An ordinary polymorphic class, unrelated to the virtual functions extension.
+class Plain {
+public:
+  virtual void unrelated();
+};
+
+SYCL_EXTERNAL void construct(void *Storage) {
+  new (Storage) Base();
+  new (Storage) Derived();
+  new (Storage) Plain();
+}
+
+// The vtables are emitted here despite the key functions being defined in other
+// translation units, and they reference the declarations of those functions.
+// Slots for virtual functions which are not device functions are nulled out.
+// CHECK-DAG: @_ZTV4Base = linkonce_odr {{.*}} constant { [3 x ptr addrspace(4)] } { [3 x ptr addrspace(4)] [ptr addrspace(4) null, ptr addrspace(4) null, ptr addrspace(4) addrspacecast (ptr @_ZN4Base9incrementEPi to ptr addrspace(4))] }
+// CHECK-DAG: @_ZTV7Derived = linkonce_odr {{.*}} constant { [4 x ptr addrspace(4)] } { [4 x ptr addrspace(4)] [ptr addrspace(4) null, ptr addrspace(4) null, ptr addrspace(4) addrspacecast (ptr @_ZN4Base9incrementEPi to ptr addrspace(4)), ptr addrspace(4) null] }
+
+// 'Plain' has nothing to do with the virtual functions extension, so no
+// definition of its vtable is emitted - only a declaration, exactly as before.
+// CHECK-DAG: @_ZTV5Plain = external unnamed_addr addrspace(1) constant { [3 x ptr addrspace(4)] }, align 8
+
+// CHECK: declare {{.*}}spir_func void @_ZN4Base9incrementEPi({{.*}}#[[#DECL_ATTRS:]]
+// CHECK: attributes #[[#DECL_ATTRS]] = {{.*}}"indirectly-callable"="set-a"

--- a/llvm/test/SYCLLowerIR/SYCLVirtualFunctionsAnalysis/calls-indirectly-propagation-5.ll
+++ b/llvm/test/SYCLLowerIR/SYCLVirtualFunctionsAnalysis/calls-indirectly-propagation-5.ll
@@ -1,0 +1,27 @@
+; RUN: opt -S -passes=sycl-virtual-functions-analysis %s | FileCheck %s
+;
+; Virtual functions may be defined in a different translation unit (or even in a
+; different device image) than the one which constructs objects of the
+; corresponding polymorphic class. In that case a vtable references only a
+; declaration of a virtual function, but the "indirectly-callable" attribute is
+; still attached to it and therefore "calls-indirectly" should still be
+; propagated onto kernels using that vtable.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64-unknown-unknown"
+
+@vtable = linkonce_odr dso_local unnamed_addr addrspace(1) constant { [3 x ptr addrspace(4)] } { [3 x ptr addrspace(4)] [ptr addrspace(4) null, ptr addrspace(4) null, ptr addrspace(4) addrspacecast (ptr @foo to ptr addrspace(4))] }, align 8
+
+declare spir_func void @foo() #0
+
+define weak_odr dso_local spir_kernel void @kernel(ptr addrspace(1) noundef align 8 %_arg_StorageAcc) #1 {
+entry:
+  store ptr addrspace(1) getelementptr inbounds inrange(-16, 8) (i8, ptr addrspace(1) @vtable, i64 16), ptr addrspace(1) %_arg_StorageAcc, align 8
+  ret void
+}
+
+; CHECK: @kernel({{.*}} #[[#KERNEL_ATTRS:]]
+; CHECK: attributes #[[#KERNEL_ATTRS]] = {{.*}}"calls-indirectly"="set-foo"
+
+attributes #0 = { "indirectly-callable"="set-foo" "sycl-module-id"="v.cpp" }
+attributes #1 = { "sycl-module-id"="v.cpp" }

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-call.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-call.cpp
@@ -1,11 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
 //
-// VTables are global variables with possibly external linkage and that causes
-// them to be copied into every module we produce during device code split
-// which in turn leads to multiple definitions error at runtime.
-// XFAIL: run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15069
-//
 // This test covers a scenario where virtual functions defintion and their uses
 // are split into different translation units. In particular:
 // - both virtual functions and construct kernel are in the same translation
@@ -14,6 +8,11 @@
 //
 // RUN: %{build} %S/Inputs/call.cpp -o %t.out %helper-includes
 // RUN: %{run} %t.out
+//
+// Vtable emission for classes with 'indirectly_callable' virtual functions
+// depends on the optimization level, so check -O0 explicitly as well.
+// RUN: %{build} %O0 %S/Inputs/call.cpp -o %t-O0.out %helper-includes
+// RUN: %{run} %t-O0.out
 
 #include "Inputs/declarations.hpp"
 

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-call.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-call.cpp
@@ -1,3 +1,6 @@
+// UNSUPPORTED: gpu-intel-gen12
+// UNSUPPORTED-TRACKER: GSD-11997
+
 // REQUIRES: aspect-usm_shared_allocations
 //
 // This test covers a scenario where virtual functions defintion and their uses

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs-and-call.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs-and-call.cpp
@@ -1,3 +1,6 @@
+// UNSUPPORTED: gpu-intel-gen12
+// UNSUPPORTED-TRACKER: GSD-11997
+
 // REQUIRES: aspect-usm_shared_allocations
 //
 // This test covers a scenario where virtual functions defintion and their uses

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs-and-call.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs-and-call.cpp
@@ -1,18 +1,15 @@
 // REQUIRES: aspect-usm_shared_allocations
 //
-// We attach calls-indirectly attribute (and therefore device image property)
-// to construct kernels at compile step. At that stage we may not see virtual
-// function definitions and therefore we won't mark construct kernel as using
-// virtual functions and link operation at runtime will fail due to undefined
-// references to virtual functions from vtable.
-// XFAIL: run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15071
-//
 // This test covers a scenario where virtual functions defintion and their uses
 // are all split into different translation units.
 //
 // RUN: %{build} %S/Inputs/call.cpp %S/Inputs/vf.cpp -o %t.out %helper-includes
 // RUN: %{run} %t.out
+//
+// Vtable emission for classes with 'indirectly_callable' virtual functions
+// depends on the optimization level, so check -O0 explicitly as well.
+// RUN: %{build} %O0 %S/Inputs/call.cpp %S/Inputs/vf.cpp -o %t-O0.out %helper-includes
+// RUN: %{run} %t-O0.out
 
 #include "Inputs/declarations.hpp"
 

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs.cpp
@@ -1,13 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
 //
-// We attach calls-indirectly attribute (and therefore device image property)
-// to construct kernels at compile step. At that stage we may not see virtual
-// function definitions and therefore we won't mark construct kernel as using
-// virtual functions and link operation at runtime will fail due to undefined
-// references to virtual functions from vtable.
-// XFAIL: run-mode
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15071
-//
 // This test covers a scenario where virtual functions defintion and their uses
 // are split into different translation units. In particular:
 // - use and construct kernesl are in the same translation unit
@@ -15,6 +7,11 @@
 //
 // RUN: %{build} %S/Inputs/vf.cpp -o %t.out %helper-includes
 // RUN: %{run} %t.out
+//
+// Vtable emission for classes with 'indirectly_callable' virtual functions
+// depends on the optimization level, so check -O0 explicitly as well.
+// RUN: %{build} %O0 %S/Inputs/vf.cpp -o %t-O0.out %helper-includes
+// RUN: %{run} %t-O0.out
 
 #include "Inputs/declarations.hpp"
 


### PR DESCRIPTION
SYCLVirtualFunctionsAnalysisPass propagates the "calls-indirectly" attribute onto kernels by walking from a virtual function carrying "indirectly-callable" to the vtables which reference it, and from there to the kernels which reference those vtables. That only works if both the vtable initializer and the attribute are visible in the module being analyzed, which was not the case when a virtual function was defined out-of-line:

* "indirectly-callable" was only attached to function definitions, so a translation unit which only saw a declaration lost the information;
* ModuleBuilder::HandleVTable bailed out unconditionally for SYCL device compilation, so a vtable whose key function is defined in another translation unit was never emitted at all and the analysis had nothing to look at.

As a result a kernel which merely constructed an object of a polymorphic class was not marked as using virtual functions, and runtime linking later failed with undefined references to the virtual functions from the vtable.

This does the following, all restricted to SYCL device compilation and to classes which declare (or inherit) an 'indirectly_callable' virtual function:

* attach compile-time properties to function declarations as well, not just to definitions;
* force the vtable to be emitted in every translation unit which references the vtable, regardless of where the key function is defined;
* give such vtables linkonce_odr linkage so that emitting them more than once is not a problem once all device code is linked together, and so that they can be duplicated across device images produced by device code split - which is what #15069 was about.

Vtables of polymorphic classes unrelated to the virtual functions extension keep the previous behaviour of not being defined in device code at all.

The three previously XFAILed end-to-end tests are un-XFAILed and gain -O0 RUN lines, since vtable linkage depends on the optimization level.

Closes: #15071 
Closes: #15069