### PR TITLE
Revert "[SYCL] Disable sycl-cts/test_multi_ptr (#22096)"

### DIFF
--- a/sycl/cts_exclude_filter/LINUX_L0_GPU
+++ b/sycl/cts_exclude_filter/LINUX_L0_GPU
@@ -1,4 +1,2 @@
 # Please use "#" to add comments here.
 # Do not delete the file even if it's empty.
-# https://github.com/intel/llvm/issues/22095
-multi_ptr


### PR DESCRIPTION
This reverts commit 89b94d6369dfc6674f9e89fdb3b41ebb01a1de49.

The test started to pass again after L0 driver update to v26.31.39395.13 -
see #23024 and https://github.com/intel/llvm/actions/runs/34228635116.

Fixes: #22095