### PR TITLE
[SYCL] Avoid redundant deep device type checks

### DIFF
--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -289,6 +289,8 @@ private:
   // special types inside. Relevant for free function kernels only.
   llvm::DenseSet<const RecordDecl *> StructsWithSpecialTypes;
 
+  llvm::DenseSet<const RecordDecl *> DeepTypeCheckedRecords;
+
 public:
   SemaSYCL(Sema &S);
 
@@ -319,9 +321,7 @@ public:
       DeviceDiagnosticReason Reason = DeviceDiagnosticReason::Sycl |
                                       DeviceDiagnosticReason::Esimd);
 
-  void deepTypeCheckForDevice(SourceLocation UsedAt,
-                              llvm::DenseSet<QualType> Visited,
-                              ValueDecl *DeclToCheck);
+  void deepTypeCheckForDevice(SourceLocation UsedAt, ValueDecl *DeclToCheck);
 
   const KernelFDPairs &getKernelFDPairs() { return SyclKernelsToOpenCLKernels; }
 

--- a/clang/include/clang/Sema/SemaSYCL.h
+++ b/clang/include/clang/Sema/SemaSYCL.h
@@ -289,7 +289,7 @@ private:
   // special types inside. Relevant for free function kernels only.
   llvm::DenseSet<const RecordDecl *> StructsWithSpecialTypes;
 
-  llvm::DenseSet<const RecordDecl *> DeepTypeCheckedRecords;
+  llvm::DenseSet<CanonicalDeclPtr<const TagDecl>> DeepTypeCheckedRecords;
 
 public:
   SemaSYCL(Sema &S);

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -2438,10 +2438,8 @@ void Sema::checkTypeSupport(QualType Ty, SourceLocation Loc, ValueDecl *D) {
   // declarations can be replaced with an array of bytes of the same size during
   // codegen, such replacement doesn't seem to be possible for types without
   // constant byte size like zero length arrays. So, do a deep check for SYCL.
-  if (D && LangOpts.SYCLIsDevice) {
-    llvm::DenseSet<QualType> Visited;
-    SYCL().deepTypeCheckForDevice(Loc, Visited, D);
-  }
+  if (D && LangOpts.SYCLIsDevice)
+    SYCL().deepTypeCheckForDevice(Loc, D);
 
   Decl *C = cast<Decl>(getCurLexicalContext());
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -425,19 +425,19 @@ static bool isZeroSizedArray(SemaSYCL &S, QualType Ty) {
   return false;
 }
 
-static bool needsDeepTypeCheck(SemaSYCL &S, QualType Ty,
-                               const RecordDecl *&RootRecord) {
-  RootRecord = nullptr;
+static std::pair<const RecordDecl *, bool> needsDeepTypeCheck(SemaSYCL &S,
+                                                              QualType Ty) {
+  const RecordDecl *RootRecord = nullptr;
   while (Ty->isAnyPointerType() || Ty->isArrayType() || Ty->isReferenceType()) {
     if (isZeroSizedArray(S, Ty))
-      return true;
+      return {nullptr, true};
     if (Ty->isArrayType())
       Ty = QualType{Ty->getArrayElementTypeNoTypeQual(), 0};
     else
       Ty = Ty->getPointeeType();
   }
   RootRecord = Ty->getAsRecordDecl();
-  return RootRecord != nullptr;
+  return {RootRecord, RootRecord != nullptr};
 }
 
 static void checkSYCLType(SemaSYCL &S, QualType Ty, SourceRange Loc,
@@ -6004,8 +6004,9 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
                                       ValueDecl *DeclToCheck) {
   assert(getLangOpts().SYCLIsDevice &&
          "Should only be called during SYCL compilation");
-  const RecordDecl *RootRecord = nullptr;
-  if (!needsDeepTypeCheck(*this, DeclToCheck->getType(), RootRecord))
+  const auto [RootRecord, NeedsCheck] =
+      needsDeepTypeCheck(*this, DeclToCheck->getType());
+  if (!NeedsCheck)
     return;
   if (RootRecord && RootRecord->isCompleteDefinition() &&
       DeepTypeCheckedRecords.contains(

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -428,8 +428,7 @@ static bool isZeroSizedArray(SemaSYCL &S, QualType Ty) {
 static bool needsDeepTypeCheck(SemaSYCL &S, QualType Ty,
                                const RecordDecl *&RootRecord) {
   RootRecord = nullptr;
-  while (Ty->isAnyPointerType() || Ty->isArrayType() ||
-         Ty->isReferenceType()) {
+  while (Ty->isAnyPointerType() || Ty->isArrayType() || Ty->isReferenceType()) {
     if (isZeroSizedArray(S, Ty))
       return true;
     if (Ty->isArrayType())
@@ -6017,8 +6016,7 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
   // to avoid mess of notes. This flag is to track that error already happened.
   bool NeedToEmitNotes = true;
   bool FoundError = false;
-  bool CanCacheResult =
-      RootRecord && RootRecord->isCompleteDefinition();
+  bool CanCacheResult = RootRecord && RootRecord->isCompleteDefinition();
   llvm::SmallDenseSet<QualType, 8> Visited;
 
   auto Check = [&](QualType TypeToCheck, const ValueDecl *D) {
@@ -6110,8 +6108,8 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
   } while (!StackForRecursion.empty());
 
   if (CanCacheResult && !FoundError)
-  DeepTypeCheckedRecords.insert(
-    cast<RecordDecl>(RootRecord->getCanonicalDecl()));
+    DeepTypeCheckedRecords.insert(
+        cast<RecordDecl>(RootRecord->getCanonicalDecl()));
 }
 
 void SemaSYCL::finalizeSYCLDelayedAnalysis(const FunctionDecl *Caller,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -425,6 +425,22 @@ static bool isZeroSizedArray(SemaSYCL &S, QualType Ty) {
   return false;
 }
 
+static bool needsDeepTypeCheck(SemaSYCL &S, QualType Ty,
+                               const RecordDecl *&RootRecord) {
+  RootRecord = nullptr;
+  while (Ty->isAnyPointerType() || Ty->isArrayType() ||
+         Ty->isReferenceType()) {
+    if (isZeroSizedArray(S, Ty))
+      return true;
+    if (Ty->isArrayType())
+      Ty = QualType{Ty->getArrayElementTypeNoTypeQual(), 0};
+    else
+      Ty = Ty->getPointeeType();
+  }
+  RootRecord = Ty->getAsRecordDecl();
+  return RootRecord != nullptr;
+}
+
 static void checkSYCLType(SemaSYCL &S, QualType Ty, SourceRange Loc,
                           llvm::DenseSet<QualType> Visited,
                           SourceRange UsedAtLoc = SourceRange()) {
@@ -5986,13 +6002,24 @@ SemaSYCL::DiagIfDeviceCode(SourceLocation Loc, unsigned DiagID,
 }
 
 void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
-                                      llvm::DenseSet<QualType> Visited,
                                       ValueDecl *DeclToCheck) {
   assert(getLangOpts().SYCLIsDevice &&
          "Should only be called during SYCL compilation");
+  const RecordDecl *RootRecord = nullptr;
+  if (!needsDeepTypeCheck(*this, DeclToCheck->getType(), RootRecord))
+    return;
+  if (RootRecord && RootRecord->isCompleteDefinition() &&
+      DeepTypeCheckedRecords.contains(
+          cast<RecordDecl>(RootRecord->getCanonicalDecl())))
+    return;
+
   // Emit notes only for the first discovered declaration of unsupported type
   // to avoid mess of notes. This flag is to track that error already happened.
   bool NeedToEmitNotes = true;
+  bool FoundError = false;
+  bool CanCacheResult =
+      RootRecord && RootRecord->isCompleteDefinition();
+  llvm::SmallDenseSet<QualType, 8> Visited;
 
   auto Check = [&](QualType TypeToCheck, const ValueDecl *D) {
     bool ErrorFound = false;
@@ -6035,6 +6062,8 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
 
     if (!Visited.insert(NextTy).second)
       continue;
+    if (NextTy->isDependentType())
+      CanCacheResult = false;
 
     auto EmitHistory = [&]() {
       // The first element is always nullptr.
@@ -6049,6 +6078,7 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
       if (NeedToEmitNotes)
         EmitHistory();
       NeedToEmitNotes = false;
+      FoundError = true;
     }
 
     // In case pointer/array/reference type is met get pointee type, then
@@ -6063,10 +6093,13 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
         if (NeedToEmitNotes)
           EmitHistory();
         NeedToEmitNotes = false;
+        FoundError = true;
       }
     }
 
     if (const auto *RecDecl = NextTy->getAsRecordDecl()) {
+      if (!RecDecl->isCompleteDefinition())
+        CanCacheResult = false;
       if (auto *NextFD = dyn_cast<FieldDecl>(Next))
         History.push_back(NextFD);
       // When nullptr is discovered, this means we've gone back up a level, so
@@ -6075,6 +6108,10 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
       llvm::append_range(StackForRecursion, RecDecl->fields());
     }
   } while (!StackForRecursion.empty());
+
+  if (CanCacheResult && !FoundError)
+  DeepTypeCheckedRecords.insert(
+    cast<RecordDecl>(RootRecord->getCanonicalDecl()));
 }
 
 void SemaSYCL::finalizeSYCLDelayedAnalysis(const FunctionDecl *Caller,
@@ -8041,7 +8078,7 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
   for (const VarDecl *VD : GlobalVars) {
     VD = VD->getCanonicalDecl();
 
-    // Skip if this isn't a SpecIdType, DeviceGlobal, or HostPipe.  This 
+    // Skip if this isn't a SpecIdType, DeviceGlobal, or HostPipe.  This
     // can happen if it was a deduced type.
     if (!SemaSYCL::isSyclType(VD->getType(), SYCLTypeAttr::specialization_id) &&
         !SemaSYCL::isSyclType(VD->getType(), SYCLTypeAttr::host_pipe) &&

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -427,7 +427,6 @@ static bool isZeroSizedArray(SemaSYCL &S, QualType Ty) {
 
 static std::pair<const RecordDecl *, bool> needsDeepTypeCheck(SemaSYCL &S,
                                                               QualType Ty) {
-  const RecordDecl *RootRecord = nullptr;
   while (Ty->isAnyPointerType() || Ty->isArrayType() || Ty->isReferenceType()) {
     if (isZeroSizedArray(S, Ty))
       return {nullptr, true};
@@ -436,8 +435,7 @@ static std::pair<const RecordDecl *, bool> needsDeepTypeCheck(SemaSYCL &S,
     else
       Ty = Ty->getPointeeType();
   }
-  RootRecord = Ty->getAsRecordDecl();
-  return {RootRecord, RootRecord != nullptr};
+  return {Ty->getAsRecordDecl(), false};
 }
 
 static void checkSYCLType(SemaSYCL &S, QualType Ty, SourceRange Loc,
@@ -6004,9 +6002,9 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
                                       ValueDecl *DeclToCheck) {
   assert(getLangOpts().SYCLIsDevice &&
          "Should only be called during SYCL compilation");
-  const auto [RootRecord, NeedsCheck] =
+  const auto [RootRecord, HasZeroSizedArray] =
       needsDeepTypeCheck(*this, DeclToCheck->getType());
-  if (!NeedsCheck)
+  if (!RootRecord && !HasZeroSizedArray)
     return;
   if (RootRecord && RootRecord->isCompleteDefinition() &&
       DeepTypeCheckedRecords.contains(RootRecord))

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -428,6 +428,8 @@ static bool isZeroSizedArray(SemaSYCL &S, QualType Ty) {
 static std::pair<const RecordDecl *, bool> needsDeepTypeCheck(SemaSYCL &S,
                                                               QualType Ty) {
   while (Ty->isAnyPointerType() || Ty->isArrayType() || Ty->isReferenceType()) {
+    // A zero-length array has no record to traverse, but the DFS below must
+    // still visit it to emit the required diagnostic.
     if (isZeroSizedArray(S, Ty))
       return {nullptr, true};
     if (Ty->isArrayType())
@@ -6016,6 +6018,7 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
   bool FoundError = false;
   bool CanCacheResult = RootRecord && RootRecord->isCompleteDefinition();
   llvm::SmallDenseSet<QualType, 8> Visited;
+  // Cache complete nested records after this whole traversal succeeds.
   llvm::SmallDenseSet<CanonicalDeclPtr<const TagDecl>, 8> VisitedRecords;
 
   auto Check = [&](QualType TypeToCheck, const ValueDecl *D) {
@@ -6059,6 +6062,8 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
 
     if (!Visited.insert(NextTy).second)
       continue;
+    // A dependent type can resolve differently when instantiated, so an
+    // error-free traversal cannot be reused for later instantiations.
     if (NextTy->isDependentType())
       CanCacheResult = false;
 
@@ -6095,6 +6100,7 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
     }
 
     if (const auto *RecDecl = NextTy->getAsRecordDecl()) {
+      // An incomplete record can acquire unsupported fields when completed.
       if (!RecDecl->isCompleteDefinition())
         CanCacheResult = false;
       else if (DeepTypeCheckedRecords.contains(RecDecl))

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -6009,8 +6009,7 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
   if (!NeedsCheck)
     return;
   if (RootRecord && RootRecord->isCompleteDefinition() &&
-      DeepTypeCheckedRecords.contains(
-          cast<RecordDecl>(RootRecord->getCanonicalDecl())))
+      DeepTypeCheckedRecords.contains(RootRecord))
     return;
 
   // Emit notes only for the first discovered declaration of unsupported type
@@ -6109,8 +6108,7 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
   } while (!StackForRecursion.empty());
 
   if (CanCacheResult && !FoundError)
-    DeepTypeCheckedRecords.insert(
-        cast<RecordDecl>(RootRecord->getCanonicalDecl()));
+    DeepTypeCheckedRecords.insert(RootRecord);
 }
 
 void SemaSYCL::finalizeSYCLDelayedAnalysis(const FunctionDecl *Caller,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -6016,6 +6016,7 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
   bool FoundError = false;
   bool CanCacheResult = RootRecord && RootRecord->isCompleteDefinition();
   llvm::SmallDenseSet<QualType, 8> Visited;
+  llvm::SmallDenseSet<CanonicalDeclPtr<const TagDecl>, 8> VisitedRecords;
 
   auto Check = [&](QualType TypeToCheck, const ValueDecl *D) {
     bool ErrorFound = false;
@@ -6096,6 +6097,10 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
     if (const auto *RecDecl = NextTy->getAsRecordDecl()) {
       if (!RecDecl->isCompleteDefinition())
         CanCacheResult = false;
+      else if (DeepTypeCheckedRecords.contains(RecDecl))
+        continue;
+      else
+        VisitedRecords.insert(RecDecl);
       if (auto *NextFD = dyn_cast<FieldDecl>(Next))
         History.push_back(NextFD);
       // When nullptr is discovered, this means we've gone back up a level, so
@@ -6106,7 +6111,7 @@ void SemaSYCL::deepTypeCheckForDevice(SourceLocation UsedAt,
   } while (!StackForRecursion.empty());
 
   if (CanCacheResult && !FoundError)
-    DeepTypeCheckedRecords.insert(RootRecord);
+    DeepTypeCheckedRecords.insert_range(VisitedRecords);
 }
 
 void SemaSYCL::finalizeSYCLDelayedAnalysis(const FunctionDecl *Caller,


### PR DESCRIPTION
Skip types that cannot contain zero-length arrays, use an inline visited
set, and cache successfully validated complete record definitions. This
reduces temporary allocations from repeated SYCL type validation while
preserving diagnostics for invalid and incomplete records.

Assisted-by: GPT-5.6 Terra <noreply@openai.com>