### PR TITLE
[SYCL][Graph][Test] Add native recording mock fixture

### DIFF
--- a/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
@@ -10,6 +10,8 @@ add_sycl_unittest(CommandGraphExtensionTests OBJECT
   Exceptions.cpp
   InOrderQueue.cpp
   MultiThreaded.cpp
+  NativeRecording.cpp
+  NativeRecordingMock.cpp
   Queries.cpp
   Regressions.cpp
   Subgraph.cpp

--- a/sycl/unittests/Extensions/CommandGraph/Common.hpp
+++ b/sycl/unittests/Extensions/CommandGraph/Common.hpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+#pragma once
+
 #include "sycl/ext/oneapi/experimental/graph.hpp"
 #include <sycl/sycl.hpp>
 

--- a/sycl/unittests/Extensions/CommandGraph/NativeRecording.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/NativeRecording.cpp
@@ -1,0 +1,186 @@
+//==------------------------- NativeRecording.cpp --------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "NativeRecordingMock.hpp"
+
+using NativeRecordingMock::state;
+using NativeRecordingMock::traceCount;
+using NativeRecordingMock::traceIndex;
+
+// Test that native recording throws when UR does not support it
+TEST_F(NativeRecordingTest, NativeRecordingUnsupportedDevice) {
+  state().SupportsNativeRecording = false;
+  try {
+    makeGraph();
+    FAIL() << "Expected an exception";
+  } catch (sycl::exception &E) {
+    EXPECT_EQ(E.code(), sycl::errc::invalid);
+  }
+}
+
+// Traces UR recording layer
+TEST_F(NativeRecordingTest, RecordingUrTrace) {
+  auto Graph = makeGraph();
+
+  Graph.begin_recording(Queue);
+  Queue.submit(
+      [&](sycl::handler &CGH) { CGH.single_task<TestKernel>([]() {}); });
+  Graph.end_recording(Queue);
+
+  ASSERT_EQ(traceCount("urQueueBeginCaptureIntoGraphExp"), 1u);
+  ASSERT_EQ(traceCount("urEnqueueKernelLaunchWithArgsExp"), 1u);
+  ASSERT_EQ(traceCount("urQueueEndGraphCaptureExp"), 1u);
+  EXPECT_LT(traceIndex("urQueueBeginCaptureIntoGraphExp"),
+            traceIndex("urEnqueueKernelLaunchWithArgsExp"));
+  EXPECT_LT(traceIndex("urEnqueueKernelLaunchWithArgsExp"),
+            traceIndex("urQueueEndGraphCaptureExp"));
+}
+
+// Finalize and submission traces
+TEST_F(NativeRecordingTest, FinalizeSubmitUrTrace) {
+  auto Graph = makeGraph();
+
+  Graph.begin_recording(Queue);
+  Queue.submit(
+      [&](sycl::handler &CGH) { CGH.single_task<TestKernel>([]() {}); });
+  Graph.end_recording(Queue);
+
+  EXPECT_EQ(traceCount("urGraphInstantiateGraphExp"), 0u);
+
+  auto ExecGraph = Graph.finalize();
+
+  EXPECT_EQ(traceCount("urGraphInstantiateGraphExp", nativeHandle(Graph)), 1u);
+  ASSERT_NE(nativeHandle(ExecGraph), nullptr);
+  EXPECT_EQ(traceCount("urEnqueueGraphExp"), 0u);
+
+  Queue.ext_oneapi_graph(ExecGraph);
+  Queue.wait();
+
+  EXPECT_EQ(traceCount("urEnqueueGraphExp", nativeHandle(ExecGraph)), 1u);
+  EXPECT_EQ(traceCount("urCommandBufferCreateExp"), 0u);
+}
+
+// The executable graph must be destroyed prior to the modifiable.
+TEST_F(NativeRecordingTest, DestructionOrder) {
+  ur_exp_graph_handle_t GraphHandle = nullptr;
+  ur_exp_executable_graph_handle_t ExecHandle = nullptr;
+  {
+    auto ExecGraph = [&]() {
+      auto Graph = makeGraph();
+      GraphHandle = nativeHandle(Graph);
+
+      Graph.begin_recording(Queue);
+      Queue.submit(
+          [&](sycl::handler &CGH) { CGH.single_task<TestKernel>([]() {}); });
+      Graph.end_recording(Queue);
+
+      return Graph.finalize();
+    }();
+    ExecHandle = nativeHandle(ExecGraph);
+
+    ASSERT_NE(GraphHandle, nullptr);
+    ASSERT_NE(ExecHandle, nullptr);
+    EXPECT_EQ(traceCount("urGraphDestroyExp"), 0u);
+    EXPECT_EQ(traceCount("urGraphExecutableGraphDestroyExp"), 0u);
+  }
+
+  EXPECT_EQ(traceCount("urGraphExecutableGraphDestroyExp", ExecHandle), 1u);
+  EXPECT_EQ(traceCount("urGraphDestroyExp", GraphHandle), 1u);
+  EXPECT_LT(traceIndex("urGraphExecutableGraphDestroyExp"),
+            traceIndex("urGraphDestroyExp"));
+}
+
+// Check that destruction callback goes through UR and not SYCL command buffer
+// path.
+TEST_F(NativeRecordingTest, DestructionCallbackUrTrace) {
+  bool CallbackFired1 = false;
+  bool CallbackFired2 = false;
+  ur_exp_graph_handle_t Handle = nullptr;
+  {
+    auto Graph = makeGraph();
+    Handle = nativeHandle(Graph);
+
+    EXPECT_EQ(traceCount("urGraphCreateExp", Handle), 1u);
+    ASSERT_NE(Handle, nullptr);
+
+    Graph.set_destruction_callback(
+        [&CallbackFired1]() { CallbackFired1 = true; });
+    Graph.set_destruction_callback(
+        [&CallbackFired2]() { CallbackFired2 = true; });
+
+    EXPECT_EQ(traceCount("urGraphSetDestructionCallbackExp", Handle), 2u);
+    EXPECT_FALSE(CallbackFired1);
+    EXPECT_FALSE(CallbackFired2);
+    EXPECT_EQ(traceCount("urGraphDestroyExp"), 0u);
+  }
+
+  EXPECT_EQ(traceCount("urGraphDestroyExp", Handle), 1u);
+  EXPECT_LT(traceIndex("urGraphCreateExp"), traceIndex("urGraphDestroyExp"));
+  EXPECT_LT(traceIndex("urGraphSetDestructionCallbackExp"),
+            traceIndex("urGraphDestroyExp"));
+  EXPECT_TRUE(CallbackFired1);
+  EXPECT_TRUE(CallbackFired2);
+}
+
+// Check that the graph ID is going through UR and not the SYCL command buffer
+// or native recording fallback path.
+TEST_F(NativeRecordingTest, GetIdUrTrace) {
+  auto Graph = makeGraph();
+  EXPECT_EQ(Graph.get_id(), NativeRecordingMock::FirstGraphId);
+  EXPECT_EQ(traceCount("urGraphGetIdExp", nativeHandle(Graph)), 1u);
+}
+
+// Check UR call for get graph and graph uniqueness
+TEST_F(NativeRecordingTest, GetGraphUrTrace) {
+  auto Graph = makeGraph();
+  auto SecondGraph = makeGraph();
+  sycl::queue SecondQueue{Dev, {sycl::property::queue::in_order{}}};
+
+  Graph.begin_recording(Queue);
+  SecondGraph.begin_recording(SecondQueue);
+
+  auto RecordedGraph = Queue.ext_oneapi_get_graph();
+  auto SecondRecordedGraph = SecondQueue.ext_oneapi_get_graph();
+
+  EXPECT_EQ(traceCount("urQueueGetGraphExp"), 2u);
+  EXPECT_EQ(getSyclObjImpl(RecordedGraph), getSyclObjImpl(Graph));
+  EXPECT_EQ(getSyclObjImpl(SecondRecordedGraph), getSyclObjImpl(SecondGraph));
+  EXPECT_EQ(nativeHandle(RecordedGraph), nativeHandle(Graph));
+  EXPECT_EQ(nativeHandle(SecondRecordedGraph), nativeHandle(SecondGraph));
+
+  Graph.end_recording(Queue);
+  SecondGraph.end_recording(SecondQueue);
+}
+
+// Check UR empty graph call
+TEST_F(NativeRecordingTest, EmptyUrTrace) {
+  auto Graph = makeGraph();
+  ur_exp_graph_handle_t Handle = nativeHandle(Graph);
+
+  state().graph(Handle).IsEmpty = true;
+  EXPECT_TRUE(Graph.empty());
+  EXPECT_EQ(traceCount("urGraphIsEmptyExp", Handle), 1u);
+
+  state().graph(Handle).IsEmpty = false;
+  EXPECT_FALSE(Graph.empty());
+  EXPECT_EQ(traceCount("urGraphIsEmptyExp", Handle), 2u);
+}
+
+// Check UR call for queue state
+TEST_F(NativeRecordingTest, GetStateUrTrace) {
+  auto Graph = makeGraph();
+  EXPECT_EQ(Queue.ext_oneapi_get_state(), experimental::queue_state::executing);
+
+  Graph.begin_recording(Queue);
+  EXPECT_EQ(Queue.ext_oneapi_get_state(), experimental::queue_state::recording);
+
+  Graph.end_recording(Queue);
+  EXPECT_EQ(Queue.ext_oneapi_get_state(), experimental::queue_state::executing);
+
+  EXPECT_GE(traceCount("urQueueIsGraphCaptureEnabledExp"), 3u);
+}

--- a/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.cpp
@@ -1,0 +1,248 @@
+//==--------------------- NativeRecordingMock.cpp---------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "NativeRecordingMock.hpp"
+
+#include <algorithm>
+
+namespace NativeRecordingMock {
+
+GraphState &MockState::graph(ur_exp_graph_handle_t Handle) {
+  auto It = Graphs.find(Handle);
+  assert(It != Graphs.end() && "Not a live mock graph handle");
+  return It->second;
+}
+
+MockState &state() {
+  static MockState State;
+  return State;
+}
+
+size_t traceCount(std::string_view EntryPoint) {
+  const std::vector<TraceEntry> &Trace = state().Trace;
+  return std::count_if(
+      Trace.begin(), Trace.end(),
+      [&](const TraceEntry &Entry) { return Entry.EntryPoint == EntryPoint; });
+}
+
+size_t traceCount(std::string_view EntryPoint, const void *Handle) {
+  const std::vector<TraceEntry> &Trace = state().Trace;
+  return std::count_if(
+      Trace.begin(), Trace.end(), [&](const TraceEntry &Entry) {
+        return Entry.EntryPoint == EntryPoint && Entry.Handle == Handle;
+      });
+}
+
+size_t traceIndex(std::string_view EntryPoint) {
+  const std::vector<TraceEntry> &Trace = state().Trace;
+  auto It =
+      std::find_if(Trace.begin(), Trace.end(), [&](const TraceEntry &Entry) {
+        return Entry.EntryPoint == EntryPoint;
+      });
+  if (It == Trace.end()) {
+    ADD_FAILURE() << EntryPoint << " was never called";
+    return std::string::npos;
+  }
+  return It - Trace.begin();
+}
+
+namespace {
+
+void trace(std::string EntryPoint, const void *Handle = nullptr) {
+  state().Trace.push_back({std::move(EntryPoint), Handle});
+}
+
+// Adds native recording support
+ur_result_t mock_urDeviceGetInfoAfter(void *pParams) {
+  auto Params = *static_cast<ur_device_get_info_params_t *>(pParams);
+  if (*Params.ppropName == UR_DEVICE_INFO_GRAPH_RECORD_AND_REPLAY_SUPPORT_EXP) {
+    if (*Params.ppPropValue)
+      *static_cast<ur_bool_t *>(*Params.ppPropValue) =
+          state().SupportsNativeRecording;
+    if (*Params.ppPropSizeRet)
+      **Params.ppPropSizeRet = sizeof(ur_bool_t);
+  }
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urGraphCreateExp(void *pParams) {
+  auto Params = *static_cast<ur_graph_create_exp_params_t *>(pParams);
+  MockState &State = state();
+  auto Handle = mock::createDummyHandle<ur_exp_graph_handle_t>();
+  State.Graphs[Handle] = GraphState{State.NextGraphId++};
+  trace("urGraphCreateExp", Handle);
+  **Params.pphGraph = Handle;
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urGraphDestroyExp(void *pParams) {
+  auto Params = *static_cast<ur_graph_destroy_exp_params_t *>(pParams);
+  MockState &State = state();
+  ur_exp_graph_handle_t Handle = *Params.phGraph;
+  trace("urGraphDestroyExp", Handle);
+  const GraphState Destroyed = State.graph(Handle);
+  State.Graphs.erase(Handle);
+  mock::releaseDummyHandle(Handle);
+  for (size_t i = 0; i < Destroyed.DestructionCallbacks.size(); ++i) {
+    Destroyed.DestructionCallbacks[i](Destroyed.DestructionCallbacksData[i]);
+  }
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urGraphSetDestructionCallbackExp(void *pParams) {
+  auto Params =
+      *static_cast<ur_graph_set_destruction_callback_exp_params_t *>(pParams);
+  trace("urGraphSetDestructionCallbackExp", *Params.phGraph);
+  GraphState &Graph = state().graph(*Params.phGraph);
+  Graph.DestructionCallbacks.push_back(*Params.ppfnCallback);
+  Graph.DestructionCallbacksData.push_back(*Params.ppUserData);
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urGraphInstantiateGraphExp(void *pParams) {
+  auto Params =
+      *static_cast<ur_graph_instantiate_graph_exp_params_t *>(pParams);
+  trace("urGraphInstantiateGraphExp", *Params.phGraph);
+  **Params.pphExecGraph =
+      mock::createDummyHandle<ur_exp_executable_graph_handle_t>();
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urGraphExecutableGraphDestroyExp(void *pParams) {
+  auto Params =
+      *static_cast<ur_graph_executable_graph_destroy_exp_params_t *>(pParams);
+  trace("urGraphExecutableGraphDestroyExp", *Params.phExecutableGraph);
+  mock::releaseDummyHandle(*Params.phExecutableGraph);
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urGraphIsEmptyExp(void *pParams) {
+  auto Params = *static_cast<ur_graph_is_empty_exp_params_t *>(pParams);
+  trace("urGraphIsEmptyExp", *Params.phGraph);
+  **Params.ppResult = state().graph(*Params.phGraph).IsEmpty;
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urGraphGetIdExp(void *pParams) {
+  auto Params = *static_cast<ur_graph_get_id_exp_params_t *>(pParams);
+  trace("urGraphGetIdExp", *Params.phGraph);
+  **Params.ppGraphId = state().graph(*Params.phGraph).Id;
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urQueueBeginCaptureIntoGraphExp(void *pParams) {
+  auto Params =
+      *static_cast<ur_queue_begin_capture_into_graph_exp_params_t *>(pParams);
+  trace("urQueueBeginCaptureIntoGraphExp", *Params.phQueue);
+  if (!state()
+           .PrimaryCapturing.try_emplace(*Params.phQueue, *Params.phGraph)
+           .second)
+    return UR_RESULT_ERROR_INVALID_ARGUMENT;
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urQueueEndGraphCaptureExp(void *pParams) {
+  auto Params =
+      *static_cast<ur_queue_end_graph_capture_exp_params_t *>(pParams);
+  MockState &State = state();
+  trace("urQueueEndGraphCaptureExp", *Params.phQueue);
+  auto It = State.PrimaryCapturing.find(*Params.phQueue);
+  if (It == State.PrimaryCapturing.end())
+    return UR_RESULT_ERROR_COMMAND_LIST_NOT_CAPTURING;
+  **Params.pphGraph = It->second;
+  State.PrimaryCapturing.erase(It);
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urQueueIsGraphCaptureEnabledExp(void *pParams) {
+  auto Params =
+      *static_cast<ur_queue_is_graph_capture_enabled_exp_params_t *>(pParams);
+  trace("urQueueIsGraphCaptureEnabledExp", *Params.phQueue);
+  **Params.ppResult = state().PrimaryCapturing.count(*Params.phQueue) != 0;
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t mock_urQueueGetGraphExp(void *pParams) {
+  auto Params = *static_cast<ur_queue_get_graph_exp_params_t *>(pParams);
+  trace("urQueueGetGraphExp", *Params.phQueue);
+  auto It = state().PrimaryCapturing.find(*Params.phQueue);
+  if (It == state().PrimaryCapturing.end())
+    return UR_RESULT_ERROR_COMMAND_LIST_NOT_CAPTURING;
+  **Params.pphGraph = It->second;
+  return UR_RESULT_SUCCESS;
+}
+
+// A before-callback so the generated mock still produces the output event.
+ur_result_t mock_urEnqueueGraphExpBefore(void *pParams) {
+  auto Params = *static_cast<ur_enqueue_graph_exp_params_t *>(pParams);
+  trace("urEnqueueGraphExp", *Params.phGraph);
+  return UR_RESULT_SUCCESS;
+}
+
+} // namespace
+
+// Extends entry point with UR tracing in the singleton
+#define TRACE_UR_ENTRY_POINT(EntryPoint)                                       \
+  mock::getCallbacks().set_before_callback(#EntryPoint,                        \
+                                           [](void *) -> ur_result_t {         \
+                                             trace(#EntryPoint);               \
+                                             return UR_RESULT_SUCCESS;         \
+                                           })
+
+void registerDefaultCallbacks() {
+  state() = MockState{};
+
+  mock::getCallbacks().set_after_callback("urDeviceGetInfo",
+                                          &mock_urDeviceGetInfoAfter);
+#define REPLACE_UR_ENTRY_POINT(EntryPoint)                                     \
+  mock::getCallbacks().set_replace_callback(#EntryPoint, &mock_##EntryPoint)
+  REPLACE_UR_ENTRY_POINT(urGraphCreateExp);
+  REPLACE_UR_ENTRY_POINT(urGraphDestroyExp);
+  REPLACE_UR_ENTRY_POINT(urGraphSetDestructionCallbackExp);
+  REPLACE_UR_ENTRY_POINT(urGraphInstantiateGraphExp);
+  REPLACE_UR_ENTRY_POINT(urGraphExecutableGraphDestroyExp);
+  REPLACE_UR_ENTRY_POINT(urGraphIsEmptyExp);
+  REPLACE_UR_ENTRY_POINT(urGraphGetIdExp);
+  REPLACE_UR_ENTRY_POINT(urQueueBeginCaptureIntoGraphExp);
+  REPLACE_UR_ENTRY_POINT(urQueueEndGraphCaptureExp);
+  REPLACE_UR_ENTRY_POINT(urQueueIsGraphCaptureEnabledExp);
+  REPLACE_UR_ENTRY_POINT(urQueueGetGraphExp);
+#undef REPLACE_UR_ENTRY_POINT
+
+  mock::getCallbacks().set_before_callback("urEnqueueGraphExp",
+                                           &mock_urEnqueueGraphExpBefore);
+
+  TRACE_UR_ENTRY_POINT(urEnqueueKernelLaunchWithArgsExp);
+  TRACE_UR_ENTRY_POINT(urCommandBufferCreateExp);
+}
+#undef TRACE_UR_ENTRY_POINT
+
+} // namespace NativeRecordingMock
+
+NativeRecordingTest::NativeRecordingTest()
+    : Plat{sycl::platform()}, Dev{Plat.get_devices()[0]},
+      Queue{Dev, {sycl::property::queue::in_order{}}} {
+  NativeRecordingMock::registerDefaultCallbacks();
+}
+
+NativeRecordingTest::ModifiableGraph NativeRecordingTest::makeGraph() {
+  return ModifiableGraph{
+      Queue.get_context(),
+      Dev,
+      {experimental::property::graph::enable_native_recording{}}};
+}
+
+ur_exp_graph_handle_t
+NativeRecordingTest::nativeHandle(const ModifiableGraph &Graph) {
+  return getSyclObjImpl(Graph)->getNativeGraphHandle();
+}
+
+ur_exp_executable_graph_handle_t
+NativeRecordingTest::nativeHandle(const ExecutableGraph &ExecGraph) {
+  return getSyclObjImpl(ExecGraph)->getNativeExecutableGraphHandle();
+}

--- a/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.cpp
@@ -57,7 +57,7 @@ void trace(std::string EntryPoint, const void *Handle = nullptr) {
   state().Trace.push_back({std::move(EntryPoint), Handle});
 }
 
-// Adds native recording support
+// This is called after urDeviceGetInfo() to inject native recording support
 ur_result_t mock_urDeviceGetInfoAfter(void *pParams) {
   auto Params = *static_cast<ur_device_get_info_params_t *>(pParams);
   if (*Params.ppropName == UR_DEVICE_INFO_GRAPH_RECORD_AND_REPLAY_SUPPORT_EXP) {
@@ -177,7 +177,7 @@ ur_result_t mock_urQueueGetGraphExp(void *pParams) {
   return UR_RESULT_SUCCESS;
 }
 
-// A before-callback so the generated mock still produces the output event.
+// Use the default urEnqueueGraphExp() mock but trace before
 ur_result_t mock_urEnqueueGraphExpBefore(void *pParams) {
   auto Params = *static_cast<ur_enqueue_graph_exp_params_t *>(pParams);
   trace("urEnqueueGraphExp", *Params.phGraph);

--- a/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.hpp
+++ b/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.hpp
@@ -30,8 +30,8 @@ struct TraceEntry {
 struct GraphState {
   uint64_t Id = 0;
   bool IsEmpty = true;
-  std::vector<ur_exp_graph_destruction_callback_t> DestructionCallbacks;
-  std::vector<void *> DestructionCallbacksData;
+  std::vector<ur_exp_graph_destruction_callback_t> DestructionCallbacks = {};
+  std::vector<void *> DestructionCallbacksData = {};
 };
 
 inline constexpr uint64_t FirstGraphId = 1;

--- a/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.hpp
+++ b/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.hpp
@@ -1,0 +1,93 @@
+//==--------------------- NativeRecordingMock.hpp---------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Mock UR native graph support and test fixture for the SYCL native-recording
+// path.
+
+#pragma once
+
+#include "Common.hpp"
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace NativeRecordingMock {
+
+// UR function name and associated object handle for tracing UR calls.
+struct TraceEntry {
+  std::string EntryPoint;
+  const void *Handle;
+};
+
+// Unique per-graph state
+struct GraphState {
+  uint64_t Id = 0;
+  bool IsEmpty = true;
+  std::vector<ur_exp_graph_destruction_callback_t> DestructionCallbacks;
+  std::vector<void *> DestructionCallbacksData;
+};
+
+inline constexpr uint64_t FirstGraphId = 1;
+
+// Singleton state the mock callbacks share.
+struct MockState {
+  bool SupportsNativeRecording = true;
+
+  std::vector<TraceEntry> Trace;
+  std::unordered_map<ur_exp_graph_handle_t, GraphState> Graphs;
+  std::unordered_map<ur_queue_handle_t, ur_exp_graph_handle_t> PrimaryCapturing;
+  uint64_t NextGraphId = FirstGraphId;
+
+  GraphState &graph(ur_exp_graph_handle_t Handle);
+};
+
+MockState &state();
+
+size_t traceCount(std::string_view EntryPoint);
+
+// Calls to EntryPoint that were about Handle, for tests with more than one
+// graph or queue in flight.
+size_t traceCount(std::string_view EntryPoint, const void *Handle);
+
+// Position of the first call to EntryPoint, so that comparing two positions
+// orders two calls. Fails the test and returns npos if it was never called.
+size_t traceIndex(std::string_view EntryPoint);
+
+// Resets the mock state and registers the callbacks. Must run after the UrMock
+// constructor. The default callbacks are meant to
+// simulate "success" states. To test error handling, the user should override
+// these defaults as needed.
+void registerDefaultCallbacks();
+
+} // namespace NativeRecordingMock
+
+// Fixture for the native-recording path
+class NativeRecordingTest : public ::testing::Test {
+public:
+  NativeRecordingTest();
+
+protected:
+  using ModifiableGraph =
+      experimental::command_graph<experimental::graph_state::modifiable>;
+  using ExecutableGraph =
+      experimental::command_graph<experimental::graph_state::executable>;
+
+  ModifiableGraph makeGraph();
+
+  static ur_exp_graph_handle_t nativeHandle(const ModifiableGraph &Graph);
+
+  static ur_exp_executable_graph_handle_t
+  nativeHandle(const ExecutableGraph &ExecGraph);
+
+  unittest::UrMock<> Mock;
+  sycl::platform Plat;
+  sycl::device Dev;
+  sycl::queue Queue;
+};


### PR DESCRIPTION
Adds UR graph fixture for unit testing native recording. Basic tests are added to validate the native recording trace. The UR function overrides simulate successful graph scenarios tracked in a singleton state.