### PR TITLE
[SYCL][Unittests] Don't pass addresses of local variables as UR handles in unit tests

### DIFF
--- a/sycl/unittests/Extensions/BindlessImages/Semaphores.cpp
+++ b/sycl/unittests/Extensions/BindlessImages/Semaphores.cpp
@@ -120,7 +120,7 @@ TEST(BindlessImagesExtensionTests, ExternalSemaphoreSignal) {
 
   // Create a dummy external semaphore and set the raw handle to some dummy.
   // The mock implementation should never access the handle, so this is safe.
-  int DummyInt1 = 0, DummyInt2 = 0;
+  int DummyInt1 = 0;
   syclexp::external_semaphore DummySemaphore{};
   DummySemaphore.raw_handle =
       reinterpret_cast<ur_exp_external_semaphore_handle_t>(&DummyInt1);
@@ -131,8 +131,10 @@ TEST(BindlessImagesExtensionTests, ExternalSemaphoreSignal) {
       *sycl::detail::getSyclObjImpl(Q));
   auto DummyEventImpl2 = sycl::detail::event_impl::create_device_event(
       *sycl::detail::getSyclObjImpl(Q));
-  DummyEventImpl1->setHandle(reinterpret_cast<ur_event_handle_t>(&DummyInt1));
-  DummyEventImpl2->setHandle(reinterpret_cast<ur_event_handle_t>(&DummyInt2));
+  // The runtime releases these handles when the events die, so they must be
+  // real dummy handles rather than arbitrary pointers.
+  DummyEventImpl1->setHandle(mock::createDummyHandle<ur_event_handle_t>());
+  DummyEventImpl2->setHandle(mock::createDummyHandle<ur_event_handle_t>());
   sycl::event DummyEvent1 =
       sycl::detail::createSyclObjFromImpl<sycl::event>(DummyEventImpl1);
   sycl::event DummyEvent2 =

--- a/sycl/unittests/handler/SetArgForLocalAccessor.cpp
+++ b/sycl/unittests/handler/SetArgForLocalAccessor.cpp
@@ -44,17 +44,23 @@ TEST(HandlerSetArg, LocalAccessor) {
   constexpr size_t Size = 128;
   sycl::queue Q;
 
-  ur_native_handle_t handle = mock::createDummyHandle<ur_native_handle_t>();
+  // The mock treats the native handle as a dummy handle and retains/releases
+  // it, so it has to be passed by value and the reference owned by the test
+  // released once the kernel is gone.
+  ur_native_handle_t Handle = mock::createDummyHandle<ur_native_handle_t>();
   auto KernelCL = reinterpret_cast<typename sycl::backend_traits<
-      sycl::backend::opencl>::template input_type<sycl::kernel>>(&handle);
-  auto Kernel =
-      sycl::make_kernel<sycl::backend::opencl>(KernelCL, Q.get_context());
+      sycl::backend::opencl>::template input_type<sycl::kernel>>(Handle);
+  {
+    auto Kernel =
+        sycl::make_kernel<sycl::backend::opencl>(KernelCL, Q.get_context());
 
-  Q.submit([&](sycl::handler &CGH) {
-     sycl::local_accessor<float, 1> Acc(Size, CGH);
-     CGH.set_arg(0, Acc);
-     CGH.single_task(Kernel);
-   }).wait();
+    Q.submit([&](sycl::handler &CGH) {
+       sycl::local_accessor<float, 1> Acc(Size, CGH);
+       CGH.set_arg(0, Acc);
+       CGH.single_task(Kernel);
+     }).wait();
+  }
+  mock::releaseDummyHandle(Handle);
 
   ASSERT_EQ(LocalBufferArgSize, Size * sizeof(float));
 }

--- a/sycl/unittests/thread_safety/InteropKernelEnqueue.cpp
+++ b/sycl/unittests/thread_safety/InteropKernelEnqueue.cpp
@@ -55,22 +55,28 @@ TEST(KernelEnqueue, InteropKernel) {
   platform Plt = sycl::platform();
   queue Q;
 
+  // The mock treats the native handle as a dummy handle and retains/releases
+  // it, so it has to be passed by value and the reference owned by the test
+  // released once the kernel is gone.
   ur_native_handle_t Handle = mock::createDummyHandle<ur_native_handle_t>();
   auto KernelCL = reinterpret_cast<typename sycl::backend_traits<
-      sycl::backend::opencl>::template input_type<sycl::kernel>>(&Handle);
-  auto Kernel =
-      sycl::make_kernel<sycl::backend::opencl>(KernelCL, Q.get_context());
+      sycl::backend::opencl>::template input_type<sycl::kernel>>(Handle);
+  {
+    auto Kernel =
+        sycl::make_kernel<sycl::backend::opencl>(KernelCL, Q.get_context());
 
-  auto TestLambda = [&](std::size_t ThreadId) {
-    Q.submit([&](sycl::handler &CGH) {
-       for (std::size_t I = 0; I < NArgs; ++I)
-         CGH.set_arg(I, ThreadId);
-       CGH.single_task(Kernel);
-     }).wait();
-  };
+    auto TestLambda = [&](std::size_t ThreadId) {
+      Q.submit([&](sycl::handler &CGH) {
+         for (std::size_t I = 0; I < NArgs; ++I)
+           CGH.set_arg(I, ThreadId);
+         CGH.single_task(Kernel);
+       }).wait();
+    };
 
-  for (std::size_t I = 0; I < LaunchCount; ++I) {
-    ThreadPool Pool(ThreadCount, TestLambda);
+    for (std::size_t I = 0; I < LaunchCount; ++I) {
+      ThreadPool Pool(ThreadCount, TestLambda);
+    }
   }
+  mock::releaseDummyHandle(Handle);
 }
 } // namespace


### PR DESCRIPTION
## Problem

The UR mock adapter reinterpret_casts every handle it receives to `mock::dummy_handle_t_` and touches `MRefCounter` on retain/release. Three unit tests passed the **address** of a local variable where the runtime expects a handle, so those retain/release calls wrote into the tests' own stack frames.

**1. `sycl/unittests/Extensions/BindlessImages/Semaphores.cpp`** — `BindlessImagesExtensionTests.ExternalSemaphoreSignal` built fake device events with

```cpp
int DummyInt1 = 0, DummyInt2 = 0;
DummyEventImpl1->setHandle(reinterpret_cast<ur_event_handle_t>(&DummyInt1));
DummyEventImpl2->setHandle(reinterpret_cast<ur_event_handle_t>(&DummyInt2));
```

`~event_impl()` calls `urEventRelease` on those handles:

```
ERROR: AddressSanitizer: stack-buffer-overflow on address ...
WRITE of size 8 at ... thread T0
    #0 ... in operator-- bits/atomic_base.h:410
    #1 ... in releaseDummyHandle<ur_event_handle_t_ *>
       unified-runtime/source/mock/ur_mock_helpers.hpp:74
    #2 ... in driver::urEventRelease(ur_event_handle_t_*)
    ...
    #6 ... in sycl::_V1::detail::event_impl::~event_impl()
    #10 ... in BindlessImagesExtensionTests_ExternalSemaphoreSignal_Test::TestBody()
```

The same pattern also produced a UBSan `member access within misaligned address ... for type 'dummy_handle_t_'` diagnostic, because a 4-byte-aligned `int` is not suitably aligned for the handle struct.

**2. `sycl/unittests/thread_safety/InteropKernelEnqueue.cpp`** (`KernelEnqueue.InteropKernel`) and **3. `sycl/unittests/handler/SetArgForLocalAccessor.cpp`** (`HandlerSetArg.LocalAccessor`) — both created a native handle and then passed its *address* to `make_kernel`:

```cpp
auto Handle = mock::createDummyHandle<ur_native_handle_t>();
... reinterpret_cast<cl_kernel>(&Handle) ...
```

so the runtime's retain/release of the interop kernel mutated the local `Handle` variable, and the handle it actually created was never released (a leak on top of the corruption).

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>