### PR TITLE
[UR][L0] Treat ZE_RESULT_ERROR_NOT_AVAILABLE as unsupported fan speed query

### DIFF
--- a/unified-runtime/source/adapters/level_zero/common/device.cpp
+++ b/unified-runtime/source/adapters/level_zero/common/device.cpp
@@ -1471,12 +1471,18 @@ ur_result_t urDeviceGetInfo(
     int32_t Speed = -1;
     for (auto Fan : ZeFanHandles) {
       int32_t CurSpeed;
-      auto result = ze2urResult(ZE_CALL_NOCHECK(
-          zesFanGetState, (Fan, ZES_FAN_SPEED_UNITS_PERCENT, &CurSpeed)));
-      if (result != UR_RESULT_SUCCESS)
-        return result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+      // Some drivers/KMDs report an enumerated fan as unreadable via
+      // ZE_RESULT_ERROR_UNSUPPORTED_FEATURE, others via
+      // ZE_RESULT_ERROR_NOT_AVAILABLE. Treat both as "unsupported" so the
+      // query is reported consistently instead of surfacing an unrelated
+      // UR error (e.g. UR_RESULT_ERROR_INVALID_OPERATION).
+      ze_result_t ZeResult = ZE_CALL_NOCHECK(
+          zesFanGetState, (Fan, ZES_FAN_SPEED_UNITS_PERCENT, &CurSpeed));
+      if (ZeResult != ZE_RESULT_SUCCESS)
+        return (ZeResult == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE ||
+                ZeResult == ZE_RESULT_ERROR_NOT_AVAILABLE)
                    ? UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
-                   : result;
+                   : ze2urResult(ZeResult);
       Speed = std::max(Speed, CurSpeed);
     }
     return ReturnValue(Speed);


### PR DESCRIPTION
CI on Level Zero V2 / Arc B580 started failing
urDeviceGetInfoTest.SuccessFanSpeed: zesFanGetState(ZES_FAN_SPEED_UNITS_PERCENT)
now returns ZE_RESULT_ERROR_NOT_AVAILABLE instead of
ZE_RESULT_ERROR_UNSUPPORTED_FEATURE on this hardware/KMD combination.
ze2urResult() maps NOT_AVAILABLE to UR_RESULT_ERROR_INVALID_OPERATION, which
the conformance test doesn't accept as an optional-query failure (it only
allows UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION), so
UR_DEVICE_INFO_FAN_SPEED failed with an unrelated error instead of being
reported as unsupported.

Check the raw ze_result_t before conversion and treat both
ZE_RESULT_ERROR_UNSUPPORTED_FEATURE and ZE_RESULT_ERROR_NOT_AVAILABLE as
'this fan cannot report its state', consistently returning
UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION for either.

Ref: https://github.com/intel/llvm/actions/runs/34096141372/job/101664166940?pr=23110

Ref: Jira VLK-92189
