### PR TITLE
[SYCL][UB] Make `Command::isHostTask()` virtual instead of downcasting on `MType`

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -241,12 +241,6 @@ std::vector<ur_event_handle_t> Command::getUrEvents(events_range Events) const {
   return getUrEvents(Events, MWorkerQueue.get(), isHostTask());
 }
 
-bool Command::isHostTask() const {
-  return (MType == CommandType::RUN_CG) /* host task has this type also */ &&
-         ((static_cast<const ExecCGCommand *>(this))->getCG().getType() ==
-          CGType::CodeplayHostTask);
-}
-
 namespace {
 
 struct EnqueueNativeCommandData {

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -251,7 +251,10 @@ public:
                                                     queue_impl *CommandQueue,
                                                     bool IsHostTaskCommand);
 
-  bool isHostTask() const;
+  /// Returns true iff this command represents a host task. Only ExecCGCommand
+  /// can, so the base implementation always returns false: the command type
+  /// alone does not imply the dynamic type of the command.
+  virtual bool isHostTask() const { return false; }
 
 protected:
   std::shared_ptr<queue_impl> MQueue;
@@ -648,6 +651,10 @@ public:
   std::string_view getTypeString() const;
 
   detail::CG &getCG() const { return *MCommandGroup; }
+
+  bool isHostTask() const final {
+    return getCG().getType() == CGType::CodeplayHostTask;
+  }
 
   // MEmptyCmd is only employed if this command refers to host-task.
   // The mechanism of lookup for single EmptyCommand amongst users of


### PR DESCRIPTION
## Problem

`Command::isHostTask()` deduced the dynamic type of the command from its type tag and then downcast unconditionally:

```cpp
bool Command::isHostTask() const {
  return (MType == CommandType::RUN_CG) /* host task has this type also */ &&
         ((static_cast<const ExecCGCommand *>(this))->getCG().getType() ==
          CGType::CodeplayHostTask);
}
```

`static_cast` to a derived type is undefined behaviour unless the object really is of that type; nothing in the type system enforces `RUN_CG => ExecCGCommand`, only convention. When the object is a plain `Command` subobject, `getCG()` reads `MCommandGroup` from beyond the end of the allocation.

AddressSanitizer report (ASan+UBSan build, `SchedulerTest.DontEnqueueDepsIfOneOfThemIsBlocked`):

```
ERROR: AddressSanitizer: global-buffer-overflow on address ...
READ of size 4 at ... thread T0
    #0 ... in getType sycl/source/detail/cg.hpp:104
    #1 ... in sycl::_V1::detail::Command::isHostTask() const
       sycl/source/detail/scheduler/commands.cpp:246
    #2 ... in isBlocking sycl/source/detail/scheduler/commands.hpp:178
    #3 ... in Scheduler::GraphProcessor::handleBlockingCmd(...)
```

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
