### PR TITLE
[SYCL][ESIMD] Fix leak of the demangler output buffer

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -41,6 +41,7 @@
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 
 #include <cctype>
+#include <cstdlib>
 #include <cstring>
 #include <unordered_map>
 
@@ -1981,12 +1982,16 @@ bool SYCLLowerESIMDPass::prepareForAlwaysInliner(Module &M) {
     if (NameNode->getKind() == id::Node::KLocalName)
       return false;
 
+    // OutputBuffer does not own its buffer - it must be freed by the caller.
     id::OutputBuffer NameBuf;
     NameNode->print(NameBuf);
     StringRef Name(NameBuf.getBuffer(), NameBuf.getCurrentPosition());
 
-    return Name.starts_with("sycl::_V1::ext::intel::esimd::") ||
-           Name.starts_with("sycl::_V1::ext::intel::experimental::esimd::");
+    bool IsESIMDFunction =
+        Name.starts_with("sycl::_V1::ext::intel::esimd::") ||
+        Name.starts_with("sycl::_V1::ext::intel::experimental::esimd::");
+    std::free(NameBuf.getBuffer());
+    return IsESIMDFunction;
   };
   bool NeedInline = false;
   for (auto &F : M) {


### PR DESCRIPTION
## Problem

`SYCLLowerESIMDPass::prepareForAlwaysInliner()` demangles each function name to decide whether it belongs to the ESIMD namespaces:

```cpp
id::OutputBuffer NameBuf;
NameNode->print(NameBuf);
StringRef Name(NameBuf.getBuffer(), NameBuf.getCurrentPosition());

return Name.starts_with("sycl::_V1::ext::intel::esimd::") ||
       Name.starts_with("sycl::_V1::ext::intel::experimental::esimd::");
```

`llvm::itanium_demangle::OutputBuffer` grows its storage with `realloc` and has a defaulted destructor — **it does not own that storage**, and the caller is required to `std::free(getBuffer())`. This lambda is invoked once per function in the module and leaks the buffer every time.

LeakSanitizer report (ASan+UBSan build, leak reached through `clang++ -fsycl` on an ESIMD test):

```
Direct leak of 998 byte(s) in 1 object(s) allocated from:
    #0 ... in realloc
    #1 ... in llvm::itanium_demangle::OutputBuffer::grow(unsigned long)
    #2 ... in SYCLLowerESIMDPass::prepareForAlwaysInliner(llvm::Module&)
    llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp:1985
```

Observed 998 B to ~14 KB per compilation depending on how many ESIMD functions the module contains.

-----

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
