### PR TITLE
[SYCL][E2E] Fix dlclose_shared_kernel_name.cpp in split build/run mode

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/dependency/dynamic_lib_device_global.cpp
+++ b/sycl/test-e2e/AddressSanitizer/dependency/dynamic_lib_device_global.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: linux, cpu || (gpu && level_zero)
 // RUN: rm -rf %t.dir; mkdir -p %t.dir
 // RUN: %{build} %device_asan_flags -O0 -g -fPIC -shared -fsycl-allow-device-image-dependencies -DBUILD_LIB -o %t.dir/libdevice_oob.so
-// RUN: %{build} %device_asan_flags -O0 -g -fsycl-allow-device-image-dependencies -o %t.out -L%t.dir -ldevice_oob -Wl,-rpath=%t.dir
+// RUN: %{run-aux} %{build} %device_asan_flags -O0 -g -fsycl-allow-device-image-dependencies -o %t.out -L%t.dir -ldevice_oob -Wl,-rpath=%t.dir
 // RUN: %{run} not --crash %t.out 2>&1 | FileCheck %s
 #include <sycl/detail/core.hpp>
 


### PR DESCRIPTION
The test links its executable with an absolute `-Wl,-rpath,%t.dir` and then
dlopen()s the two DSOs by bare soname, so the lookup relies entirely on the
embedded DT_RUNPATH.

With `--param test-mode=build-only` / `run-only`, the link runs on the build
machine and only the `%{run}` line is re-executed on the run machine. The
build tree is transferred, so `%t.dir` and its DSOs do exist where the test
runs -- but under a different absolute prefix, while DT_RUNPATH still names
the builder's directory. dlopen() returns NULL and the test aborts on
`assert(hA && "failed to dlopen libA")` without ever reaching the
ProgramManager::removeImages use-after-free scenario it was written for.
