### PR TITLE
[Clang] Fix out-of-bounds read when filtering dependency-file entries

### DIFF
--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -287,7 +287,7 @@ bool DependencyFileGenerator::sawDependency(StringRef Filename, bool FromModule,
 
   // Remove dependencies that are prefixed by the Filter string.
   for (const std::string &FD : DependencyFilter)
-    if (FD.compare(0, FD.size(), Filename.data(), FD.size()) == 0)
+    if (Filename.starts_with(FD))
       return false;
 
   if (IncludeSystemHeaders)


### PR DESCRIPTION
`DependencyFileGenerator::sawDependency()` filters out dependencies whose name starts with a filter string:

```cpp
// Remove dependencies that are prefixed by the Filter string.
for (const std::string &FD : DependencyFilter)
  if (FD.compare(0, FD.size(), Filename.data(), FD.size()) == 0)
    return false;
```

`Filename` is a `StringRef`, and `std::string::compare(pos, len, const char *s, size_t n)` reads `n` bytes from `s` unconditionally. When the filename is shorter than the filter, this reads past the end of the referenced buffer. `StringRef` is not guaranteed to be NULL-terminated, and here it points into memory owned by a `BumpPtrAllocator`, so the read runs into the allocator's redzone.

AddressSanitizer report, hit while compiling `sycl/test/include_deps/header_reach.cpp` with `-fsycl`:

```
ERROR: AddressSanitizer: use-after-poison on address ...
READ of size 42 at ... thread T0
    #0 ... in clang::DependencyFileGenerator::sawDependency(llvm::StringRef, bool, bool, bool, bool)
       clang/lib/Frontend/DependencyFile.cpp:290
```
---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
