### PR TITLE
[SYCL][lit] Fix four XPASSing tests with libc++

### DIFF
--- a/sycl/test/basic_tests/group.cpp
+++ b/sycl/test/basic_tests/group.cpp
@@ -7,9 +7,6 @@
 // RUN: not --crash %t.out get_local_id_3d
 // RUN: not --crash %t.out get_local_linear_id_3d
 
-// XFAIL: libcxx
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
-
 //==--------------- group.cpp - SYCL group test ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/id.cpp
+++ b/sycl/test/basic_tests/id.cpp
@@ -3,9 +3,6 @@
 // RUN: %clangxx -D__SYCL_DISABLE_ID_TO_INT_CONV__ -fsycl %s -o %t_dis.out
 // RUN: %t_dis.out
 
-// XFAIL: libcxx
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
-
 //==--------------- id.cpp - SYCL id test ----------------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/item.cpp
+++ b/sycl/test/basic_tests/item.cpp
@@ -1,7 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %t.out
-// XFAIL: libcxx
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 //==--------------- item.cpp - SYCL item test ------------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/range.cpp
+++ b/sycl/test/basic_tests/range.cpp
@@ -1,7 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %t.out
-// XFAIL: libcxx
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/19616
 //==--------------- range.cpp - SYCL range test ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
XPASSing now, see https://github.com/intel/llvm/actions/runs/34557495521/job/103133167949.
I updated the GH issue.