### PR TITLE
[SYCL][E2E] guard on tests, note about VS 2019

### DIFF
--- a/sycl/test-e2e/DeviceLib/exp/exp-std-complex-double-edge-cases.cpp
+++ b/sycl/test-e2e/DeviceLib/exp/exp-std-complex-double-edge-cases.cpp
@@ -4,9 +4,14 @@
 // REQUIRES: aspect-fp64
 // UNSUPPORTED: target-amd || target-nvidia
 // UNSUPPORTED-INTENDED: This test is intended for backends with SPIR-V support.
+
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 //
-// RUN: %{build} -o %t.out
+// RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
+
+// NOTE: on Windows this test will fail with MSVC 2019 STL headers
+// due to a bug in those headers.
 
 #include "exp-std-complex-edge-cases.hpp"
 

--- a/sycl/test-e2e/DeviceLib/exp/exp-std-complex-float-edge-cases.cpp
+++ b/sycl/test-e2e/DeviceLib/exp/exp-std-complex-float-edge-cases.cpp
@@ -4,8 +4,13 @@
 // UNSUPPORTED: target-amd || target-nvidia
 // UNSUPPORTED-INTENDED: This test is intended for backends with SPIR-V support.
 //
-// RUN: %{build} -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+//
+// RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
+
+// NOTE: on Windows this test will fail with MSVC 2019 STL headers
+// due to a bug in those headers.
 
 #include "exp-std-complex-edge-cases.hpp"
 


### PR DESCRIPTION
The tests in question are passing just fine in SYCLOS which defaults to {{-fno-fast-math}}, but would fail if fast math were used.
Like the other tests in this oeuvre it should really specify the flag if that is a limitation. Note, also, that this trips over a known (and since fixed) bug in the Windows MSVC STL headers from VS 2019.  We don't have gating for MSVC versions in our test harness, so I'm simply noting this. 