### PR TITLE
[UR][L0] Call zeCommandListAppendHostFunction directly since L0 1.17

### DIFF
--- a/unified-runtime/source/adapters/level_zero/common/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/common/platform.cpp
@@ -796,10 +796,15 @@ ur_result_t ur_platform_handle_t_::initialize() {
       .DisableZeLaunchKernelWithArgs =
       getenv_tobool("UR_L0_V2_DISABLE_ZE_LAUNCH_KERNEL_WITH_ARGS", false);
 
-  ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
-                  (ZeDriver, "zeCommandListAppendHostFunction",
-                   reinterpret_cast<void **>(
-                       &ZeHostTaskExt.zeCommandListAppendHostFunction)));
+  if (this->isDriverVersionNewerOrSimilar(1, 17, 0)) {
+    ZeHostTaskExt.zeCommandListAppendHostFunction =
+        zeCommandListAppendHostFunction;
+  } else {
+    ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
+                    (ZeDriver, "zeCommandListAppendHostFunction",
+                     reinterpret_cast<void **>(
+                         &ZeHostTaskExt.zeCommandListAppendHostFunction)));
+  }
 
   ZeHostTaskExt.Supported =
       ZeHostTaskExt.zeCommandListAppendHostFunction != nullptr;

--- a/unified-runtime/source/adapters/level_zero/common/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/common/platform.hpp
@@ -275,9 +275,10 @@ struct ur_platform_handle_t_ : ur::level_zero::ur_object_t, public ur_platform {
   struct ZeHostTaskExtension {
     bool Supported = false;
     ze_result_t (*zeCommandListAppendHostFunction)(
-        ze_command_list_handle_t hCommandList, void *pHostFunction,
-        void *pUserData, void *pNext, ze_event_handle_t hSignalEvent,
-        uint32_t numWaitEvents, ze_event_handle_t *phWaitEvents);
+        ze_command_list_handle_t hCommandList,
+        ze_host_function_callback_t pHostFunction, void *pUserData,
+        const void *pNext, ze_event_handle_t hSignalEvent,
+        uint32_t numWaitEvents, _ze_event_handle_t **phWaitEvents);
   } ZeHostTaskExt;
 
   // Flag to indicate whether zeDeviceSynchronize is supported.

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_manager.cpp
@@ -1482,7 +1482,8 @@ ur_result_t ur_command_list_manager::appendHostTaskExp(
   }
 
   ZE2UR_CALL(hPlatform->ZeHostTaskExt.zeCommandListAppendHostFunction,
-             (getZeCommandList(), (void *)pfnHostTask, data,
+             (getZeCommandList(),
+              reinterpret_cast<ze_host_function_callback_t>(pfnHostTask), data,
               const_cast<void *>(reinterpret_cast<const void *>(pProperties)),
               getSignalEvent(phEvent, UR_COMMAND_HOST_TASK_EXP),
               waitListView.num, waitListView.handles));


### PR DESCRIPTION
Starting with Level Zero driver version 1.17, `zeCommandListAppendHostFunction`
is part of the core API, so it can be called directly instead of being
resolved via `zeDriverGetExtensionFunctionAddress`. For older drivers, keep
resolving it dynamically as an extension.

Update the `ZeHostTaskExtension::zeCommandListAppendHostFunction` function
pointer type to match the real API signature (`ze_host_function_callback_t,
const void *pNext, ze_event_handle_t *phWaitEvents`), and fix the call site
in command_list_manager.cpp to cast `pfnHostTask` to
`ze_host_function_callback_t` instead of `void *`, avoiding an invalid
`void *` to function-pointer conversion.

Ref: Jira URT-1275