### PR TITLE
[SYCL] Make device_event::wait() noexcept

### DIFF
--- a/sycl/include/sycl/device_event.hpp
+++ b/sycl/include/sycl/device_event.hpp
@@ -30,7 +30,7 @@ public:
 
   device_event(__ocl_event_t Event) : m_Event(Event) {}
 
-  void wait() {
+  void wait() noexcept {
     (void)m_Event;
 #ifdef __SYCL_DEVICE_ONLY__
     __spirv_GroupWaitEvents(__spv::Scope::Workgroup, 1, &m_Event);

--- a/sycl/test/basic_tests/nd_item_interface.cpp
+++ b/sycl/test/basic_tests/nd_item_interface.cpp
@@ -132,5 +132,6 @@ static_assert(noexcept(std::declval<const Item &>().async_work_group_copy(
     std::declval<DecoratedGlobalIntPtr>(),
     std::declval<DecoratedLocalConstIntPtr>(), std::size_t{})));
 
+static_assert(noexcept(std::declval<sycl::device_event &>().wait()));
 static_assert(noexcept(
     std::declval<const Item &>().wait_for(std::declval<sycl::device_event>())));


### PR DESCRIPTION
The function should be noexcept according to SYCL 2020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)