### PR TITLE
Revert "[SYCL][Windows] Don't do backend calls in DLL_PROCESS_DETACH (#22277)"

### DIFF
--- a/sycl/source/detail/adapter_impl.cpp
+++ b/sycl/source/detail/adapter_impl.cpp
@@ -14,10 +14,6 @@
 
 #include "adapter_impl.hpp"
 
-#ifdef _WIN32
-#include <windows.h>
-#endif
-
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
@@ -42,16 +38,6 @@ void adapter_impl::ur_failed_throw_exception(sycl::errc errc,
   throw set_ur_error(sycl::exception(sycl::make_error_code(errc), message),
                      ur_result);
 }
-
-#ifdef _WIN32
-bool isProcessShuttingDown() {
-  using RtlDllShutdownInProgress_t = BOOLEAN(WINAPI *)();
-  static RtlDllShutdownInProgress_t FnPtr =
-      reinterpret_cast<RtlDllShutdownInProgress_t>(GetProcAddress(
-          GetModuleHandleA("ntdll.dll"), "RtlDllShutdownInProgress"));
-  return FnPtr && FnPtr();
-}
-#endif
 
 } // namespace detail
 } // namespace _V1

--- a/sycl/source/detail/adapter_impl.hpp
+++ b/sycl/source/detail/adapter_impl.hpp
@@ -236,15 +236,6 @@ private:
   UrFuncPtrMapT UrFuncPtrs;
 }; // class adapter_impl
 
-#ifdef _WIN32
-// Returns true once ExitProcess()/LdrShutdownProcess() has begun for the
-// current process, regardless of which module's context this is called
-// from. Unlike DllMain's lpReserved parameter, this is safe to query from
-// code that is not itself running inside a DllMain callback (e.g. an
-// atexit() callback registered by a separately-loaded DLL).
-bool isProcessShuttingDown();
-#endif
-
 template <typename URResource> class Managed {
   static constexpr auto Release = []() constexpr {
     if constexpr (std::is_same_v<URResource, ur_program_handle_t>)
@@ -299,17 +290,6 @@ public:
       return;
 
     try {
-#ifdef _WIN32
-      if (Adapter->getBackend() != backend::ext_oneapi_level_zero &&
-          isProcessShuttingDown()) {
-        // The process is exiting and it is unsafe to make this backend call
-        // (e.g. this destructor is running from a separately-loaded DLL's
-        // own atexit teardown after ExitProcess has begun). Leak the
-        // resource rather than risk a crash; the OS will reclaim it.
-        R = nullptr;
-        return;
-      }
-#endif
       Adapter->call<Release>(R);
     } catch (std::exception &e) {
       __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~Managed", e);

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -302,37 +302,6 @@ void GlobalHandler::drainThreadPool() {
     MHostTaskThreadPool.Inst->drain();
 }
 
-#if defined(_WIN32)
-bool GlobalHandler::winEarlyExitCheck(bool ProcessExiting = true) {
-  // In Windows ExitProcess all non host threads are forcibly terminated prior
-  // to DLL_PROCESS_DETACH. However, backend or XPTI calls may rely on these
-  // threads being active. In such cases, making XPTI or backend calls at
-  // DLL_PROCESS_DETACH can lead to hangs or memory corruption. Because of this
-  // it is best to not unload the backend after thread destruction.
-#if defined(XPTI_ENABLE_INSTRUMENTATION)
-  if (xptiTraceEnabled())
-    return true;
-#endif
-  if (ProcessExiting) {
-    // Level zero relies on unloading cleanup for UR_L0_LEAKS_DEBUG
-    // functionality on Windows so don't exit early for L0 platforms.
-    if (auto PlatformCache =
-            GlobalHandler::RTGlobalObjHandler->getPlatformCache();
-        !std::any_of(PlatformCache.begin(), PlatformCache.end(),
-                     [](const std::shared_ptr<platform_impl> &p) {
-                       return p->getBackend() == backend::ext_oneapi_level_zero;
-                     })) {
-
-      // If spawned threads using the Windows CRT are forcibly killed, this
-      // can prevent stdout buffer being flushed at the program end.
-      std::fflush(stdout);
-      return true;
-    }
-  }
-  return false;
-}
-#endif
-
 // Note: this function can be called on Windows twice:
 //  1) when library is unloaded via FreeLibrary
 //  2) when process is being terminated
@@ -341,13 +310,14 @@ void shutdown_early(bool CanJoinThreads = true) {
   if (!GlobalHandler::RTGlobalObjHandler)
     return;
 
+#if defined(XPTI_ENABLE_INSTRUMENTATION) && defined(_WIN32)
+  if (xptiTraceEnabled())
+    return; // When doing xpti tracing, we can't safely shutdown on Win.
+            // TODO: figure out why XPTI prevents release.
+#endif
+
   // Now that we are shutting down, we will no longer defer MemObj releases.
   GlobalHandler::RTGlobalObjHandler->endDeferredRelease();
-
-#ifdef _WIN32
-  if (GlobalHandler::winEarlyExitCheck(CanJoinThreads))
-    return;
-#endif
 
   // Ensure neither host task is working so that no default context is accessed
   // upon its release
@@ -394,9 +364,10 @@ void shutdown_late() {
   if (!GlobalHandler::RTGlobalObjHandler)
     return;
 
-#ifdef _WIN32
-  if (GlobalHandler::winEarlyExitCheck())
-    return;
+#if defined(XPTI_ENABLE_INSTRUMENTATION) && defined(_WIN32)
+  if (xptiTraceEnabled())
+    return; // When doing xpti tracing, we can't safely shutdown on Win.
+            // TODO: figure out why XPTI prevents release.
 #endif
 
   // First, release resources, that may access adapters.

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -116,10 +116,6 @@ private:
     SpinLock Lock;
   };
 
-#ifdef _WIN32
-  static bool winEarlyExitCheck(bool);
-#endif
-
   template <typename T, typename... Types>
   T &getOrCreate(InstWithLock<T> &IWL, Types &&...Args);
 

--- a/sycl/test-e2e/Adapters/adapter-release.cpp
+++ b/sycl/test-e2e/Adapters/adapter-release.cpp
@@ -1,8 +1,3 @@
-// UNSUPPORTED: windows && (opencl || cuda)
-// UNSUPPORTED-INTENDED: Only L0 does adapter release on Windows. Windows
-// recommends not doing cleanup at unloading, however L0 still requires this in
-// order to enable UR_L0_LEAKS_DEBUG on Windows.
-
 // ensure that urAdapterRelease is called
 
 // RUN: env SYCL_UR_TRACE=2 %{run-unfiltered-devices} sycl-ls 2>&1| FileCheck %s

--- a/sycl/test-e2e/Adapters/dll-detach-order.cpp
+++ b/sycl/test-e2e/Adapters/dll-detach-order.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: windows && level_zero
+// REQUIRES: windows
 // RUN: env SYCL_UR_TRACE=-1 %{run-unfiltered-devices} sycl-ls 2>&1 | FileCheck %s
 
 // ensure that the adapters are detached AFTER urLoaderTearDown is done


### PR DESCRIPTION
This reverts commit e1e4bc8dae81d030eaadbfd5c6cfd83b9785e483.

Causing failures in Windows unit tests.
