### PR TITLE
[CI] Don't restrict tests on Linux Arc in precommit

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -162,7 +162,6 @@ jobs:
           - name: Intel / Arc A-Series Graphics
             runner: '["Linux", "arc"]'
             target_devices: level_zero:gpu;opencl:gpu;level_zero_v2:gpu         
-            env: '{"LIT_FILTER":"Matrix/"}'
           - name: Intel / Ponte Vecchio GPU
             runner: '["Linux", "pvc"]'
             target_devices: level_zero:gpu;opencl:gpu;level_zero_v2:gpu


### PR DESCRIPTION
We were only running Matrix tests on Linux arc.

This was introduced by me in https://github.com/intel/llvm/commit/2a85b7735f80f8a1b9d43378feca0620ee28652e, previously we only ran Matrix tests for `dev-igc` but that change accidentally propagated it to the normal Linux Arc run.