### PR TITLE
[UR] Fix logger use-after-free during shutdown teardown

### DIFF
--- a/unified-runtime/source/common/logger/ur_logger.hpp
+++ b/unified-runtime/source/common/logger/ur_logger.hpp
@@ -70,10 +70,14 @@ create_logger(std::string logger_name, bool skip_prefix = false,
 inline Logger &
 get_logger(std::string name = "common",
            ur_logger_level_t default_log_level = UR_LOGGER_LEVEL_QUIET) {
-  static Logger logger =
+  struct SingletonLogger {
+    Logger logger;
+    ~SingletonLogger() { isTearDowned.store(true, std::memory_order_release); }
+  };
+  static SingletonLogger singleton{
       create_logger(std::move(name), /*skip_prefix*/ false,
-                    /*slip_linebreak*/ false, default_log_level);
-  return logger;
+                    /*slip_linebreak*/ false, default_log_level)};
+  return singleton.logger;
 }
 
 inline void init(const std::string &name) { get_logger(name.c_str()); }


### PR DESCRIPTION
On shutdown, SharedLayer::tearDown() logs while unloading the sanitizer
library, but get_logger()'s singleton sink may already be freed. The
isTearDowned latch that guards this was only set by ~StderrSink, so it
stayed false for stdout/file sinks (used under SYCL_UR_TRACE), and the
log dereferenced the freed sink.

Set the latch from the get_logger() singleton's destructor so it fires
for any sink type.