### PR TITLE
[SYCL] Add macro to disable SYCL's device copyability checks

### DIFF
--- a/sycl/doc/PreprocessorMacros.md
+++ b/sycl/doc/PreprocessorMacros.md
@@ -29,6 +29,22 @@ This file describes macros that have effect on SYCL compiler and run-time.
   Disables all deprecation warnings in SYCL runtime headers, including SYCL
   1.2.1 deprecations.
 
+- **SYCL_DISABLE_DEVICE_COPYABLE_CHECKS**
+
+  Makes `sycl::is_device_copyable_v<T>` report `true` for every type, which
+  disables all diagnostics that the SYCL headers issue when a type does not
+  satisfy the device copyability requirements of the SYCL specification. This
+  covers the checks on the captures and base classes of a kernel functor, on the
+  element type of a `buffer`, and on the pattern type of `handler::fill` and
+  `handler::ext_oneapi_fill2d`.
+
+  This macro exists to ease the migration of large existing code bases whose
+  types are known to be safe to copy to a device but cannot practically be
+  declared device copyable. Defining it makes the program's behavior undefined
+  for every type that is not actually device copyable, and the user takes on the
+  responsibility of ensuring that the types they pass to a device may be copied
+  by the implementation.
+
 - **SYCL_DISABLE_IMAGE_ASPECT_WARNING**
 
   Disables warning diagnostic issued when calling `device::has(aspect::image)`

--- a/sycl/doc/PreprocessorMacros.md
+++ b/sycl/doc/PreprocessorMacros.md
@@ -31,19 +31,13 @@ This file describes macros that have effect on SYCL compiler and run-time.
 
 - **SYCL_DISABLE_DEVICE_COPYABLE_CHECKS**
 
-  Makes `sycl::is_device_copyable_v<T>` report `true` for every type, which
+  Makes `sycl::is_device_copyable_v<T>` report `true` for every type, and
   disables all diagnostics that the SYCL headers issue when a type does not
-  satisfy the device copyability requirements of the SYCL specification. This
-  covers the checks on the captures and base classes of a kernel functor, on the
-  element type of a `buffer`, and on the pattern type of `handler::fill` and
-  `handler::ext_oneapi_fill2d`.
-
-  This macro exists to ease the migration of large existing code bases whose
-  types are known to be safe to copy to a device but cannot practically be
-  declared device copyable. Defining it makes the program's behavior undefined
-  for every type that is not actually device copyable, and the user takes on the
-  responsibility of ensuring that the types they pass to a device may be copied
-  by the implementation.
+  satisfy the device copyability requirements of the SYCL specification. 
+  Defining it makes the program's behavior undefined for every type that is
+  not actually device copyable, and the user takes on the responsibility of
+  ensuring that the types they pass to a device may be copied by the
+  implementation.
 
 - **SYCL_DISABLE_IMAGE_ASPECT_WARNING**
 

--- a/sycl/doc/PreprocessorMacros.md
+++ b/sycl/doc/PreprocessorMacros.md
@@ -34,10 +34,9 @@ This file describes macros that have effect on SYCL compiler and run-time.
   Makes `sycl::is_device_copyable_v<T>` report `true` for every type, and
   disables all diagnostics that the SYCL headers issue when a type does not
   satisfy the device copyability requirements of the SYCL specification. 
-  Defining it makes the program's behavior undefined for every type that is
-  not actually device copyable, and the user takes on the responsibility of
-  ensuring that the types they pass to a device may be copied by the
-  implementation.
+  Passing an object whose type is not actually device copyable to a device
+  results in undefined behavior. The user takes responsibility for ensuring
+  that every type passed to a device can be copied by the implementation.
 
 - **SYCL_DISABLE_IMAGE_ASPECT_WARNING**
 

--- a/sycl/doc/PreprocessorMacros.md
+++ b/sycl/doc/PreprocessorMacros.md
@@ -31,12 +31,8 @@ This file describes macros that have effect on SYCL compiler and run-time.
 
 - **SYCL_DISABLE_DEVICE_COPYABLE_CHECKS**
 
-  Makes `sycl::is_device_copyable_v<T>` report `true` for every type, and
-  disables all diagnostics that the SYCL headers issue when a type does not
-  satisfy the device copyability requirements of the SYCL specification. 
-  Passing an object whose type is not actually device copyable to a device
-  results in undefined behavior. The user takes responsibility for ensuring
-  that every type passed to a device can be copied by the implementation.
+  Disables all diagnostics that the SYCL headers issue when a type does not
+  satisfy the device copyability requirements of the SYCL specification.
 
 - **SYCL_DISABLE_IMAGE_ASPECT_WARNING**
 

--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -173,7 +173,7 @@ class buffer : public detail::buffer_plain,
                public detail::OwnerLessBase<buffer<T, dimensions, AllocatorT>> {
   static_assert((dimensions > 0) && (dimensions <= 3),
                 "buffer dimensions must be 1, 2, or 3");
-  static_assert(is_device_copyable_v<T>,
+  static_assert(detail::check_if_device_copyable_v<T>,
                 "Underlying type of a buffer must be device copyable!");
 
 public:

--- a/sycl/include/sycl/detail/is_device_copyable.hpp
+++ b/sycl/include/sycl/detail/is_device_copyable.hpp
@@ -39,8 +39,15 @@ struct is_device_copyable_impl<
     : is_device_copyable<std::remove_cv_t<T>> {};
 } // namespace detail
 
+#ifdef SYCL_DISABLE_DEVICE_COPYABLE_CHECKS
+// The user has opted out of the device copyability checks, and takes
+// responsibility for the copyability of the types they pass to a device. See
+// sycl/doc/PreprocessorMacros.md.
+template <typename T> struct is_device_copyable : std::true_type {};
+#else
 template <typename T>
 struct is_device_copyable : detail::is_device_copyable_impl<T> {};
+#endif
 
 // std::array<T, 0> is implicitly device copyable type.
 template <typename T>

--- a/sycl/include/sycl/detail/is_device_copyable.hpp
+++ b/sycl/include/sycl/detail/is_device_copyable.hpp
@@ -39,15 +39,8 @@ struct is_device_copyable_impl<
     : is_device_copyable<std::remove_cv_t<T>> {};
 } // namespace detail
 
-#ifdef SYCL_DISABLE_DEVICE_COPYABLE_CHECKS
-// The user has opted out of the device copyability checks, and takes
-// responsibility for the copyability of the types they pass to a device. See
-// sycl/doc/PreprocessorMacros.md.
-template <typename T> struct is_device_copyable : std::true_type {};
-#else
 template <typename T>
 struct is_device_copyable : detail::is_device_copyable_impl<T> {};
-#endif
 
 // std::array<T, 0> is implicitly device copyable type.
 template <typename T>
@@ -91,14 +84,36 @@ struct is_device_copyable<T[N]> : is_device_copyable<T> {};
 template <typename T>
 inline constexpr bool is_device_copyable_v = is_device_copyable<T>::value;
 namespace detail {
+
+/// The predicate that all the device copyability requirements enforced by the
+/// implementation are written in terms of. It is is_device_copyable, except
+/// that SYCL_DISABLE_DEVICE_COPYABLE_CHECKS makes it true for every type. See
+/// sycl/doc/PreprocessorMacros.md.
+///
+/// The checks consult this instead of is_device_copyable directly so that the
+/// macro does not change the value the user facing trait reports: code outside
+/// of the implementation specializes and queries is_device_copyable, and it
+/// must keep seeing the answer the SYCL specification gives.
+#ifdef SYCL_DISABLE_DEVICE_COPYABLE_CHECKS
+template <typename T> struct check_if_device_copyable : std::true_type {};
+#else
+template <typename T>
+struct check_if_device_copyable : is_device_copyable<T> {};
+#endif
+
+template <typename T>
+inline constexpr bool check_if_device_copyable_v =
+    check_if_device_copyable<T>::value;
+
 #ifdef __SYCL_DEVICE_ONLY__
 template <typename T, typename> struct CheckFieldsAreDeviceCopyable;
 template <typename T, typename> struct CheckBasesAreDeviceCopyable;
 
 template <typename T>
 inline constexpr bool is_deprecated_device_copyable_v =
-    is_device_copyable_v<T> || (std::is_trivially_copy_constructible_v<T> &&
-                                std::is_trivially_destructible_v<T>);
+    check_if_device_copyable_v<T> ||
+    (std::is_trivially_copy_constructible_v<T> &&
+     std::is_trivially_destructible_v<T>);
 
 template <typename T, unsigned... FieldIds>
 struct CheckFieldsAreDeviceCopyable<T, std::index_sequence<FieldIds...>> {

--- a/sycl/include/sycl/ext/oneapi/memcpy2d.hpp
+++ b/sycl/include/sycl/ext/oneapi/memcpy2d.hpp
@@ -123,7 +123,7 @@ template <typename T>
 void handler::ext_oneapi_fill2d(void *Dest, size_t DestPitch, const T &Pattern,
                                 size_t Width, size_t Height) {
   throwIfActionIsCreated();
-  static_assert(is_device_copyable<T>::value,
+  static_assert(detail::check_if_device_copyable_v<T>,
                 "Pattern must be device copyable");
   if (Width > DestPitch)
     throw sycl::exception(sycl::make_error_code(errc::invalid),

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1168,7 +1168,7 @@ public:
             std::is_pointer_v<remove_cv_ref_t<T>>) // USM
         || is_same_type<OpenCLMemT, T>::value      // Interop
         || is_same_type<stream, T>::value          // Stream
-        || sycl::is_device_copyable_v<remove_cv_ref_t<T>>;
+        || detail::check_if_device_copyable_v<remove_cv_ref_t<T>>;
   };
 
   /// Sets argument for OpenCL interoperability kernels.
@@ -2016,7 +2016,7 @@ public:
   template <typename T> void fill(void *Ptr, const T &Pattern, size_t Count) {
     throwIfActionIsCreated();
     setUserFacingNodeType(ext::oneapi::experimental::node_type::memfill);
-    static_assert(is_device_copyable<T>::value,
+    static_assert(detail::check_if_device_copyable_v<T>,
                   "Pattern must be device copyable");
     if (getDeviceBackend() == backend::ext_oneapi_level_zero) {
       parallel_for<__usmfill<T>>(range<1>(Count), [=](id<1> Index) {

--- a/sycl/test/basic_tests/device_copyable_checks_disabled.cpp
+++ b/sycl/test/basic_tests/device_copyable_checks_disabled.cpp
@@ -14,5 +14,10 @@ struct NotDeviceCopyable {
 int main() {
   NotDeviceCopyable Val;
   // checks-on-error@*:* {{The specified type is not device copyable}}
+#ifdef SYCL_DISABLE_DEVICE_COPYABLE_CHECKS
+  static_assert(sycl::is_device_copyable_v<NotDeviceCopyable>);
+#else
+  static_assert(!sycl::is_device_copyable_v<NotDeviceCopyable>);
+#endif
   sycl::queue{}.single_task([=] { (void)Val; });
 }

--- a/sycl/test/basic_tests/device_copyable_checks_disabled.cpp
+++ b/sycl/test/basic_tests/device_copyable_checks_disabled.cpp
@@ -1,0 +1,18 @@
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -Xclang -verify=checks-on -Xclang -verify-ignore-unexpected=warning,note %s
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -DSYCL_DISABLE_DEVICE_COPYABLE_CHECKS -Xclang -verify=checks-off -Xclang -verify-ignore-unexpected=warning,note %s
+
+// checks-off-no-diagnostics
+
+#include <sycl/detail/core.hpp>
+
+// A user-provided destructor is enough to make this neither device copyable nor
+// eligible for the deprecated trivially-copyable exception.
+struct NotDeviceCopyable {
+  ~NotDeviceCopyable() {}
+};
+
+int main() {
+  NotDeviceCopyable Val;
+  // checks-on-error@*:* {{The specified type is not device copyable}}
+  sycl::queue{}.single_task([=] { (void)Val; });
+}

--- a/sycl/test/basic_tests/device_copyable_checks_disabled.cpp
+++ b/sycl/test/basic_tests/device_copyable_checks_disabled.cpp
@@ -11,13 +11,15 @@ struct NotDeviceCopyable {
   ~NotDeviceCopyable() {}
 };
 
+// The macro only turns the checks off, it must not change what the user facing
+// trait reports about a type.
+static_assert(!sycl::is_device_copyable_v<NotDeviceCopyable>);
+
 int main() {
   NotDeviceCopyable Val;
   // checks-on-error@*:* {{The specified type is not device copyable}}
-#ifdef SYCL_DISABLE_DEVICE_COPYABLE_CHECKS
-  static_assert(sycl::is_device_copyable_v<NotDeviceCopyable>);
-#else
-  static_assert(!sycl::is_device_copyable_v<NotDeviceCopyable>);
-#endif
   sycl::queue{}.single_task([=] { (void)Val; });
+
+  // checks-on-error@*:* {{a buffer must be device copyable}}
+  sycl::buffer<NotDeviceCopyable, 1> Buf{sycl::range<1>{1}};
 }


### PR DESCRIPTION
This PR adds a new macro, **SYCL_DISABLE_DEVICE_COPYABLE_CHECKS**, that makes `sycl::is_device_copyable_v<T>` report `true` for every type, and disables all diagnostics that the SYCL headers issue when a type does not satisfy the device copyability requirements of the SYCL specification. 