### PR TITLE
[SYCL] Fix leak of the UR memory object behind `get_native()` on an interop buffer

### DIFF
--- a/sycl/source/detail/buffer_impl.cpp
+++ b/sycl/source/detail/buffer_impl.cpp
@@ -51,11 +51,17 @@ void buffer_impl::addInteropObject(
                   ur::cast<ur_native_handle_t>(MInteropMemObject)) ==
         Handles.end()) {
       adapter_impl &Adapter = getAdapter();
-      Adapter.call<UrApiKind::urMemRetain>(
-          ur::cast<ur_mem_handle_t>(MInteropMemObject));
       ur_native_handle_t NativeHandle = 0;
       Adapter.call<UrApiKind::urMemGetNativeHandle>(MInteropMemObject, nullptr,
                                                     &NativeHandle);
+      // Retain the native handle on the caller's behalf, the same contract
+      // getNativeVector() honours for memory objects that have a MemObjRecord.
+      // Retaining the UR handle instead would leak it: nothing releases that
+      // reference, so the urMemRelease in ~SYCLMemObjT never drops the
+      // reference count to zero and the UR memory object, along with the UR
+      // context it keeps alive, is never freed.
+      if (MInteropContext->getBackend() == backend::opencl)
+        retainOpenCLMemObject(NativeHandle);
       Handles.push_back(NativeHandle);
     }
   }


### PR DESCRIPTION
## Bug

`get_native<backend::opencl>()` on a buffer built by `sycl::make_buffer()` leaks the UR memory object, and with it the UR context that object keeps alive.

`buffer_impl::addInteropObject()` retains the **UR** handle and then hands the caller the **native** handle:

```cpp
adapter_impl &Adapter = getAdapter();
Adapter.call<UrApiKind::urMemRetain>(          // <-- retains the UR handle
    ur::cast<ur_mem_handle_t>(MInteropMemObject));
ur_native_handle_t NativeHandle = 0;
Adapter.call<UrApiKind::urMemGetNativeHandle>(MInteropMemObject, nullptr,
                                              &NativeHandle);
Handles.push_back(NativeHandle);
```

Nothing ever releases that reference, so the `urMemRelease` in `~SYCLMemObjT` (`sycl_mem_obj_t.cpp:175`) only takes the reference count from 2 to 1 and the UR memory object is never freed. Because the OpenCL adapter's `ur_mem_handle_t_` holds a reference on its `ur_context_handle_t_`, the UR context leaks too.

The sibling branch of the very same function already does the right thing for memory objects that have a `MemObjRecord` — `getNativeVector()` retains the *native* handle:

```cpp
// sycl/source/detail/buffer_impl.cpp, getNativeVector()
if (Platform.getBackend() == backend::opencl) {
  retainOpenCLMemObject(Handle);
}
```

That is the actual `get_native()` contract: the caller receives a handle with a reference of its own. `addInteropObject()` gives the caller a handle it does not own, and leaks a UR object in exchange.

## Sanitizer report

```
ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x.. in operator new(unsigned long) (/usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.asan-x86_64.so+0x..)
    #1 0x.. in ur::opencl::ur_mem_handle_t_::makeWithNative(_cl_mem*, ur_context_handle_t_*, ur_mem_handle_t_*&) unified-runtime/source/adapters/opencl/memory.cpp:330:18
    #2 0x.. in ur::opencl::urMemBufferCreateWithNativeHandle(unsigned long, ur_context_handle_t_*, ur_mem_native_properties_t const*, ur_mem_handle_t_**) unified-runtime/source/adapters/opencl/memory.cpp:497:3
    #3 0x.. in urMemBufferCreateWithNativeHandle unified-runtime/source/loader/ur_libapi.cpp:1894:10
    #4 0x.. in call_nocheck<(sycl::_V1::detail::UrApiKind)85, unsigned long &, ur_context_handle_t_ *&, ur_mem_native_properties_t *, ur_mem_handle_t_ **> sycl/source/detail/adapter_impl.hpp:123:11
    #5 0x.. in call<(sycl::_V1::detail::UrApiKind)85, unsigned long &, ur_context_handle_t_ *&, ur_mem_native_properties_t *, ur_mem_handle_t_ **> sycl/source/detail/adapter_impl.hpp:133:16
    #6 0x.. in sycl::_V1::detail::SYCLMemObjT::SYCLMemObjT(unsigned long, sycl::_V1::context const&, bool, sycl::_V1::event, std::unique_ptr<sycl::_V1::detail::SYCLMemObjAllocator, std::default_delete<sycl::_V1::detail::SYCLMemObjAllocator>>) sycl/source/detail/sycl_mem_obj_t.cpp:43:11
    #7 0x.. in sycl::_V1::detail::buffer_impl::buffer_impl(unsigned long, sycl::_V1::context const&, std::unique_ptr<sycl::_V1::detail::SYCLMemObjAllocator, std::default_delete<sycl::_V1::detail::SYCLMemObjAllocator>>, bool, sycl::_V1::event) sycl/source/detail/buffer_impl.hpp:130:9
    #8 0x.. in sycl::_V1::detail::buffer_plain::buffer_plain(unsigned long, sycl::_V1::context const&, std::unique_ptr<sycl::_V1::detail::SYCLMemObjAllocator, std::default_delete<sycl::_V1::detail::SYCLMemObjAllocator>>, bool, sycl::_V1::event const&) sycl/source/buffer.cpp:60:10
    #9 0x.. in sycl::_V1::buffer<int, 1, sycl::_V1::detail::aligned_allocator<int>, void>::buffer<1, void>(unsigned long, sycl::_V1::context const&, bool, sycl::_V1::event const&, sycl::_V1::detail::code_location) (build-san/tools/sycl/test-e2e/Adapters/Output/interop-opencl.cpp.tmp.out+0x..)
    #10 0x.. in sycl::_V1::buffer<int, 1, sycl::_V1::detail::aligned_allocator<int>, void> sycl::_V1::detail::make_buffer_helper<int, 1, sycl::_V1::detail::aligned_allocator<int>>(unsigned long, sycl::_V1::context const&, sycl::_V1::event const&, bool) (build-san/tools/sycl/test-e2e/Adapters/Output/interop-opencl.cpp.tmp.out+0x..)
    #11 0x.. in std::enable_if<detail::InteropFeatureSupportMap<(sycl::_V1::backend)1>::MakeBuffer == true && (sycl::_V1::backend)1 != (sycl::_V1::backend)2, sycl::_V1::buffer<int, 1, sycl::_V1::detail::aligned_allocator<int>, void>>::type sycl::_V1::make_buffer<(sycl::_V1::backend)1, int, 1, sycl::_V1::detail::aligned_allocator<int>>(sycl::_V1::backend_traits<(sycl::_V1::backend)1>::input_type<sycl::_V1::buffer<int, 1, sycl::_V1::detail::aligned_allocator<int>, void>> const&, sycl::_V1::context const&, sycl::_V1::event) (build-san/tools/sycl/test-e2e/Adapters/Output/interop-opencl.cpp.tmp.out+0x..)
    #12 0x.. in main (build-san/tools/sycl/test-e2e/Adapters/Output/interop-opencl.cpp.tmp.out+0x..)
    #13 0x.. in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #14 0x.. in __libc_start_main csu/../csu/libc-start.c:360:3
    #15 0x.. in _start (build-san/tools/sycl/test-e2e/Adapters/Output/interop-opencl.cpp.tmp.out+0x..)
...
SUMMARY: AddressSanitizer: 96 byte(s) leaked in 3 allocation(s).
```

## Fix

Drop the `urMemRetain` and retain the native handle instead, matching what `getNativeVector()` already does two branches away.

This is safe on the native side: `~ur_mem_handle_t_` only calls `clReleaseMemObject` when `IsNativeHandleOwned`, and that is already balanced by the `retainOpenCLMemObject(MemObject)` in `SYCLMemObjT`'s native-handle constructor (`sycl_mem_obj_t.cpp:60`).