### PR TITLE
[SYCL][E2E] Destroy the Level Zero handles interop-direct.cpp owns

### DIFF
--- a/sycl/test-e2e/Adapters/level_zero/interop-direct.cpp
+++ b/sycl/test-e2e/Adapters/level_zero/interop-direct.cpp
@@ -52,6 +52,24 @@ int main() {
   ze_driver_handle_t ZeDriver = driver_handles[0];
   std::cout << "Using default driver, index 0\n";
 
+  // Everything below is created with ownership::keep, so this test owns the
+  // Level Zero handles and must destroy them. Declared before the SYCL interop
+  // objects so that it is destroyed last: the SYCL queues and context must
+  // release the handles before the handles themselves go away.
+  struct ZeHandles {
+    ze_context_handle_t Context = nullptr;
+    ze_command_queue_handle_t Queue = nullptr;
+    ze_command_list_handle_t List = nullptr;
+    ~ZeHandles() {
+      if (List)
+        zeCommandListDestroy(List);
+      if (Queue)
+        zeCommandQueueDestroy(Queue);
+      if (Context)
+        zeContextDestroy(Context);
+    }
+  } ZeOwned;
+
   // Create Context
   ze_context_handle_t ZeContext;
   ze_context_desc_t ctxtDesc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, nullptr, 0};
@@ -59,6 +77,7 @@ int main() {
     std::cout << "Context create failed\n";
     return 1;
   }
+  ZeOwned.Context = ZeContext;
 
   // Create Devices
   uint32_t device_count = 0;
@@ -90,6 +109,7 @@ int main() {
     std::cout << "zeCommandQueueCreate failed\n";
     return 1;
   }
+  ZeOwned.Queue = ZeCommand_queue;
   std::cout << "Commandqueue created: " << ZeCommand_queue << std::endl;
 
   // Create Command List
@@ -100,6 +120,7 @@ int main() {
     std::cout << "zeCommandListCreate failed\n";
     return 1;
   }
+  ZeOwned.List = ZeCommand_list;
   std::cout << "Commandlist created: " << ZeCommand_list << std::endl;
 
   // Interop object creation


### PR DESCRIPTION
## Bug

`Adapters/level_zero/interop-direct.cpp` creates a `ze_context`, a `ze_command_queue` and an immediate `ze_command_list` directly through the Level Zero API and never destroys any of them. All three are handed to SYCL with `ext::oneapi::level_zero::ownership::keep`, so destroying them is the test's own responsibility.

Under an ASan+UBSan runtime build the test fails with **20768 bytes leaked in 14 allocations** (7 per `RUN` line, and there are two). Every frame is in the test's own `main` plus the vendor Level Zero driver — there is no SYCL or Unified Runtime frame anywhere in the report, so this is purely the test leaking:

```
ERROR: LeakSanitizer: detected memory leaks

Direct leak of 14672 byte(s) in 1 object(s) allocated from:
    #0 0x.. in operator new(unsigned long) (/usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.asan-x86_64.so+0x..)
    #1 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #2 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #3 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #4 0x.. in zeCommandListCreateImmediate build-san/_deps/level-zero-loader-src/source/lib/ze_libapi.cpp:3420:12
    #5 0x.. in main (build-san/tools/sycl/test-e2e/Adapters/level_zero/Output/interop-direct.cpp.tmp.out+0x..)
    #6 0x.. in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #7 0x.. in __libc_start_main csu/../csu/libc-start.c:360:3
    #8 0x.. in _start (build-san/tools/sycl/test-e2e/Adapters/level_zero/Output/interop-direct.cpp.tmp.out+0x..)

Indirect leak of 4176 byte(s) in 1 object(s) allocated from:
    #0 0x.. in operator new(unsigned long) (/usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.asan-x86_64.so+0x..)
    #1 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #2 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #3 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #4 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #5 0x.. in zeCommandListCreateImmediate build-san/_deps/level-zero-loader-src/source/lib/ze_libapi.cpp:3420:12
    #6 0x.. in main (build-san/tools/sycl/test-e2e/Adapters/level_zero/Output/interop-direct.cpp.tmp.out+0x..)
    #7 0x.. in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #8 0x.. in __libc_start_main csu/../csu/libc-start.c:360:3
    #9 0x.. in _start (build-san/tools/sycl/test-e2e/Adapters/level_zero/Output/interop-direct.cpp.tmp.out+0x..)

Indirect leak of 1024 byte(s) in 1 object(s) allocated from:
    #0 0x.. in operator new(unsigned long) (/usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.asan-x86_64.so+0x..)
    #1 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #2 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #3 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #4 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
    #5 0x..  (/rdrive/ref/opencl/runtime/linux/oclgpu/Kobuk-26.14.37833.4/libze_intel_gpu.so.1+0x..)
... (11 more groups, same shape, from the second RUN line)

SUMMARY: AddressSanitizer: 20768 byte(s) leaked in 14 allocation(s).
```

## Fix

Destroy the three handles the test owns.

Ordering matters: `InteropContext`, `InteropQueueCQ` and `InteropQueueCL` are function-scope SYCL objects, so their destructors run *after* the closing `return`. Calling `zeContextDestroy` just before `return 0` would therefore tear the context down while SYCL objects still referencing it are alive. A small RAII holder declared *before* the SYCL interop objects is destroyed last, which gives the right order and also covers the eleven early `return 1` paths without reindenting the body.

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>