### PR TITLE
[SYCL][NFC] Query the last event once per async allocation

### DIFF
--- a/sycl/source/detail/async_alloc.cpp
+++ b/sycl/source/detail/async_alloc.cpp
@@ -114,8 +114,13 @@ __SYCL_EXPORT void *async_malloc(const sycl::queue &q, sycl::usm::alloc kind,
       q,
       [&](sycl::handler &h) {
         // In order queues must wait on the previous event before calling alloc.
-        if (q.is_in_order() && q.ext_oneapi_get_last_event())
-          h.depends_on(q.ext_oneapi_get_last_event().value());
+        // Query the last event once: when the queue has no last event yet, each
+        // call enqueues a fresh marker instead of returning the same one.
+        if (q.is_in_order()) {
+          if (std::optional<sycl::event> LastEvent =
+                  q.ext_oneapi_get_last_event())
+            h.depends_on(*LastEvent);
+        }
         temp = async_malloc(h, kind, size);
       },
       CodeLoc);
@@ -175,8 +180,13 @@ async_malloc_from_pool(const sycl::queue &q, size_t size,
       q,
       [&](sycl::handler &h) {
         // In order queues must wait on the previous event before calling alloc.
-        if (q.is_in_order() && q.ext_oneapi_get_last_event())
-          h.depends_on(q.ext_oneapi_get_last_event().value());
+        // Query the last event once: when the queue has no last event yet, each
+        // call enqueues a fresh marker instead of returning the same one.
+        if (q.is_in_order()) {
+          if (std::optional<sycl::event> LastEvent =
+                  q.ext_oneapi_get_last_event())
+            h.depends_on(*LastEvent);
+        }
         temp = async_malloc_from_pool(h, size, pool);
       },
       CodeLoc);


### PR DESCRIPTION
### The problem

The queue shortcuts for `async_malloc()` / `async_malloc_from_pool()` call
`queue::ext_oneapi_get_last_event()` twice — once to test it, once to read it:

```cpp
if (q.is_in_order() && q.ext_oneapi_get_last_event())
  h.depends_on(q.ext_oneapi_get_last_event().value());
```

`queue_impl::getLastEvent()` does not cache what it returns. When the queue has no last
event recorded it calls `insertMarkerEvent()`, which enqueues a `urEnqueueEventsWait`
marker and does **not** store it back into `LastEventPtr`. The second call therefore
enqueues a *second* marker, and the event produced by the first is destroyed immediately
with its result thrown away. Every async allocation on an in-order queue costs an extra
marker command plus an extra UR round-trip for nothing.

### The fix

Query it once into a local. No functional change: the command still depends on a marker
that orders it after everything previously submitted to the in-order queue.

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>