### PR TITLE
[SYCL] Keep fast kernel cache entries when the kernel name is already registered

### DIFF
--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -484,9 +484,19 @@ public:
     // if no insertion took place, then some other thread has already inserted
     // smth in the cache
     traceKernel("Kernel inserted.", KernelName, true);
-    MFastKernelCache.try_emplace(
-        std::string(KernelName),
-        FastKernelSubcacheWrapper(KernelSubcache, getURContext()));
+    // Only construct the wrapper when it is going to be stored. A temporary
+    // wrapper that try_emplace does not insert (the kernel name is already
+    // registered, which is the case for every cache miss after the first one)
+    // is destroyed intact, and its destructor erases every entry of this
+    // context from the subcache. With more than one device in the context the
+    // next launch of the kernel on another device then misses again, and every
+    // launch alternating between devices re-enters saveKernel and appends to
+    // MProgramToFastKernelCacheKeyMap without bound.
+    if (MFastKernelCache.find(std::string(KernelName)) ==
+        MFastKernelCache.end())
+      MFastKernelCache.emplace(
+          std::string(KernelName),
+          FastKernelSubcacheWrapper(KernelSubcache, getURContext()));
 
     FastKernelSubcacheWriteLockT SubcacheLock{KernelSubcache.Mutex};
     ur_context_handle_t Context = getURContext();

--- a/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
+++ b/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
@@ -6,8 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 #include "detail/context_impl.hpp"
+#include "detail/device_impl.hpp"
 #include "detail/kernel_bundle_impl.hpp"
 #include "detail/kernel_program_cache.hpp"
+#include "detail/program_manager/program_manager.hpp"
 #include <helpers/MockDeviceImage.hpp>
 #include <helpers/MockKernelInfo.hpp>
 #include <helpers/UrMock.hpp>
@@ -195,3 +197,60 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Values(std::array<size_t, NumDevices>{0, 1, 2},
                     std::array<size_t, NumDevices>{1, 0, 2},
                     std::array<size_t, NumDevices>{2, 1, 0}));
+
+class MultipleDeviceFastCacheTest : public ::testing::Test {
+public:
+  MultipleDeviceFastCacheTest() : Mock{}, Plt{sycl::platform()} {}
+
+protected:
+  void SetUp() override {
+    mock::getCallbacks().set_after_callback("urDeviceGet",
+                                            &redefinedDeviceGetAfter);
+    mock::getCallbacks().set_before_callback("urDeviceGetInfo",
+                                             &redefinedDeviceGetInfo);
+  }
+
+protected:
+  unittest::UrMock<> Mock;
+  platform Plt;
+};
+
+// Launching the same kernel on several devices of one context must leave one
+// fast kernel cache entry per device, so that every later launch hits the fast
+// cache. saveKernel used to build a FastKernelSubcacheWrapper temporary for
+// try_emplace; when the kernel name was already registered the temporary was
+// not inserted and its destructor erased the entries of the context, so
+// launches alternating between two devices missed the fast cache every time
+// and appended to MProgramToFastKernelCacheKeyMap without bound.
+TEST_F(MultipleDeviceFastCacheTest, EntriesKeptForAllDevices) {
+  std::vector<sycl::device> Devices = Plt.get_devices(info::device_type::gpu);
+  ASSERT_EQ(Devices.size(), NumDevices);
+  sycl::context Context(Devices);
+  sycl::queue Queue0(Context, Devices[0]);
+  sycl::queue Queue1(Context, Devices[1]);
+
+  for (int I = 0; I < 3; ++I) {
+    Queue0.submit([&](sycl::handler &cgh) {
+      cgh.single_task<MultipleDevsCacheTestKernel>([]() {});
+    });
+    Queue1.submit([&](sycl::handler &cgh) {
+      cgh.single_task<MultipleDevsCacheTestKernel>([]() {});
+    });
+  }
+
+  detail::context_impl &CtxImpl = *detail::getSyclObjImpl(Context);
+  detail::KernelProgramCache &Cache = CtxImpl.getKernelProgramCache();
+  std::string_view KernelName =
+      detail::KernelInfo<MultipleDevsCacheTestKernel>::getName();
+  detail::FastKernelSubcacheT &Subcache = detail::ProgramManager::getInstance()
+                                              .getDeviceKernelInfo(KernelName)
+                                              .getKernelSubcache();
+
+  EXPECT_EQ(Subcache.Entries.size(), size_t{2})
+      << "Expect one fast cache entry per device that launched the kernel";
+  for (size_t I : {size_t{0}, size_t{1}}) {
+    ur_device_handle_t Dev = detail::getSyclObjImpl(Devices[I])->getHandleRef();
+    EXPECT_TRUE(Cache.tryToGetKernelFast(KernelName, Dev, Subcache) != nullptr)
+        << "Expect a fast cache hit for device " << I;
+  }
+}


### PR DESCRIPTION
`KernelProgramCache::saveKernel` registers the kernel name in `MFastKernelCache` with

```cpp
MFastKernelCache.try_emplace(std::string(KernelName), FastKernelSubcacheWrapper(KernelSubcache, getURContext()));
```

The wrapper temporary is built before the call and destroyed after it, whether it was inserted or not. When the name is already registered (every fast cache miss after the first one for that kernel) the temporary is destroyed intact, and `~FastKernelSubcacheWrapper` erases every entry of the current context from the kernel's subcache.

With a single device this goes unnoticed, the entry that was just erased is added right back. With two or more devices in one context it makes the fast cache useless: a launch on device B erases the entry for device A, the next launch on A misses, erases B, and so on. Every one of those misses goes through the slow path and appends a `(std::string kernel name, device)` pair to `MProgramToFastKernelCacheKeyMap`, which is never trimmed while in-memory cache eviction is off (the default). On a llama.cpp server running Qwen3.8-27B tensor-split across two Intel Arc Pro B70s (oneAPI 2026.1, one context, about a thousand launches per decode step) this leaked around 3 MB/s while generating tokens and got the process OOM killed roughly every 2.5 hours.

The fix constructs the wrapper only when it is going to be stored; the lookup and the insert happen under `MFastKernelCacheMutex`, which `saveKernel` already holds. A unit test launches the same kernel alternately on two mock devices of one context and checks that the subcache keeps one entry per device and that `tryToGetKernelFast` hits for both.

How it was validated: on the shipped 2026.1.0 `libsycl.so.9` first, by patching the equivalent branch in the compiled `saveKernel` (the `je` that skips the inlined destructor when the wrapper was moved-from, turned into a `jmp`). `saveKernel` calls during a 200 token generation went from about 4000 (breakpoint count under gdb, one per launch) to 0, RSS growth per 600 token generation went from +90..+280 MiB to within +-10 MiB, and single stream decode went from about 26 to about 31 tokens/s because the launches now hit the fast cache.

Then with this branch built from source (Release, GCC 13, `buildbot/configure.py --disable-jit --disable-preview-lib`), running `KernelAndProgramTests-Non_Preview_Tests --gtest_filter='MultipleDevice*'`:

- with the fix: 4 tests pass, including the new `MultipleDeviceFastCacheTest.EntriesKeptForAllDevices`.
- with `kernel_program_cache.hpp` from the parent commit swapped back in: the new test fails with `Subcache.Entries.size()` being 1 instead of 2 (only the last device launched is left) and `tryToGetKernelFast` missing for device 0, which is the thrash described above. The three existing `ProgramRetain` cases still pass.
- with the fix restored: 4 tests pass again.
