### PR TITLE
[UR][L0v2] Fix condition when copy offload is not supported by the driver

### DIFF
--- a/unified-runtime/source/adapters/level_zero/v2/command_list_cache.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_cache.cpp
@@ -110,7 +110,8 @@ command_list_cache_t::createCommandList(const command_list_descriptor_t &desc) {
     requestedCopyOffload = false;
   }
 
-  if (!ZeCopyOffloadExtensionSupported && requestedCopyOffload) {
+  if (requestedCopyOffload && !ZeCopyOffloadQueueFlagSupported &&
+      !ZeCopyOffloadListFlagSupported) {
     UR_LOG(INFO,
            "Copy offload is requested but is not supported by the driver.");
     requestedCopyOffload = false;


### PR DESCRIPTION
Copy Offload is incorrectly disabled when Copy Offload extension is set to unsupported.

Fixes: URT-1280