### PR TITLE
[AArch64][Win] Account for the fixed object area when classifying CSR…

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -1391,8 +1391,18 @@ StackOffset AArch64FrameLowering::resolveFrameOffsetReference(
 
   int64_t FPOffset = getFPOffset(MF, ObjectOffset).getFixed();
   int64_t Offset = getStackOffset(MF, ObjectOffset).getFixed();
-  bool isCSR =
-      !isFixed && ObjectOffset >= -((int)AFI->getCalleeSavedStackSize(MFI));
+
+  // The fixed object area sits above the callee-saved area and can grow
+  // large enough to displace it; account for that displacement here so CSR
+  // objects aren't misclassified as locals and addressed via the base
+  // pointer.
+  const int64_t FixedObjectSize = getFixedObjectSize(
+      MF, AFI,
+      Subtarget.isCallingConvWin64(MF.getFunction().getCallingConv(), 
+                                  MF.getFunction().isVarArg()), false);
+  bool isCSR = !isFixed &&
+               ObjectOffset >= -((int64_t)AFI->getCalleeSavedStackSize(MFI) +
+                                 FixedObjectSize);
   bool isSVE = MFI.isScalableStackID(StackID);
 
   StackOffset ZPRStackSize = getZPRStackSize(MF);

--- a/llvm/test/CodeGen/AArch64/wineh-csr-area-spill.ll
+++ b/llvm/test/CodeGen/AArch64/wineh-csr-area-spill.ll
@@ -1,0 +1,61 @@
+; RUN: llc %s --mtriple=aarch64-pc-windows-msvc -o - | FileCheck %s
+
+; Regression test: a stack object inside the callee-saved register area must
+; not be addressed via the base pointer, since its distance from the base
+; pointer varies with the stack realignment padding.
+
+; CHECK-LABEL: "?repro@@YAHH@Z":
+; CHECK:       str x19, [sp, #-64]!
+; CHECK:       add x29, sp, #8
+; CHECK:       sub x[[TMP:[0-9]+]], sp, #64
+; CHECK:       and sp, x[[TMP]], #0xffffffffffffffc0
+; CHECK:       mov x19, sp
+
+; This spill must be x29-relative, not reached through the base pointer, whose
+; distance to it varies with the realignment padding.
+; CHECK:       str wzr, [x29, #20]
+; CHECK-NOT:   [x19, #92]
+
+
+define i32 @"?repro@@YAHH@Z"(i32 %common.ret.op1) personality ptr @__CxxFrameHandler3 {
+entry:
+  %b.sroa.0 = alloca [16 x i32], align 64
+  %e = alloca ptr, align 8
+  %e156 = alloca ptr, align 8
+  %e162 = alloca ptr, align 8
+  call void @llvm.memset.p0.i64(ptr %b.sroa.0, i8 0, i64 0, i1 false)
+  invoke void @"?thrower@@YAXH@Z"(i32 0)
+          to label %common.ret unwind label %catch.dispatch
+
+catch.dispatch:                                   ; preds = %entry
+  %0 = catchswitch within none [label %catch173, label %catch161, label %catch155, label %catch] unwind to caller
+
+catch173:                                         ; preds = %catch.dispatch
+  %1 = catchpad within %0 [ptr null, i32 0, ptr null]
+  catchret from %1 to label %common.ret
+
+catch161:                                         ; preds = %catch.dispatch
+  %2 = catchpad within %0 [ptr null, i32 0, ptr %e162]
+  catchret from %2 to label %common.ret
+
+common.ret:                                       ; preds = %catch, %catch155, %catch161, %catch173, %entry
+  %common.ret.op11 = phi i32 [ 0, %catch155 ], [ 1, %catch ], [ 0, %catch161 ], [ 0, %catch173 ], [ 0, %entry ]
+  ret i32 %common.ret.op11
+
+catch155:                                         ; preds = %catch.dispatch
+  %3 = catchpad within %0 [ptr null, i32 0, ptr %e156]
+  br label %common.ret
+
+catch:                                            ; preds = %catch.dispatch
+  %4 = catchpad within %0 [ptr null, i32 0, ptr %e]
+  catchret from %4 to label %common.ret
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg) #0
+
+declare i32 @__CxxFrameHandler3(...)
+
+declare void @"?thrower@@YAXH@Z"(i32)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3 aria-level="6" style="unicode-bidi: plaintext; margin-top: 0px; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">On <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">aarch64-pc-windows-msvc</code>, a stack object in the callee-saved register area can be addressed through the base pointer instead of the frame pointer, corrupting saved registers — including the return address.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Frame layout, with offsets from the case in the test:</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(18, 19, 20); border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">frame base (SP on entry) ....................... offset    0
   +--------------------------------------+
   | FIXED OBJECT AREA                    |  incoming args, varargs spill,
   |                                      |  UnwindHelp, catch objects
   +--------------------------------------+ ..... offset -208
   | CALLEE-SAVED AREA                    |  13 regs = 104 B, rounded to 112
   |   spill slots in the 8-byte padding  |  &lt;-- offsets -196 .. -216
   |   saved x30 (return address)         |
   +--------------------------------------+ ..... offset -320
   | realignment padding: 0/16/32/48 B    |  &lt;-- size known only at RUNTIME
   +--------------------------------------+ &lt;--- x19 (base pointer)
   | LOCALS (208 bytes)                   |
   +--------------------------------------+
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The realignment padding sits between the two halves, so each has exactly one register giving a compile-time-constant offset: <strong>x29</strong> for everything above it, <strong>x19</strong> for the locals below. Measuring across the padding is impossible.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">resolveFrameOffsetReference()</code> chose between them with:</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(18, 19, 20); border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code class="language-cpp" style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ObjectOffset &gt;= -CalleeSavedStackSize      // i.e. &gt;= -112
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">That assumes the callee-saved area starts at frame offset 0. It doesn't — the fixed object area displaces it to <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">[-320, -208)</code>. So the threshold landed <em>inside the fixed object area</em>, and no callee-saved-area object could pass it:</p><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(18, 19, 20); border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">   offset    0  --+  fixed object area
   offset -112  --+  &lt;-- threshold (inside the fixed object area)
   offset -208  --+  top of the REAL callee-saved area
                  |  entire area below the threshold -&gt; all misclassified
   offset -320  --+  bottom
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The spill slots at <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">-196 .. -216</code> were treated as locals and emitted as <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">[x19, #312/316/328/332]</code> — up to 124 bytes past the end of the 208-byte locals region. That resolves correctly only when the realignment padding is zero; otherwise it drifts down into the saved registers.</p><h3 aria-level="6" style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fix</h3><div class="codeBlockWrapper_-a7MRw" style="position: relative; margin: 8px 0px; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button class="copyButton_CEmTFw copyButton_-a7MRw" title="Copy code" aria-label="Copy code to clipboard" style="color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; background: none 0% 0% / auto repeat scroll padding-box border-box rgb(18, 19, 20); border-color: rgb(42, 43, 44); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; cursor: pointer; opacity: 0; display: flex; border-radius: 4px; justify-content: center; align-items: center; padding: 4px; transition: opacity 0.15s, background 0.15s; position: absolute; top: 4px; right: 4px;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon" class="copyIcon_CEmTFw"><path fill-rule="evenodd" d="M15.988 3.012A2.25 2.25 0 0 1 18 5.25v6.5A2.25 2.25 0 0 1 15.75 14H13.5v-3.379a3 3 0 0 0-.879-2.121l-3.12-3.121a3 3 0 0 0-1.402-.791 2.252 2.252 0 0 1 1.913-1.576A2.25 2.25 0 0 1 12.25 1h1.5a2.25 2.25 0 0 1 2.238 2.012ZM11.5 3.25a.75.75 0 0 1 .75-.75h1.5a.75.75 0 0 1 .75.75v.25h-3v-.25Z" clip-rule="evenodd"></path><path d="M3.5 6A1.5 1.5 0 0 0 2 7.5v9A1.5 1.5 0 0 0 3.5 18h7a1.5 1.5 0 0 0 1.5-1.5v-5.879a1.5 1.5 0 0 0-.44-1.06L8.44 6.439A1.5 1.5 0 0 0 7.378 6H3.5Z"></path></svg></button><pre style="overflow-x: auto; white-space: pre; box-sizing: border-box; border-radius: 4px; max-width: 100%; margin: 0px; padding: 8px;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 0px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">before:  ObjectOffset &gt;= -CalleeSavedStackSize                      // &gt;= -112
after:   ObjectOffset &gt;= -(CalleeSavedStackSize + FixedObjectSize)   // &gt;= -320
</code></pre></div><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Those objects then take the existing <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">isCSR &amp;&amp; hasStackRealignment</code> path and become x29-relative. The change only widens the range, so anything already classified correctly is unaffected — and locals cannot be caught by it, since the frame layout always places them below the callee-saved area.</p><h3 aria-level="6" style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Why it surfaced now</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The discrepancy equals the fixed object area's size. While that area held only <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">UnwindHelp</code> it was 16 bytes — too narrow for anything but the lowest callee-saved slot, and callee-saved spills/restores never consult this classification, since the prologue and epilogue address them directly with computed offsets. #147421 moved one slot per catch clause there, growing the area past the callee-saved size and making the whole area misclassified — including anything else the frame layout packs in, such as a spill slot in the alignment padding.</p><h3 aria-level="6" style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Testing</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>New test</strong> — <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">llvm/test/CodeGen/AArch64/wineh-csr-area-spill.ll</code>, verified both ways:</p>