### PR TITLE
[SYCL] Re-enable free_function_kernels.cpp e2e test  on Gen12 graphics

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/free_function_kernels.cpp
+++ b/sycl/test-e2e/KernelAndProgram/free_function_kernels.cpp
@@ -1,8 +1,6 @@
 // REQUIRES: aspect-usm_shared_allocations
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// XFAIL: windows && gpu-intel-gen12
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/21994
 // This test tests free function kernel code generation and execution.
 
 #include <iostream>


### PR DESCRIPTION
Related to: https://github.com/intel/llvm/issues/21994
