### PR TITLE
[SYCL] Add sycl_khr_properties queue properties

### DIFF
--- a/sycl/include/sycl/khr/properties.hpp
+++ b/sycl/include/sycl/khr/properties.hpp
@@ -34,6 +34,10 @@
 
 namespace sycl {
 inline namespace _V1 {
+// Forward declarations of the SYCL classes that the named properties below
+// register against (via is_property_key_for). Only incomplete types are needed.
+class queue;
+
 namespace khr {
 
 template <typename... EncodedProperties> class __SYCL_EBO properties;
@@ -290,6 +294,38 @@ template <typename... Properties>
 properties(Properties... props) -> properties<Properties...>;
 
 using empty_properties_t = decltype(properties{});
+
+//===----------------------------------------------------------------------===//
+// Named properties
+//
+// The concrete properties defined by this extension live here (one header for
+// the whole extension). Each property registers the classes it applies to via
+// is_property_key_for. Constructor/overload support for these lives in the
+// respective SYCL object headers (e.g. queue.hpp).
+//===----------------------------------------------------------------------===//
+
+namespace property {
+namespace key {
+struct enable_profiling : detail::runtime_property_key {};
+struct in_order : detail::runtime_property_key {};
+} // namespace key
+
+// Queue properties.
+struct enable_profiling : detail::runtime_property<key::enable_profiling> {
+  constexpr enable_profiling(bool v = true) : value{v} {}
+  bool value;
+};
+struct in_order : detail::runtime_property<key::in_order> {
+  constexpr in_order(bool v = true) : value{v} {}
+  bool value;
+};
+} // namespace property
+
+template <>
+struct is_property_key_for<property::key::enable_profiling, queue>
+    : std::true_type {};
+template <>
+struct is_property_key_for<property::key::in_order, queue> : std::true_type {};
 
 } // namespace khr
 } // namespace _V1

--- a/sycl/include/sycl/khr/properties.hpp
+++ b/sycl/include/sycl/khr/properties.hpp
@@ -279,8 +279,13 @@ public:
   }
 
   // Runtime (or hybrid) key: return a copy of the stored property.
+  //
+  // The dummy `int` parameter gives this overload a parameter list distinct
+  // from the static compile-time overload above. Without it, MSVC rejects the
+  // two overloads (static vs non-static) as differing only in return type
+  // (C2686) during class definition, before the enable_if SFINAE applies.
   template <typename PropertyKey>
-  constexpr auto get_property() const -> std::enable_if_t<
+  constexpr auto get_property(int = 0) const -> std::enable_if_t<
       !is_property_key_compile_time_v<PropertyKey>,
       property::detail::property_of_key_t<PropertyKey, EncodedProperties...>> {
     return static_cast<const property::detail::property_of_key_t<

--- a/sycl/include/sycl/khr/properties.hpp
+++ b/sycl/include/sycl/khr/properties.hpp
@@ -38,6 +38,11 @@ namespace khr {
 
 template <typename... EncodedProperties> class __SYCL_EBO properties;
 
+// The property-definition infrastructure lives in `sycl::khr::property::detail`
+// (not `sycl::khr::detail`) so it does not shadow `sycl::detail` for
+// unqualified `detail::` lookups in sibling headers under `namespace
+// sycl::khr`.
+namespace property {
 namespace detail {
 
 //===----------------------------------------------------------------------===//
@@ -77,13 +82,14 @@ inline constexpr bool __detail_has_runtime_value =
 
 // Base for a runtime property key (all of the property's values are supplied at
 // runtime). Usage:
-//   struct my_key : detail::runtime_property_key {};
-//   struct my_prop : detail::runtime_property<my_key> { int value; ... };
+//   struct my_key : property::detail::runtime_property_key {};
+//   struct my_prop : property::detail::runtime_property<my_key> { int value;
+//   ... };
 struct runtime_property_key : property_key_tag {};
 template <typename Key> struct runtime_property : property_base<Key> {};
 
 // Base for a compile-time property key with a single non-type value. Usage:
-//   struct my_key : detail::constant_value_property_key {};
+//   struct my_key : property::detail::constant_value_property_key {};
 //   template <int V>
 //   inline constexpr my_key::__detail_property_t<my_key, int, V> my_prop;
 struct constant_value_property_key : compile_time_property_key_tag {
@@ -94,7 +100,7 @@ struct constant_value_property_key : compile_time_property_key_tag {
 };
 
 // Base for a compile-time property key with a single type value. Usage:
-//   struct my_key : detail::constant_type_property_key {};
+//   struct my_key : property::detail::constant_type_property_key {};
 //   template <typename T>
 //   inline constexpr my_key::__detail_property_t<my_key, T> my_prop;
 struct constant_type_property_key : compile_time_property_key_tag {
@@ -107,8 +113,9 @@ struct constant_type_property_key : compile_time_property_key_tag {
 // Base for a hybrid property key (some values compile-time, some runtime). The
 // key is a runtime key (the property carries runtime data and is stored).
 // Usage:
-//   struct my_key : detail::hybrid_property_key {};
-//   template <int X> struct my_prop : detail::hybrid_property<my_key> {
+//   struct my_key : property::detail::hybrid_property_key {};
+//   template <int X> struct my_prop : property::detail::hybrid_property<my_key>
+//   {
 //     static constexpr int x = X; int y; constexpr my_prop(int y):y{y}{} };
 struct hybrid_property_key : property_key_tag {};
 template <typename Key> struct hybrid_property : property_base<Key> {};
@@ -162,25 +169,36 @@ struct build_storage<property_storage<Sel...>, P, Rest...>
 template <typename... All>
 using storage_for = typename build_storage<property_storage<>, All...>::type;
 
+// True if T is a khr::properties list. Used to exclude the list itself from
+// is_property (the list privately inherits its properties, so is_base_of would
+// otherwise report it as a property).
+template <typename> struct is_properties_list : std::false_type {};
+template <typename... Ps>
+struct is_properties_list<properties<Ps...>> : std::true_type {};
+
 } // namespace detail
+} // namespace property
 
 //===----------------------------------------------------------------------===//
 // Property traits
 //===----------------------------------------------------------------------===//
 
 template <typename T>
-struct is_property : std::is_base_of<detail::property_tag, T> {};
+struct is_property
+    : std::bool_constant<std::is_base_of_v<property::detail::property_tag, T> &&
+                         !property::detail::is_properties_list<T>::value> {};
 template <typename T>
 inline constexpr bool is_property_v = is_property<T>::value;
 
 template <typename T>
-struct is_property_key : std::is_base_of<detail::property_key_tag, T> {};
+struct is_property_key
+    : std::is_base_of<property::detail::property_key_tag, T> {};
 template <typename T>
 inline constexpr bool is_property_key_v = is_property_key<T>::value;
 
 template <typename T>
 struct is_property_key_compile_time
-    : std::is_base_of<detail::compile_time_property_key_tag, T> {};
+    : std::is_base_of<property::detail::compile_time_property_key_tag, T> {};
 template <typename T>
 inline constexpr bool is_property_key_compile_time_v =
     is_property_key_compile_time<T>::value;
@@ -219,8 +237,8 @@ inline constexpr bool is_property_list_for_v =
 
 template <typename... EncodedProperties>
 class __SYCL_EBO properties
-    : private detail::storage_for<EncodedProperties...> {
-  using storage_t = detail::storage_for<EncodedProperties...>;
+    : private property::detail::storage_for<EncodedProperties...> {
+  using storage_t = property::detail::storage_for<EncodedProperties...>;
 
   static_assert((is_property_v<EncodedProperties> && ...),
                 "Template arguments of khr::properties must be properties.");
@@ -251,18 +269,18 @@ public:
   template <typename PropertyKey>
   static constexpr auto get_property() -> std::enable_if_t<
       is_property_key_compile_time_v<PropertyKey>,
-      detail::property_of_key_t<PropertyKey, EncodedProperties...>> {
-    return detail::property_of_key_t<PropertyKey, EncodedProperties...>{};
+      property::detail::property_of_key_t<PropertyKey, EncodedProperties...>> {
+    return property::detail::property_of_key_t<PropertyKey,
+                                               EncodedProperties...>{};
   }
 
   // Runtime (or hybrid) key: return a copy of the stored property.
   template <typename PropertyKey>
   constexpr auto get_property() const -> std::enable_if_t<
       !is_property_key_compile_time_v<PropertyKey>,
-      detail::property_of_key_t<PropertyKey, EncodedProperties...>> {
-    return static_cast<
-        const detail::property_of_key_t<PropertyKey, EncodedProperties...> &>(
-        *this);
+      property::detail::property_of_key_t<PropertyKey, EncodedProperties...>> {
+    return static_cast<const property::detail::property_of_key_t<
+        PropertyKey, EncodedProperties...> &>(*this);
   }
 };
 

--- a/sycl/include/sycl/property_list.hpp
+++ b/sycl/include/sycl/property_list.hpp
@@ -26,6 +26,7 @@ template <typename... PropsT> class accessor_property_list;
 namespace detail {
 class PropertyValidator;
 class SYCLMemObjT;
+class PropertyListBuilder;
 } // namespace detail
 
 /// Objects of the property_list class are containers for the SYCL properties
@@ -71,6 +72,7 @@ private:
   friend class ext::oneapi::accessor_property_list;
   friend class detail::PropertyValidator;
   friend class detail::SYCLMemObjT;
+  friend class detail::PropertyListBuilder;
 };
 
 namespace detail {
@@ -81,6 +83,24 @@ public:
                                  std::function<bool(int)> FunctionForData) {
     PropList.checkPropsAndThrow(std::move(FunctionForDataless),
                                 std::move(FunctionForData));
+  }
+};
+
+// Builds a property_list at runtime. Used to translate runtime-valued
+// sycl_khr_properties into an old-style property_list.
+class PropertyListBuilder {
+  std::bitset<DataLessPropKind::DataLessPropKindSize> MDataLessProps;
+  std::vector<std::shared_ptr<PropertyWithDataBase>> MPropsWithData;
+
+public:
+  template <typename DataLessPropT> void add() {
+    MDataLessProps.set(DataLessPropT::getKind());
+  }
+  void add(std::shared_ptr<PropertyWithDataBase> Prop) {
+    MPropsWithData.push_back(std::move(Prop));
+  }
+  property_list finalize() {
+    return property_list(MDataLessProps, MPropsWithData);
   }
 };
 } // namespace detail

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -38,7 +38,9 @@
 #include <sycl/info/queue.hpp>                    // for is_queue_info_...
 #include <sycl/kernel.hpp>                        // for auto_name
 #include <sycl/kernel_handler.hpp>                // for kernel_handler
+#include <sycl/khr/properties.hpp>                // for khr properties
 #include <sycl/nd_range.hpp>                      // for nd_range
+#include <sycl/properties/queue_properties.hpp>   // for property::queue::*
 #include <sycl/property_list.hpp>                 // for property_list
 #include <sycl/range.hpp>                         // for range
 #include <sycl/sycl_span.hpp>                     // for sycl::span
@@ -166,7 +168,7 @@ auto submit_kernel_direct_single_task(
 
 } // namespace detail
 
-namespace ext ::oneapi ::experimental {
+namespace ext::oneapi::experimental {
 // State of a queue with regards to graph recording,
 // returned by info::queue::state
 enum class queue_state { executing, recording };
@@ -355,6 +357,110 @@ public:
   /// \param PropList is a list of properties for queue construction.
   queue(const context &SyclContext, const device &SyclDevice,
         const async_handler &AsyncHandler, const property_list &PropList = {});
+
+#ifdef __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS
+  // sycl_khr_properties queue constructors. These mirror the property_list
+  // constructors above but accept a khr property or property list, translating
+  // it to the corresponding old-style property_list. PropertyOrList is not
+  // defaulted: the property_list constructors already cover the no-property
+  // case, and defaulting here would make e.g. `queue q{}` ambiguous.
+private:
+  template <typename PropertyOrList>
+  static constexpr bool KhrPropsForQueue =
+      khr::is_property_for_v<PropertyOrList, queue> ||
+      khr::is_property_list_for_v<PropertyOrList, queue>;
+
+  // Translate a khr property or property list into an old-style property_list.
+  template <typename PropertyOrList>
+  static property_list khrToPropertyList(const PropertyOrList &Props) {
+    if constexpr (khr::is_property_v<PropertyOrList>) {
+      return khrToPropertyList(khr::properties{Props});
+    } else {
+      detail::PropertyListBuilder Builder;
+      if constexpr (PropertyOrList::template has_property<
+                        khr::property::key::in_order>())
+        if (Props.template get_property<khr::property::key::in_order>().value)
+          Builder.template add<property::queue::in_order>();
+      if constexpr (PropertyOrList::template has_property<
+                        khr::property::key::enable_profiling>())
+        if (Props.template get_property<khr::property::key::enable_profiling>()
+                .value)
+          Builder.template add<property::queue::enable_profiling>();
+      return Builder.finalize();
+    }
+  }
+
+public:
+  template <typename PropertyOrList,
+            typename = std::enable_if_t<KhrPropsForQueue<PropertyOrList>>>
+  explicit queue(PropertyOrList props) : queue(khrToPropertyList(props)) {}
+
+  template <typename PropertyOrList,
+            typename = std::enable_if_t<KhrPropsForQueue<PropertyOrList>>>
+  explicit queue(const async_handler &AsyncHandler, PropertyOrList props)
+      : queue(AsyncHandler, khrToPropertyList(props)) {}
+
+  template <typename DeviceSelector,
+            typename =
+                detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>,
+            typename PropertyOrList,
+            typename = std::enable_if_t<KhrPropsForQueue<PropertyOrList>>>
+  explicit queue(const DeviceSelector &deviceSelector, PropertyOrList props)
+      : queue(deviceSelector, khrToPropertyList(props)) {}
+
+  template <typename DeviceSelector,
+            typename =
+                detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>,
+            typename PropertyOrList,
+            typename = std::enable_if_t<KhrPropsForQueue<PropertyOrList>>>
+  explicit queue(const DeviceSelector &deviceSelector,
+                 const async_handler &AsyncHandler, PropertyOrList props)
+      : queue(deviceSelector, AsyncHandler, khrToPropertyList(props)) {}
+
+  template <typename PropertyOrList,
+            typename = std::enable_if_t<KhrPropsForQueue<PropertyOrList>>>
+  explicit queue(const device &SyclDevice, PropertyOrList props)
+      : queue(SyclDevice, khrToPropertyList(props)) {}
+
+  template <typename PropertyOrList,
+            typename = std::enable_if_t<KhrPropsForQueue<PropertyOrList>>>
+  explicit queue(const device &SyclDevice, const async_handler &AsyncHandler,
+                 PropertyOrList props)
+      : queue(SyclDevice, AsyncHandler, khrToPropertyList(props)) {}
+
+  template <typename DeviceSelector,
+            typename =
+                detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>,
+            typename PropertyOrList,
+            typename = std::enable_if_t<KhrPropsForQueue<PropertyOrList>>>
+  explicit queue(const context &SyclContext,
+                 const DeviceSelector &deviceSelector, PropertyOrList props)
+      : queue(SyclContext, deviceSelector, khrToPropertyList(props)) {}
+
+  template <typename DeviceSelector,
+            typename =
+                detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>,
+            typename PropertyOrList,
+            typename = std::enable_if_t<KhrPropsForQueue<PropertyOrList>>>
+  explicit queue(const context &SyclContext,
+                 const DeviceSelector &deviceSelector,
+                 const async_handler &AsyncHandler, PropertyOrList props)
+      : queue(SyclContext, deviceSelector, AsyncHandler,
+              khrToPropertyList(props)) {}
+
+  template <typename PropertyOrList,
+            typename = std::enable_if_t<KhrPropsForQueue<PropertyOrList>>>
+  explicit queue(const context &SyclContext, const device &SyclDevice,
+                 PropertyOrList props)
+      : queue(SyclContext, SyclDevice, khrToPropertyList(props)) {}
+
+  template <typename PropertyOrList,
+            typename = std::enable_if_t<KhrPropsForQueue<PropertyOrList>>>
+  explicit queue(const context &SyclContext, const device &SyclDevice,
+                 const async_handler &AsyncHandler, PropertyOrList props)
+      : queue(SyclContext, SyclDevice, AsyncHandler, khrToPropertyList(props)) {
+  }
+#endif // __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS
 
   /// Constructs a SYCL queue with an optional async_handler from an OpenCL
   /// cl_command_queue.
@@ -3624,6 +3730,15 @@ public:
   /// to complete unlike wait().
   ///
   void khr_flush() const;
+
+#ifdef __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS
+  /// Returns true only if this queue was constructed with profiling enabled.
+  ///
+  /// Equivalent to has_property<property::queue::enable_profiling>().
+  bool khr_is_profiling_enabled() const {
+    return has_property<property::queue::enable_profiling>();
+  }
+#endif
 
   std::optional<event> ext_oneapi_get_last_event() const {
     return static_cast<std::optional<event>>(ext_oneapi_get_last_event_impl());

--- a/sycl/test/extensions/khr_properties/properties.cpp
+++ b/sycl/test/extensions/khr_properties/properties.cpp
@@ -13,7 +13,7 @@
 #error "SYCL_KHR_PROPERTIES feature-test macro is not defined"
 #endif
 
-namespace kd = sycl::khr::detail;
+namespace kd = sycl::khr::property::detail;
 using namespace sycl::khr;
 
 struct MyClass {};

--- a/sycl/test/extensions/khr_properties/properties_layout.cpp
+++ b/sycl/test/extensions/khr_properties/properties_layout.cpp
@@ -12,7 +12,7 @@
 #define __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS
 #include <sycl/khr/properties.hpp>
 
-namespace kd = sycl::khr::detail;
+namespace kd = sycl::khr::property::detail;
 using namespace sycl::khr;
 
 struct rt1_key : kd::runtime_property_key {};

--- a/sycl/test/extensions/khr_properties/properties_negative.cpp
+++ b/sycl/test/extensions/khr_properties/properties_negative.cpp
@@ -9,7 +9,7 @@
 #define __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS
 #include <sycl/khr/properties.hpp>
 
-namespace kd = sycl::khr::detail;
+namespace kd = sycl::khr::property::detail;
 using namespace sycl::khr;
 
 struct rt_key : kd::property_key_tag {};

--- a/sycl/test/extensions/khr_properties/queue_properties.cpp
+++ b/sycl/test/extensions/khr_properties/queue_properties.cpp
@@ -1,0 +1,40 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+//
+// Tests the sycl_khr_properties queue properties (enable_profiling, in_order):
+// their traits, that a queue can be constructed with them, and the queue
+// members is_in_order / khr_is_profiling_enabled.
+
+#define __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS
+#include <sycl/sycl.hpp>
+
+namespace kp = sycl::khr::property;
+using namespace sycl::khr;
+
+struct OtherClass {};
+
+// Traits: both are runtime queue properties.
+static_assert(is_property_v<kp::enable_profiling> &&
+              is_property_v<kp::in_order>);
+static_assert(is_property_key_v<kp::key::enable_profiling> &&
+              is_property_key_v<kp::key::in_order>);
+static_assert(!is_property_key_compile_time_v<kp::key::enable_profiling> &&
+              !is_property_key_compile_time_v<kp::key::in_order>);
+static_assert(is_property_for_v<kp::enable_profiling, sycl::queue> &&
+              is_property_for_v<kp::in_order, sycl::queue>);
+static_assert(!is_property_for_v<kp::enable_profiling, OtherClass>);
+
+// A property list is not itself a property.
+static_assert(!is_property_v<properties<kp::enable_profiling>>);
+static_assert(is_property_list_for_v<
+              decltype(properties{kp::enable_profiling{true}, kp::in_order{}}),
+              sycl::queue>);
+
+// A queue can be constructed from a single khr property or a khr property list.
+void ctors() {
+  sycl::queue q1{kp::enable_profiling{true}};
+  sycl::queue q2{kp::in_order{false}};
+  sycl::queue q3{properties{kp::enable_profiling{true}, kp::in_order{true}}};
+  (void)q1.is_in_order();
+  (void)q1.khr_is_profiling_enabled();
+}

--- a/sycl/test/khr/include_sycl_with_unfinished_khr.cpp
+++ b/sycl/test/khr/include_sycl_with_unfinished_khr.cpp
@@ -1,0 +1,9 @@
+// Including <sycl/sycl.hpp> with the unfinished KHR extensions enabled must
+// compile cleanly. This guards against namespace shadowing where KHR headers
+// in namespace sycl::khr use bare `detail::Foo` intending sycl::detail::Foo,
+// but resolve to a sycl::khr::detail defined by another KHR header.
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+#define __DPCPP_ENABLE_UNFINISHED_KHR_EXTENSIONS
+#include <sycl/sycl.hpp>
+int main() {}


### PR DESCRIPTION
Implements the queue portion of sycl_khr_properties: the properties
`khr::property::enable_profiling` and `khr::property::in_order`, the queue
constructor overloads accepting a khr property or property list, and
`queue::khr_is_profiling_enabled()` (`is_in_order()` already existed). The
new-style properties are translated to the existing `property::queue::*`.

KHR Link: https://github.com/KhronosGroup/SYCL-Docs/pull/980