### PR TITLE
[CI] Authenticate github.com git with the workflow token

### DIFF
--- a/.github/workflows/sycl-clang-tidy.yml
+++ b/.github/workflows/sycl-clang-tidy.yml
@@ -17,6 +17,27 @@ concurrency:
 
 permissions: read-all
 
+# Anonymous git-over-HTTPS to github.com is answered with HTTP 401 on some of our
+# runners ("could not read Username for 'https://github.com'"), which breaks the
+# repo cache update in devops/actions/cached_checkout as well as the clones
+# CMake's FetchContent performs (vc-intrinsics, level-zero, ...). Hand git the
+# workflow token for github.com, for every step of every job of this workflow.
+#
+# A credential helper is used on purpose, rather than the two more obvious
+# alternatives:
+#  * git only consults a helper once it has been answered with a 401, so steps
+#    that authenticate themselves (actions/checkout sets an
+#    `http.<url>.extraheader`) keep sending exactly one `Authorization` header.
+#    Configuring an extraheader here instead makes those steps send two, which
+#    github.com rejects with `Duplicate header: "Authorization"` / HTTP 400.
+#  * a `url.<base>.insteadOf` rewrite would be applied by `git remote get-url`,
+#    and llvm/cmake/modules/VersionFromVCS.cmake rejects a remote URL that
+#    carries a credential.
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: credential.https://github.com.helper
+  GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo "password=${{ github.token }}"; }; f'
+
 jobs:
   run-clang-tidy:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'disable-lint') }}

--- a/.github/workflows/sycl-coverity.yml
+++ b/.github/workflows/sycl-coverity.yml
@@ -18,6 +18,27 @@ on:
 
 permissions: read-all
 
+# Anonymous git-over-HTTPS to github.com is answered with HTTP 401 on some of our
+# runners ("could not read Username for 'https://github.com'"), which breaks the
+# repo cache update in devops/actions/cached_checkout as well as the clones
+# CMake's FetchContent performs (vc-intrinsics, level-zero, ...). Hand git the
+# workflow token for github.com, for every step of every job of this workflow.
+#
+# A credential helper is used on purpose, rather than the two more obvious
+# alternatives:
+#  * git only consults a helper once it has been answered with a 401, so steps
+#    that authenticate themselves (actions/checkout sets an
+#    `http.<url>.extraheader`) keep sending exactly one `Authorization` header.
+#    Configuring an extraheader here instead makes those steps send two, which
+#    github.com rejects with `Duplicate header: "Authorization"` / HTTP 400.
+#  * a `url.<base>.insteadOf` rewrite would be applied by `git remote get-url`,
+#    and llvm/cmake/modules/VersionFromVCS.cmake rejects a remote URL that
+#    carries a credential.
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: credential.https://github.com.helper
+  GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo "password=${{ github.token }}"; }; f'
+
 jobs:
   coverity:
     if: github.repository == 'intel/llvm'

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -138,6 +138,27 @@ on:
 
 permissions: read-all
 
+# Anonymous git-over-HTTPS to github.com is answered with HTTP 401 on some of our
+# runners ("could not read Username for 'https://github.com'"), which breaks the
+# repo cache update in devops/actions/cached_checkout as well as the clones
+# CMake's FetchContent performs (vc-intrinsics, level-zero, ...). Hand git the
+# workflow token for github.com, for every step of every job of this workflow.
+#
+# A credential helper is used on purpose, rather than the two more obvious
+# alternatives:
+#  * git only consults a helper once it has been answered with a 401, so steps
+#    that authenticate themselves (actions/checkout sets an
+#    `http.<url>.extraheader`) keep sending exactly one `Authorization` header.
+#    Configuring an extraheader here instead makes those steps send two, which
+#    github.com rejects with `Duplicate header: "Authorization"` / HTTP 400.
+#  * a `url.<base>.insteadOf` rewrite would be applied by `git remote get-url`,
+#    and llvm/cmake/modules/VersionFromVCS.cmake rejects a remote URL that
+#    carries a credential.
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: credential.https://github.com.helper
+  GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo "password=${{ github.token }}"; }; f'
+
 jobs:
   build:
     name: Build + LIT

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -235,6 +235,27 @@ permissions:
   contents: read
   packages: read
 
+# Anonymous git-over-HTTPS to github.com is answered with HTTP 401 on some of our
+# runners ("could not read Username for 'https://github.com'"), which breaks the
+# repo cache update in devops/actions/cached_checkout as well as the clones
+# CMake's FetchContent performs (vc-intrinsics, level-zero, ...). Hand git the
+# workflow token for github.com, for every step of every job of this workflow.
+#
+# A credential helper is used on purpose, rather than the two more obvious
+# alternatives:
+#  * git only consults a helper once it has been answered with a 401, so steps
+#    that authenticate themselves (actions/checkout sets an
+#    `http.<url>.extraheader`) keep sending exactly one `Authorization` header.
+#    Configuring an extraheader here instead makes those steps send two, which
+#    github.com rejects with `Duplicate header: "Authorization"` / HTTP 400.
+#  * a `url.<base>.insteadOf` rewrite would be applied by `git remote get-url`,
+#    and llvm/cmake/modules/VersionFromVCS.cmake rejects a remote URL that
+#    carries a credential.
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: credential.https://github.com.helper
+  GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo "password=${{ github.token }}"; }; f'
+
 jobs:
   run:
     if: github.event_name == 'workflow_dispatch' || inputs.skip_run == 'false'

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -98,6 +98,27 @@ on:
 
 permissions: read-all
 
+# Anonymous git-over-HTTPS to github.com is answered with HTTP 401 on some of our
+# runners ("could not read Username for 'https://github.com'"), which breaks the
+# repo cache update in devops/actions/cached_checkout as well as the clones
+# CMake's FetchContent performs (vc-intrinsics, level-zero, ...). Hand git the
+# workflow token for github.com, for every step of every job of this workflow.
+#
+# A credential helper is used on purpose, rather than the two more obvious
+# alternatives:
+#  * git only consults a helper once it has been answered with a 401, so steps
+#    that authenticate themselves (actions/checkout sets an
+#    `http.<url>.extraheader`) keep sending exactly one `Authorization` header.
+#    Configuring an extraheader here instead makes those steps send two, which
+#    github.com rejects with `Duplicate header: "Authorization"` / HTTP 400.
+#  * a `url.<base>.insteadOf` rewrite would be applied by `git remote get-url`,
+#    and llvm/cmake/modules/VersionFromVCS.cmake rejects a remote URL that
+#    carries a credential.
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: credential.https://github.com.helper
+  GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo "password=${{ github.token }}"; }; f'
+
 jobs:
   build:
     name: Build + LIT

--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -79,6 +79,27 @@ on:
 
 permissions: read-all
 
+# Anonymous git-over-HTTPS to github.com is answered with HTTP 401 on some of our
+# runners ("could not read Username for 'https://github.com'"), which breaks the
+# repo cache update in devops/actions/cached_checkout as well as the clones
+# CMake's FetchContent performs (vc-intrinsics, level-zero, ...). Hand git the
+# workflow token for github.com, for every step of every job of this workflow.
+#
+# A credential helper is used on purpose, rather than the two more obvious
+# alternatives:
+#  * git only consults a helper once it has been answered with a 401, so steps
+#    that authenticate themselves (actions/checkout sets an
+#    `http.<url>.extraheader`) keep sending exactly one `Authorization` header.
+#    Configuring an extraheader here instead makes those steps send two, which
+#    github.com rejects with `Duplicate header: "Authorization"` / HTTP 400.
+#  * a `url.<base>.insteadOf` rewrite would be applied by `git remote get-url`,
+#    and llvm/cmake/modules/VersionFromVCS.cmake rejects a remote URL that
+#    carries a credential.
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: credential.https://github.com.helper
+  GIT_CONFIG_VALUE_0: '!f() { echo username=x-access-token; echo "password=${{ github.token }}"; }; f'
+
 jobs:
   run:
     name: ${{ inputs.name }}

--- a/devops/actions/cached_checkout/action.yml
+++ b/devops/actions/cached_checkout/action.yml
@@ -25,6 +25,19 @@ inputs:
 runs:
   using: 'composite'
   steps:
+  # Anonymous git-over-HTTPS to github.com is answered with HTTP 401 on some of
+  # our runners ("could not read Username for 'https://github.com'"), which
+  # breaks both the cache update below and the clones CMake's FetchContent does
+  # later in the job (vc-intrinsics, level-zero, ...). Authenticate every
+  # github.com fetch of this job with the workflow token. Exported via
+  # GITHUB_ENV rather than `git config --global` so no credential is left behind
+  # on these persistent runners.
+  - name: Authenticate git for github.com
+    shell: bash
+    run: |
+      echo "GIT_CONFIG_COUNT=1" >> $GITHUB_ENV
+      echo "GIT_CONFIG_KEY_0=url.https://x-access-token:${{ github.token }}@github.com/.insteadOf" >> $GITHUB_ENV
+      echo "GIT_CONFIG_VALUE_0=https://github.com/" >> $GITHUB_ENV
   - name: Fetch cache
     shell: bash
     run: |
@@ -39,6 +52,9 @@ runs:
   - name: Checkout
     env:
       GIT_ALTERNATE_OBJECT_DIRECTORIES: ${{ inputs.cache_path }}/${{ inputs.repository }}/.git/objects
+      # actions/checkout brings its own credentials, don't stack a second
+      # Authorization header on top of them.
+      GIT_CONFIG_COUNT: 0
     uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     with:
       persist-credentials: false

--- a/devops/actions/cached_checkout/action.yml
+++ b/devops/actions/cached_checkout/action.yml
@@ -25,26 +25,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  # Anonymous git-over-HTTPS to github.com is answered with HTTP 401 on some of
-  # our runners ("could not read Username for 'https://github.com'"), which
-  # breaks both the cache update below and the clones CMake's FetchContent does
-  # later in the job (vc-intrinsics, level-zero, ...). Authenticate every
-  # github.com fetch of this job with the workflow token, the same way
-  # actions/checkout does. Exported via GITHUB_ENV rather than
-  # `git config --global` so that no credential is left behind on these
-  # persistent runners. Note that an `insteadOf` URL rewrite cannot be used
-  # here: `git remote get-url` applies it, and llvm/cmake/modules/
-  # VersionFromVCS.cmake rejects a remote URL carrying a credential.
-  - name: Authenticate git for github.com
-    shell: bash
-    env:
-      GH_TOKEN: ${{ github.token }}
-    run: |
-      CREDENTIAL=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
-      echo "::add-mask::$CREDENTIAL"
-      echo "GIT_CONFIG_COUNT=1" >> $GITHUB_ENV
-      echo "GIT_CONFIG_KEY_0=http.https://github.com/.extraheader" >> $GITHUB_ENV
-      echo "GIT_CONFIG_VALUE_0=Authorization: Basic $CREDENTIAL" >> $GITHUB_ENV
   - name: Fetch cache
     shell: bash
     run: |
@@ -59,9 +39,6 @@ runs:
   - name: Checkout
     env:
       GIT_ALTERNATE_OBJECT_DIRECTORIES: ${{ inputs.cache_path }}/${{ inputs.repository }}/.git/objects
-      # actions/checkout brings its own credentials, don't stack a second
-      # Authorization header on top of them.
-      GIT_CONFIG_COUNT: 0
     uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     with:
       persist-credentials: false

--- a/devops/actions/cached_checkout/action.yml
+++ b/devops/actions/cached_checkout/action.yml
@@ -29,15 +29,22 @@ runs:
   # our runners ("could not read Username for 'https://github.com'"), which
   # breaks both the cache update below and the clones CMake's FetchContent does
   # later in the job (vc-intrinsics, level-zero, ...). Authenticate every
-  # github.com fetch of this job with the workflow token. Exported via
-  # GITHUB_ENV rather than `git config --global` so no credential is left behind
-  # on these persistent runners.
+  # github.com fetch of this job with the workflow token, the same way
+  # actions/checkout does. Exported via GITHUB_ENV rather than
+  # `git config --global` so that no credential is left behind on these
+  # persistent runners. Note that an `insteadOf` URL rewrite cannot be used
+  # here: `git remote get-url` applies it, and llvm/cmake/modules/
+  # VersionFromVCS.cmake rejects a remote URL carrying a credential.
   - name: Authenticate git for github.com
     shell: bash
+    env:
+      GH_TOKEN: ${{ github.token }}
     run: |
+      CREDENTIAL=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
+      echo "::add-mask::$CREDENTIAL"
       echo "GIT_CONFIG_COUNT=1" >> $GITHUB_ENV
-      echo "GIT_CONFIG_KEY_0=url.https://x-access-token:${{ github.token }}@github.com/.insteadOf" >> $GITHUB_ENV
-      echo "GIT_CONFIG_VALUE_0=https://github.com/" >> $GITHUB_ENV
+      echo "GIT_CONFIG_KEY_0=http.https://github.com/.extraheader" >> $GITHUB_ENV
+      echo "GIT_CONFIG_VALUE_0=Authorization: Basic $CREDENTIAL" >> $GITHUB_ENV
   - name: Fetch cache
     shell: bash
     run: |


### PR DESCRIPTION
Anonymous git-over-HTTPS to `github.com` is answered with **HTTP 401** on some of our self-hosted runners, so any git operation that does not send credentials fails with:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
```

Two things break as a result:

1. the `Fetch cache` step of `devops/actions/cached_checkout` — [run 33638680442](https://github.com/intel/llvm/actions/runs/33638680442), runner `UR_MOM_12`;
2. and, once that is skipped (as attempted in #23089), the clones CMake's `FetchContent` performs during `Configure` — [run 33692096405](https://github.com/intel/llvm/actions/runs/33692096405), runner `UR_PRE_ESM_01`:

```
-- vc-intrinsics repo is missing. Will try to download ... from https://github.com/intel/vc-intrinsics.git
fatal: could not read Username for 'https://github.com': No such device or address
Had to git clone more than once: 3 times.
CMake Error ... Failed to clone repository: 'https://github.com/intel/vc-intrinsics.git'
Configure failed!
```

`actions/checkout` is unaffected on the very same runners because it authenticates itself. This PR hands git the workflow token for `github.com` at workflow level, so every step of every job is covered — the repo cache update, the `git fetch origin sycl` of the merge step, and every `FetchContent` clone.

### Why a credential helper, and not the two more obvious alternatives

Both were tried on this branch first, and both broke a *later* stage of the build:

* **`http.<url>.extraheader` exported via `GITHUB_ENV`** applies to every later step of the job, including the `actions/checkout` runs inside the E2E build steps, which set an extraheader of their own. Git then sends two headers and github.com returns HTTP 400 ([run 33694661627](https://github.com/intel/llvm/actions/runs/33694661627)):

  ```
  remote: Duplicate header: "Authorization"
  fatal: unable to access 'https://github.com/intel/llvm/': The requested URL returned error: 400
  ```

  This failed `Build E2E tests*`, which left the E2E binaries artifact empty and failed every downstream E2E job with `ninja: error: loading 'build.ninja': No such file or directory`.

* **a `url.<base>.insteadOf` rewrite** is applied by `git remote get-url`, so `llvm/cmake/modules/VersionFromVCS.cmake:48` rightly refused the remote URL and `VCSRevision.h` / `GenXVersion.inc` could not be generated ([run 33694150720](https://github.com/intel/llvm/actions/runs/33694150720)):

  ```
  CMake Error at llvm/cmake/modules/VersionFromVCS.cmake:48 (message):
    The git remote repository URL has an embedded password.
  ```

A credential helper avoids both: git only consults a helper *after* it has been answered with a 401, so it cannot add a second `Authorization` header to a request that is already authenticated, and it rewrites no URL.

Verified against a local HTTP server that counts the `Authorization` headers it receives:

| configuration | headers per request |
|---|---|
| extraheader in env + repo has its own extraheader (i.e. `actions/checkout`) | `[2]` → HTTP 400 |
| credential helper + repo has its own extraheader | `[1]` |
| credential helper, anonymous fetch, server 401s first | `[0, 1]` → authenticated on the retry |

Also confirmed with `zizmor` locally that this adds no new finding (the earlier revision's `GITHUB_ENV` write was flagged as `github-env`; a workflow-level `env:` is not).

This remains a workaround on our side — `github.com` answering anonymous git with 401 for these runners is an infra issue (shared egress IP throttling being the usual cause) and is worth chasing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
