### PR TITLE
[SYCL] Enable BFloat16/bfloat16_builtins.cpp e2e-test

### DIFF
--- a/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
@@ -13,9 +13,6 @@
 // UNSUPPORTED: spirv-backend && cpu
 // UNSUPPORTED-TRACKER: CMPLRLLVM-64705
 
-// XFAIL: linux && (gpu-intel-gen12 || gpu-intel-dg2 || arch-intel_gpu_pvc || arch-intel_gpu_bmg_g21 || arch-intel_gpu_mtl_u)
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/22054
-
 #include "bfloat16_builtins.hpp"
 
 int main() {

--- a/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
@@ -13,6 +13,9 @@
 // UNSUPPORTED: spirv-backend && cpu
 // UNSUPPORTED-TRACKER: CMPLRLLVM-64705
 
+// XFAIL: linux && arch-intel_gpu_mtl_u
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/22054
+
 #include "bfloat16_builtins.hpp"
 
 int main() {


### PR DESCRIPTION
The test passes with the new GPU driver, see https://github.com/intel/llvm/actions/runs/33941140181