### PR TITLE
[SYCL] Do not release threadpool resources on Windows during shutdown

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -323,7 +323,16 @@ void shutdown_early(bool CanJoinThreads = true) {
   // upon its release
   GlobalHandler::RTGlobalObjHandler->prepareSchedulerToRelease(true);
 
-  if (GlobalHandler::RTGlobalObjHandler->MHostTaskThreadPool.Inst) {
+  // Do not cleanup thread pool on windows during application shutdown.
+  // Let OS do the cleanup.
+  bool doThreadPoolCleanup =
+    GlobalHandler::RTGlobalObjHandler->MHostTaskThreadPool.Inst.get() !=
+    nullptr;
+#ifndef _WIN32
+  doThreadPoolCleanup &= !CanJoinThreads;
+#endif
+
+  if (doThreadPoolCleanup) {
     GlobalHandler::RTGlobalObjHandler->MHostTaskThreadPool.Inst->finishAndWait(
         CanJoinThreads);
     GlobalHandler::RTGlobalObjHandler->MHostTaskThreadPool.Inst.reset(nullptr);
@@ -373,8 +382,13 @@ void shutdown_late() {
 
   GlobalHandler::RTGlobalObjHandler->MXPTIRegistry.Inst.reset(nullptr);
 
-  // Release the rest of global resources.
+#ifndef _WIN32
+  // Release the rest of global resources. Do not release GlobalHandler
+  // on Windows and let OS reclaim leaked memory. Releasing GlobalHandler
+  // on Windows can seg fault if application uses host tasks, as there
+  // can be a race between host tasks and shutdown.
   delete GlobalHandler::RTGlobalObjHandler;
+#endif
   GlobalHandler::RTGlobalObjHandler = nullptr;
 }
 

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -326,9 +326,9 @@ void shutdown_early(bool CanJoinThreads = true) {
   // Do not cleanup thread pool on windows during application shutdown.
   // Let OS do the cleanup.
   bool doThreadPoolCleanup =
-    GlobalHandler::RTGlobalObjHandler->MHostTaskThreadPool.Inst.get() !=
-    nullptr;
-#ifndef _WIN32
+      GlobalHandler::RTGlobalObjHandler->MHostTaskThreadPool.Inst.get() !=
+      nullptr;
+#ifdef _WIN32
   doThreadPoolCleanup &= !CanJoinThreads;
 #endif
 


### PR DESCRIPTION
Fixes flaky crash when joining host tasks during windows shutdown.

Windows does not guarantee that threads of main application won't be killed unless DllMain(detach) is complete:
 

> When handling DLL_PROCESS_DETACH, a DLL should free resources such as heap memory only if the DLL is being unloaded dynamically (the lpvReserved parameter is NULL). If the process is terminating (the lpvReserved parameter is non-NULL), all threads in the process except the current thread either have exited already or have been explicitly terminated by a call to the [ExitProcess](https://learn.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-exitprocess) function, which might leave some process resources such as heaps in an inconsistent state. In this case, it is not safe for the DLL to clean up the resources. Instead, the DLL should allow the operating system to reclaim the memory.

[DllMain entry point (Process.h) - Win32 apps | Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/dlls/dllmain)

So, we should not try to join host tasks on windows during shutdown.

Fixes CMPLRLLVM-74436