### PR TITLE
[Driver] Fold all new-driver defaults into getUseNewOffloadingDriver()

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -901,7 +901,8 @@ public:
 
   bool getOffloadStaticLibSeen() const { return OffloadStaticLibSeen; };
 
-  /// getUseNewOffloadingDriver - use the new offload driver for OpenMP.
+  /// getUseNewOffloadingDriver - whether the new offload driver is in use
+  /// for the current compilation (OpenMP, CUDA, HIP, or -foffload-via-llvm).
   bool getUseNewOffloadingDriver() const { return UseNewOffloadingDriver; };
 
   /// isSYCLDefaultTripleImplied - The default SYCL triple (spir64) has been

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2169,11 +2169,17 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
   // Use new offloading path for OpenMP.  This is disabled as the SYCL
   // offloading path is not properly setup to use the updated device linking
   // scheme.
-  if ((C->isOffloadingHostKind(Action::OFK_OpenMP) &&
-       TranslatedArgs->hasFlag(options::OPT_fopenmp_new_driver,
-                               options::OPT_no_offload_new_driver, true)) ||
+  //
+  // Mirrors the default computed independently in BuildActions() for
+  // UseNewOffloadingDriver, so that getUseNewOffloadingDriver() is the
+  // single source of truth for every consumer (see BuildActions()).
+  if (C->isOffloadingHostKind(Action::OFK_OpenMP) ||
+      TranslatedArgs->hasFlag(options::OPT_foffload_via_llvm,
+                              options::OPT_fno_offload_via_llvm, false) ||
       TranslatedArgs->hasFlag(options::OPT_offload_new_driver,
-                              options::OPT_no_offload_new_driver, false))
+                              options::OPT_no_offload_new_driver,
+                              (C->isOffloadingHostKind(Action::OFK_Cuda) ||
+                               C->isOffloadingHostKind(Action::OFK_HIP))))
     setUseNewOffloadingDriver();
 
   bool UseModulesDriver = C->getArgs().hasFlag(
@@ -7349,14 +7355,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     }
   }
 
-  bool UseNewOffloadingDriver =
-      C.isOffloadingHostKind(Action::OFK_OpenMP) ||
-      Args.hasFlag(options::OPT_foffload_via_llvm,
-                   options::OPT_fno_offload_via_llvm, false) ||
-      Args.hasFlag(options::OPT_offload_new_driver,
-                   options::OPT_no_offload_new_driver,
-                   (C.isOffloadingHostKind(Action::OFK_Cuda) ||
-                    C.isOffloadingHostKind(Action::OFK_HIP)));
+  bool UseNewOffloadingDriver = getUseNewOffloadingDriver();
   bool HIPRDCDeviceOnlyFatBin =
       UseNewOffloadingDriver && C.isOffloadingHostKind(Action::OFK_HIP) &&
       offloadDeviceOnly() && Args.hasArg(options::OPT_hip_link) &&

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6304,10 +6304,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-emit-llvm-uselists");
 
     if (IsUsingLTO) {
-      bool IsUsingOffloadNewDriver = Args.hasFlag(
-          options::OPT_offload_new_driver, options::OPT_no_offload_new_driver,
-          (C.isOffloadingHostKind(Action::OFK_Cuda) ||
-           C.isOffloadingHostKind(Action::OFK_HIP)));
+      bool IsUsingOffloadNewDriver = D.getUseNewOffloadingDriver();
       Arg *SYCLSplitMode =
           Args.getLastArg(options::OPT_fsycl_device_code_split_EQ);
       const Arg *LTOArg = Args.getLastArg(options::OPT_foffload_lto,


### PR DESCRIPTION
BuildActions() still separately recomputed the new-driver default (OpenMP, -foffload-via-llvm, CUDA/HIP) instead of reading the member set by setUseNewOffloadingDriver(), so the two could disagree and any other consumer of getUseNewOffloadingDriver() (e.g. the SYCL/LTO check) could see a stale answer. The divergence traces to 57ef29f2835eb (2022-09-06, made BuildActions()'s OpenMP check unconditional) and 80525dfcde5bf (2024-08-12, added -foffload-via-llvm to BuildActions() only), neither of which updated the member set in BuildCompilation. Upstream llvm-project has since removed the legacy offloading driver entirely (--offload-new-driver/--no-offload-new-driver are now no-ops), so this divergence no longer exists there; it persists only in intel/llvm, which still carries the old dual-driver machinery for SYCL. Move all the defaults into setUseNewOffloadingDriver() and have BuildActions() and the LTO check both just read the member.

No new test: the fold doesn't change any observable driver output today.