### PR TITLE
[SYCL] Disable vulkan_sycl_buffer_binary_semaphore on linux

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_buffer_binary_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_sycl_buffer_binary_semaphore.cpp
@@ -7,8 +7,11 @@
 
 // RUN: %{build} %link-vulkan -o %t.out %if target-spir %{ -Wno-ignored-attributes %}
 // RUN: %{run} %t.out --no-sem
-// RUN: %{run} %t.out --dual-sem
-// RUN: %{run} %t.out
+
+// Binary semaphore does not work on Linux issue is in driver
+// related to CMPLRLLVM-78008.
+// RUN-IF: !linux %{run} %t.out --dual-sem
+// RUN-IF: !linux %{run} %t.out
 
 // clang-format off
 /*


### PR DESCRIPTION
This PR disables `vulkan_sycl_buffer_binary_semaphore` because binary semaphore sharing on linux is broken and requires an architectural redesign.

Related to: CMPLRLLVM-78008