### PR TITLE
[LLVM] Don't memcpy from a null pointer for empty byte-array properties

### DIFF
--- a/llvm/lib/Support/PropertySetIO.cpp
+++ b/llvm/lib/Support/PropertySetIO.cpp
@@ -167,8 +167,10 @@ PropertyValue::PropertyValue(const byte *Data, SizeTy DataBitSize) {
     Val.ByteArrayVal[I] = (byte)DataBitSize;
     DataBitSize >>= ByteSizeInBits;
   }
-  // Append data.
-  std::memcpy(Val.ByteArrayVal + SizeFieldSize, Data, DataSize);
+  // Append data. Data may be null when DataSize is zero, and memcpy declares
+  // its source as nonnull, so guard the call.
+  if (DataSize > 0)
+    std::memcpy(Val.ByteArrayVal + SizeFieldSize, Data, DataSize);
 }
 
 PropertyValue::PropertyValue(const PropertyValue &P) { *this = P; }

--- a/llvm/unittests/Support/PropertySetIOTest.cpp
+++ b/llvm/unittests/Support/PropertySetIOTest.cpp
@@ -69,4 +69,12 @@ TEST(PropertySet, ByteArrayValuesIO) {
   // Check that the original and the serialized version are equal
   ASSERT_EQ(Serialized, Content);
 }
+
+TEST(PropertySet, EmptyByteArrayValue) {
+  // An empty container has a null data pointer, which must not be passed to
+  // memcpy.
+  PropertyValue Prop{std::vector<char>{}};
+  ASSERT_EQ(Prop.getType(), PropertyValue::BYTE_ARRAY);
+  ASSERT_EQ(Prop.getByteArraySize(), 0u);
+}
 } // namespace


### PR DESCRIPTION
## Problem

`PropertyValue::PropertyValue(const byte *Data, SizeTy DataBitSize)` in `llvm/lib/Support/PropertySetIO.cpp` ends with:

```cpp
// Append data.
std::memcpy(Val.ByteArrayVal + SizeFieldSize, Data, DataSize);
```

`Data` is null whenever the property value is an empty container: the templated constructor in `llvm/include/llvm/Support/PropertySetIO.h` forwards `Data.data()`, and for an empty `std::vector<char>`/`SmallVector` that is `nullptr`. `memcpy`'s parameters are declared `__attribute__((nonnull))`, so `memcpy(dst, nullptr, 0)` is undefined behaviour even though the length is zero (https://en.cppreference.com/cpp/string/byte/memcpy)

UBSan diagnostic (build configured with `-DLLVM_USE_SANITIZER=Address;Undefined`):

```
llvm/lib/Support/PropertySetIO.cpp:171:49: runtime error: null pointer passed as
argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
```

## Fix

Skip the copy when there is nothing to copy:

```cpp
// Append data. Data may be null when DataSize is zero, and memcpy declares
// its source as nonnull, so guard the call.
if (DataSize > 0)
  std::memcpy(Val.ByteArrayVal + SizeFieldSize, Data, DataSize);
```

----

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
