### PR TITLE
[UR][L0] Don't leak the `zeModuleCreate` build log in `checkUnresolvedSymbols`

### DIFF
--- a/unified-runtime/source/adapters/level_zero/common/program.cpp
+++ b/unified-runtime/source/adapters/level_zero/common/program.cpp
@@ -46,7 +46,19 @@ checkUnresolvedSymbols(ze_module_handle_t ZeModule,
   // As a side effect, this will return the error
   // ZE_RESULT_ERROR_MODULE_LINK_FAILURE if there are any unresolved symbols.
   if (ZeModuleProps.flags & ZE_MODULE_PROPERTY_FLAG_IMPORTS) {
-    return ZE_CALL_NOCHECK(zeModuleDynamicLink, (1, &ZeModule, ZeBuildLog));
+    // zeModuleDynamicLink writes a fresh handle into its log argument, so
+    // passing ZeBuildLog directly would drop the handle zeModuleCreate already
+    // produced and leak that driver object. Keep the link log, because it is
+    // the one carrying the unresolved symbol diagnostics that
+    // urProgramGetBuildInfo reports, and destroy the create log here.
+    ze_module_build_log_handle_t ZeLinkLog{};
+    ZeResult = ZE_CALL_NOCHECK(zeModuleDynamicLink, (1, &ZeModule, &ZeLinkLog));
+    if (ZeLinkLog) {
+      if (*ZeBuildLog)
+        ZE_CALL_NOCHECK(zeModuleBuildLogDestroy, (*ZeBuildLog));
+      *ZeBuildLog = ZeLinkLog;
+    }
+    return ZeResult;
   }
   return ZE_RESULT_SUCCESS;
 }


### PR DESCRIPTION
`phLinkLog` is an `[out]` parameter, so the driver *stores* a newly created link
log there. Both callers (`urProgramBuildExp`, `urProgramLinkExp`) reach this point
with the handle `zeModuleCreate` already wrote into that same variable, so the
create log handle is overwritten. Only one handle per device is tracked
(`DeviceData.ZeBuildLog`), so the overwritten one can never be passed to
`zeModuleBuildLogDestroy` and the driver object leaks.

## Fix

Link into a local handle, and once the driver has produced a link log, destroy the
create log and install the link log in its place.
The user-visible build log is unchanged: before the fix the link log was already
the handle that reached the caller, it simply came at the cost of an orphaned
create log.

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>