### PR TITLE
[SYCL][NFC] Update arc-forwarded-lambda-call.mm for downstream lambda mangling

### DIFF
--- a/clang/test/CodeGenObjCXX/arc-forwarded-lambda-call.mm
+++ b/clang/test/CodeGenObjCXX/arc-forwarded-lambda-call.mm
@@ -50,8 +50,8 @@ struct Strong {
 
 using FP = Strong (*)();
 FP test2_fp = []() -> Strong { return Strong{}; };
-// CHECK-LABEL: define internal { i32, ptr } @"_ZN3$_38__invokeEv"(
-// CHECK: %call = call { i32, ptr } @"_ZNK3$_3clEv"
+// CHECK-LABEL: define internal { i32, ptr } @"_ZN8test2_fpM3$_38__invokeEv"(
+// CHECK: %call = call { i32, ptr } @"_ZNK8test2_fpM3$_3clEv"
 // CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 8 %retval, ptr align 8 %coerce, i64 16, i1 false)
 // CHECK-NEXT: [[RET:%.*]] = load { i32, ptr }, ptr %retval
 // CHECK-NEXT: ret { i32, ptr } [[RET]]


### PR DESCRIPTION
Upstream PR llvm/llvm-project#219090 ("[CodeGen] Relax an overly strict assert in EmitAggregateCopy") added a new case to this test using a lambda in a namespace-scope variable initializer, with upstream's expected mangling:
```
 - upstream: _ZN3$_38__invokeEv / _ZNK3$_3clEv
 - sycl-web: _ZN8test2_fpM3$_38__invokeEv / _ZNK8test2_fpM3$_3clEv
```
 
If I saw correctly sycl-web mangles these differently because of #20176 ("[SYCL] Fix Lambda Mangling in Namespace-Scope Variable Initializers"), an cherry-pick of the still unlanded community PR llvm/llvm-project#159115.

Fixes [CMPLRLLVM-78191](https://jira.devtools.intel.com/browse/CMPLRLLVM-78191)