### PR TITLE
[SYCL][Graph][Test] Add native recording error code tests

### DIFF
--- a/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CommandGraph/CMakeLists.txt
@@ -11,6 +11,7 @@ add_sycl_unittest(CommandGraphExtensionTests OBJECT
   InOrderQueue.cpp
   MultiThreaded.cpp
   NativeRecording.cpp
+  NativeRecordingExceptions.cpp
   NativeRecordingMock.cpp
   Queries.cpp
   Regressions.cpp

--- a/sycl/unittests/Extensions/CommandGraph/NativeRecording.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/NativeRecording.cpp
@@ -12,17 +12,6 @@ using NativeRecordingMock::state;
 using NativeRecordingMock::traceCount;
 using NativeRecordingMock::traceIndex;
 
-// Test that native recording throws when UR does not support it
-TEST_F(NativeRecordingTest, NativeRecordingUnsupportedDevice) {
-  state().SupportsNativeRecording = false;
-  try {
-    makeGraph();
-    FAIL() << "Expected an exception";
-  } catch (sycl::exception &E) {
-    EXPECT_EQ(E.code(), sycl::errc::invalid);
-  }
-}
-
 // Traces UR recording layer
 TEST_F(NativeRecordingTest, RecordingUrTrace) {
   auto Graph = makeGraph();

--- a/sycl/unittests/Extensions/CommandGraph/NativeRecordingExceptions.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/NativeRecordingExceptions.cpp
@@ -1,0 +1,200 @@
+//==--------------------- NativeRecordingExceptions.cpp --------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Checks that a failure reported by a UR native recording entry point reaches
+// the user with the originating UR error code and expected message.
+// Erroneous graph operations print the point of failure in the error message
+// while recorded operations which fail just print the UR error code.
+
+#include "NativeRecordingMock.hpp"
+
+using NativeRecordingMock::expectFailure;
+using NativeRecordingMock::state;
+using ::testing::HasSubstr;
+
+// Test that native recording throws when UR does not support it
+TEST_F(NativeRecordingTest, NativeRecordingUnsupportedDevice) {
+  state().SupportsNativeRecording = false;
+
+  std::string Message =
+      expectFailure([&]() { makeGraph(); }, std::nullopt, sycl::errc::invalid);
+  EXPECT_THAT(Message, HasSubstr("does not support graph record and replay"));
+}
+
+TEST_F(NativeRecordingTest, UnjoinedForkDescriptiveError) {
+  auto Graph1 = makeGraph();
+  Graph1.begin_recording(Queue);
+
+  FAIL_UR_AFTER(urQueueEndGraphCaptureExp,
+                UR_RESULT_ERROR_GRAPH_UNJOINED_FORKS);
+  std::string Message = expectFailure([&]() { Graph1.end_recording(Queue); },
+                                      UR_RESULT_ERROR_GRAPH_UNJOINED_FORKS);
+  EXPECT_THAT(Message, HasSubstr("ending native graph capture"));
+
+  auto Graph2 = makeGraph();
+  Graph2.begin_recording(Queue);
+  Message = expectFailure([&]() { Graph2.end_recording(); },
+                          UR_RESULT_ERROR_GRAPH_UNJOINED_FORKS);
+  EXPECT_THAT(Message, HasSubstr("ending native graph capture"));
+}
+
+TEST_F(NativeRecordingTest, InternalEventDescriptiveError) {
+  auto Graph = makeGraph();
+  Graph.begin_recording(Queue);
+
+  // Mock the next submission containing a wait event signaled on a
+  // non-recording queue.
+  FAIL_UR_BEFORE(urEnqueueKernelLaunchWithArgsExp,
+                 UR_RESULT_ERROR_GRAPH_INTERNAL_EVENT);
+  expectFailure(
+      [&]() {
+        Queue.submit(
+            [&](sycl::handler &CGH) { CGH.single_task<TestKernel>([]() {}); });
+      },
+      UR_RESULT_ERROR_GRAPH_INTERNAL_EVENT);
+
+  Graph.end_recording(Queue);
+}
+
+TEST_F(NativeRecordingTest, MergeAttemptDescriptiveError) {
+  auto Graph = makeGraph();
+  Graph.begin_recording(Queue);
+
+  // Mock the next submission containing a wait event captured in a separate
+  // graph.
+  FAIL_UR_BEFORE(urEnqueueKernelLaunchWithArgsExp,
+                 UR_RESULT_ERROR_GRAPH_CAPTURE_MERGE_ATTEMPT);
+  expectFailure(
+      [&]() {
+        Queue.submit(
+            [&](sycl::handler &CGH) { CGH.single_task<TestKernel>([]() {}); });
+      },
+      UR_RESULT_ERROR_GRAPH_CAPTURE_MERGE_ATTEMPT);
+
+  Graph.end_recording(Queue);
+}
+
+TEST_F(NativeRecordingTest, RecordedEventHostWaitDescriptiveError) {
+  auto Graph = makeGraph();
+  Graph.begin_recording(Queue);
+
+  sycl::event RecordedEvent = Queue.submit(
+      [&](sycl::handler &CGH) { CGH.single_task<TestKernel>([]() {}); });
+
+  FAIL_UR_BEFORE(urEventWait, UR_RESULT_ERROR_GRAPH_CAPTURE_UNSUPPORTED);
+  expectFailure([&]() { RecordedEvent.wait(); },
+                UR_RESULT_ERROR_GRAPH_CAPTURE_UNSUPPORTED);
+
+  Graph.end_recording(Queue);
+}
+
+TEST_F(NativeRecordingTest, RecordingQueueWaitDescriptiveError) {
+  auto Graph = makeGraph();
+  Graph.begin_recording(Queue);
+
+  FAIL_UR_BEFORE(urQueueFinish, UR_RESULT_ERROR_GRAPH_CAPTURE_UNSUPPORTED);
+  expectFailure([&]() { Queue.wait(); },
+                UR_RESULT_ERROR_GRAPH_CAPTURE_UNSUPPORTED);
+
+  Graph.end_recording(Queue);
+}
+
+TEST_F(NativeRecordingTest, GraphCreateDescriptiveError) {
+  FAIL_UR_BEFORE(urGraphCreateExp, UR_RESULT_ERROR_OUT_OF_RESOURCES);
+  std::string Message =
+      expectFailure([&]() { makeGraph(); }, UR_RESULT_ERROR_OUT_OF_RESOURCES);
+  EXPECT_THAT(Message, HasSubstr("create native UR graph"));
+}
+
+TEST_F(NativeRecordingTest, FinalizeDescriptiveError) {
+  auto Graph = makeGraph();
+
+  Graph.begin_recording(Queue);
+  Queue.submit(
+      [&](sycl::handler &CGH) { CGH.single_task<TestKernel>([]() {}); });
+  Graph.end_recording(Queue);
+
+  FAIL_UR_BEFORE(urGraphInstantiateGraphExp, UR_RESULT_ERROR_INVALID_GRAPH);
+  std::string Message =
+      expectFailure([&]() { Graph.finalize(); }, UR_RESULT_ERROR_INVALID_GRAPH);
+  EXPECT_THAT(Message, HasSubstr("instantiate native UR executable graph"));
+}
+
+TEST_F(NativeRecordingTest, BeginRecordingDescriptiveError) {
+  auto Graph = makeGraph();
+
+  FAIL_UR_BEFORE(urQueueBeginCaptureIntoGraphExp,
+                 UR_RESULT_ERROR_GRAPH_CAPTURE_UNSUPPORTED);
+  std::string Message =
+      expectFailure([&]() { Graph.begin_recording(Queue); },
+                    UR_RESULT_ERROR_GRAPH_CAPTURE_UNSUPPORTED);
+  EXPECT_THAT(Message, HasSubstr("begin native UR graph capture"));
+}
+
+TEST_F(NativeRecordingTest, SetDestructionCallbackDescriptiveError) {
+  bool CallbackFired = false;
+  {
+    auto Graph = makeGraph();
+
+    FAIL_UR_BEFORE(urGraphSetDestructionCallbackExp,
+                   UR_RESULT_ERROR_OUT_OF_RESOURCES);
+    std::string Message = expectFailure(
+        [&]() {
+          Graph.set_destruction_callback(
+              [&CallbackFired]() { CallbackFired = true; });
+        },
+        UR_RESULT_ERROR_OUT_OF_RESOURCES);
+    EXPECT_THAT(Message, HasSubstr("register graph destruction callback"));
+  }
+}
+
+TEST_F(NativeRecordingTest, EmptyDescriptiveError) {
+  auto Graph = makeGraph();
+
+  FAIL_UR_BEFORE(urGraphIsEmptyExp, UR_RESULT_ERROR_INVALID_GRAPH);
+  std::string Message =
+      expectFailure([&]() { Graph.empty(); }, UR_RESULT_ERROR_INVALID_GRAPH);
+  EXPECT_THAT(Message, HasSubstr("check if graph is empty"));
+}
+
+TEST_F(NativeRecordingTest, PrintGraphDescriptiveError) {
+  auto Graph = makeGraph();
+
+  FAIL_UR_BEFORE(urGraphDumpContentsExp, UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  std::string Message =
+      expectFailure([&]() { Graph.print_graph("native_graph.dot"); },
+                    UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  EXPECT_THAT(Message, HasSubstr("dump native UR graph contents"));
+}
+
+TEST_F(NativeRecordingTest, GetGraphDescriptiveError) {
+  auto Graph = makeGraph();
+  Graph.begin_recording(Queue);
+
+  FAIL_UR_BEFORE(urQueueGetGraphExp, UR_RESULT_ERROR_INVALID_GRAPH);
+  std::string Message = expectFailure([&]() { Queue.ext_oneapi_get_graph(); },
+                                      UR_RESULT_ERROR_INVALID_GRAPH);
+  EXPECT_THAT(Message, HasSubstr("query native UR graph from queue"));
+
+  Graph.end_recording(Queue);
+}
+
+// NOTE: The current implementation manually returns sycl::errc::invalid and the
+// UR implementation manually handles this case, diverging from the native L0
+// graph return.
+TEST_F(NativeRecordingTest, GetGraphNotRecordingError) {
+  auto Graph = makeGraph();
+  Graph.begin_recording(Queue);
+
+  FAIL_UR_BEFORE(urQueueGetGraphExp, UR_RESULT_ERROR_INVALID_OPERATION);
+  std::string Message = expectFailure([&]() { Queue.ext_oneapi_get_graph(); },
+                                      std::nullopt, sycl::errc::invalid);
+  EXPECT_THAT(Message, HasSubstr("can only be called on recording queues"));
+
+  Graph.end_recording(Queue);
+}

--- a/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.cpp
@@ -23,6 +23,10 @@ MockState &state() {
   return State;
 }
 
+void trace(std::string EntryPoint, const void *Handle) {
+  state().Trace.push_back({std::move(EntryPoint), Handle});
+}
+
 size_t traceCount(std::string_view EntryPoint) {
   const std::vector<TraceEntry> &Trace = state().Trace;
   return std::count_if(
@@ -52,10 +56,6 @@ size_t traceIndex(std::string_view EntryPoint) {
 }
 
 namespace {
-
-void trace(std::string EntryPoint, const void *Handle = nullptr) {
-  state().Trace.push_back({std::move(EntryPoint), Handle});
-}
 
 // This is called after urDeviceGetInfo() to inject native recording support
 ur_result_t mock_urDeviceGetInfoAfter(void *pParams) {

--- a/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.hpp
+++ b/sycl/unittests/Extensions/CommandGraph/NativeRecordingMock.hpp
@@ -13,6 +13,9 @@
 
 #include "Common.hpp"
 
+#include <gmock/gmock.h>
+
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -49,6 +52,51 @@ struct MockState {
 };
 
 MockState &state();
+
+// Records a call to EntryPoint, optionally against the object it was about.
+void trace(std::string EntryPoint, const void *Handle = nullptr);
+
+// Fails EntryPoint before its mock implementation runs while still tracing the
+// call
+#define FAIL_UR_BEFORE(EntryPoint, Error)                                      \
+  mock::getCallbacks().set_before_callback(                                    \
+      #EntryPoint, [](void *) -> ur_result_t {                                 \
+        static_assert(Error != UR_RESULT_SUCCESS,                              \
+                      "Injected error must be a failure");                     \
+        NativeRecordingMock::trace(#EntryPoint);                               \
+        return Error;                                                          \
+      })
+
+// Fails EntryPoint after its mock implementation ran
+#define FAIL_UR_AFTER(EntryPoint, Error)                                       \
+  mock::getCallbacks().set_after_callback(                                     \
+      #EntryPoint, [](void *) -> ur_result_t {                                 \
+        static_assert(Error != UR_RESULT_SUCCESS,                              \
+                      "Injected error must be a failure");                     \
+        return Error;                                                          \
+      })
+
+// Runs Operation, which is expected to throw, and checks the SYCL / UR error
+// codes from the exception. The error message is returned to the user.
+template <typename FnT>
+std::string expectFailure(FnT Operation,
+                          std::optional<ur_result_t> ExpectedUrError,
+                          sycl::errc ExpectedCode = sycl::errc::runtime) {
+  try {
+    Operation();
+  } catch (sycl::exception &E) {
+    EXPECT_EQ(E.code(), ExpectedCode);
+    if (ExpectedUrError) {
+      EXPECT_EQ(sycl::detail::get_ur_error(E),
+                static_cast<int32_t>(*ExpectedUrError));
+      EXPECT_THAT(E.what(), ::testing::HasSubstr(
+                                sycl::detail::codeToString(*ExpectedUrError)));
+    }
+    return E.what();
+  }
+  ADD_FAILURE() << "Expected an exception";
+  return {};
+}
 
 size_t traceCount(std::string_view EntryPoint);
 


### PR DESCRIPTION
Adds unit tests for descriptive error messaging for invalid uses of native graphs. Follow-up to https://github.com/intel/llvm/pull/22710. 