### PR TITLE
[SYCL] Restore the error message to be same as old offloading model

### DIFF
--- a/llvm/lib/Frontend/Offloading/Utility.cpp
+++ b/llvm/lib/Frontend/Offloading/Utility.cpp
@@ -516,9 +516,12 @@ offloading::compressSYCLDeviceImage(ArrayRef<uint8_t> Input,
                                     size_t Threshold, bool Verbose) {
   if (!compression::zstd::isAvailable())
     return createStringError(
-        "Device image compression was requested, but LLVM was built without "
-        "zstd support. Rebuild with LLVM_ENABLE_ZSTD enabled to use this "
-        "feature.");
+        "'--offload-compress' is specified but the compiler is built without "
+        "zstd support.\n"
+        "If you are using a custom DPC++ build, please refer to "
+        "https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md"
+        "#build-dpc-toolchain-with-device-image-compression-support for more "
+        "information on how to build with zstd support.");
 
   if (Input.size() < Threshold)
     return false;


### PR DESCRIPTION
The wording on one of the error messages were different and thus one of the test was failing when ztd was not available. The old error message was restored for uniformity.