### PR TITLE
[UR][L0v2] Remove unused ZeCopyOffloadExtensionSupported flag

### DIFF
--- a/unified-runtime/source/adapters/level_zero/common/platform.cpp
+++ b/unified-runtime/source/adapters/level_zero/common/platform.cpp
@@ -271,15 +271,6 @@ ur_result_t ur_platform_handle_t_::initialize() {
         ZeDriverEuCountExtensionFound = true;
       }
     }
-    if (strncmp(extension.name,
-                ZEX_INTEL_QUEUE_COPY_OPERATIONS_OFFLOAD_HINT_EXP_NAME,
-                strlen(ZEX_INTEL_QUEUE_COPY_OPERATIONS_OFFLOAD_HINT_EXP_NAME) +
-                    1) == 0) {
-      if (extension.version ==
-          ZEX_INTEL_QUEUE_COPY_OPERATIONS_OFFLOAD_HINT_EXP_VERSION_1_0) {
-        ZeCopyOffloadExtensionSupported = true;
-      }
-    }
     if (strncmp(extension.name, ZE_BINDLESS_IMAGE_EXP_NAME,
                 strlen(ZE_BINDLESS_IMAGE_EXP_NAME) + 1) == 0) {
       if (extension.version == ZE_BINDLESS_IMAGE_EXP_VERSION_1_0) {

--- a/unified-runtime/source/adapters/level_zero/common/platform.hpp
+++ b/unified-runtime/source/adapters/level_zero/common/platform.hpp
@@ -69,7 +69,6 @@ struct ur_platform_handle_t_ : ur::level_zero::ur_object_t, public ur_platform {
   bool ZeDriverEventPoolCountingEventsExtensionFound{false};
   bool zeDriverImmediateCommandListAppendFound{false};
   bool ZeDriverEuCountExtensionFound{false};
-  bool ZeCopyOffloadExtensionSupported{false};
   bool ZeCopyOffloadQueueFlagSupported{false};
   bool ZeCopyOffloadListFlagSupported{false};
   bool ZeBindlessImagesExtensionSupported{false};

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_cache.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_cache.cpp
@@ -85,8 +85,6 @@ command_list_cache_t::command_list_cache_t(
     ze_context_handle_t ZeContext,
     supported_extensions_descriptor_t supportedExtensions)
     : ZeContext{ZeContext},
-      ZeCopyOffloadExtensionSupported{
-          supportedExtensions.ZeCopyOffloadExtensionSupported},
       ZeMutableCmdListExtentionSupported{
           supportedExtensions.ZeMutableCmdListExtentionSupported},
       ZeCopyOffloadQueueFlagSupported{

--- a/unified-runtime/source/adapters/level_zero/v2/command_list_cache.hpp
+++ b/unified-runtime/source/adapters/level_zero/v2/command_list_cache.hpp
@@ -26,15 +26,12 @@ using command_list_unique_handle =
 } // namespace raii
 
 struct supported_extensions_descriptor_t {
-  supported_extensions_descriptor_t(bool ZeCopyOffloadExtensionSupported,
-                                    bool ZeMutableCmdListExtentionSupported,
+  supported_extensions_descriptor_t(bool ZeMutableCmdListExtentionSupported,
                                     bool ZeCopyOffloadQueueFlagSupported,
                                     bool ZeCopyOffloadListFlagSupported)
-      : ZeCopyOffloadExtensionSupported(ZeCopyOffloadExtensionSupported),
-        ZeMutableCmdListExtentionSupported(ZeMutableCmdListExtentionSupported),
+      : ZeMutableCmdListExtentionSupported(ZeMutableCmdListExtentionSupported),
         ZeCopyOffloadQueueFlagSupported(ZeCopyOffloadQueueFlagSupported),
         ZeCopyOffloadListFlagSupported(ZeCopyOffloadListFlagSupported) {}
-  bool ZeCopyOffloadExtensionSupported;
   bool ZeMutableCmdListExtentionSupported;
   bool ZeCopyOffloadQueueFlagSupported;
   bool ZeCopyOffloadListFlagSupported;
@@ -100,7 +97,6 @@ struct command_list_cache_t {
 
 private:
   ze_context_handle_t ZeContext;
-  bool ZeCopyOffloadExtensionSupported;
   bool ZeMutableCmdListExtentionSupported;
   bool ZeCopyOffloadQueueFlagSupported;
   bool ZeCopyOffloadListFlagSupported;

--- a/unified-runtime/source/adapters/level_zero/v2/context.cpp
+++ b/unified-runtime/source/adapters/level_zero/v2/context.cpp
@@ -73,8 +73,7 @@ ur_context_handle_t_::ur_context_handle_t_(ze_context_handle_t hContext,
                           phDevices[0]->Platform),
       hContext(hContext, ownZeContext),
       commandListCache(
-          hContext, {phDevices[0]->Platform->ZeCopyOffloadExtensionSupported,
-                     phDevices[0]->Platform->ZeMutableCmdListExt.Supported,
+          hContext, {phDevices[0]->Platform->ZeMutableCmdListExt.Supported,
                      phDevices[0]->Platform->ZeCopyOffloadQueueFlagSupported,
                      phDevices[0]->Platform->ZeCopyOffloadListFlagSupported}),
       eventPoolCacheImmediate(

--- a/unified-runtime/test/adapters/level_zero/v2/command_list_cache_test.cpp
+++ b/unified-runtime/test/adapters/level_zero/v2/command_list_cache_test.cpp
@@ -38,7 +38,7 @@ struct CommandListCacheTest : public uur::urContextTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(CommandListCacheTest);
 
 TEST_P(CommandListCacheTest, CanStoreAndRetriveImmediateAndRegularCmdLists) {
-  v2::supported_extensions_descriptor_t supportedExtensions(false, false, false,
+  v2::supported_extensions_descriptor_t supportedExtensions(false, false,
                                                             false);
   v2::command_list_cache_t cache(v2::v2_cast(context)->getZeHandle(),
                                  supportedExtensions);
@@ -96,7 +96,7 @@ TEST_P(CommandListCacheTest, CanStoreAndRetriveImmediateAndRegularCmdLists) {
 }
 
 TEST_P(CommandListCacheTest, ImmediateCommandListsHaveProperAttributes) {
-  v2::supported_extensions_descriptor_t supportedExtensions(false, false, false,
+  v2::supported_extensions_descriptor_t supportedExtensions(false, false,
                                                             false);
   v2::command_list_cache_t cache(v2::v2_cast(context)->getZeHandle(),
                                  supportedExtensions);


### PR DESCRIPTION
After the fix in #23110 (which changed createCommandList()'s
copy-offload-support check to rely solely on
ZeCopyOffloadQueueFlagSupported / ZeCopyOffloadListFlagSupported),
ZeCopyOffloadExtensionSupported is set during platform initialization
but never read anywhere in any conditional logic. It only flowed
through: platform.cpp (probed from the driver's extension list) ->
context.cpp (passed to command_list_cache_t's constructor) ->
command_list_cache.hpp/cpp (stored as a class member), without
affecting behavior.

Remove the flag and its now-pointless extension name/version probing
block across platform.hpp/.cpp, context.cpp, and
command_list_cache.hpp/.cpp. No behavior change; the
ur_zex_intel_queue_copy_operations_offload_hint_exp_desc_t descriptor
and its pNext fallback usage are unrelated and unaffected.