### PR TITLE
[SYCL] Give free function kernel entry points vague linkage

### DIFF
--- a/clang/lib/CodeGen/CodeGenSYCL.cpp
+++ b/clang/lib/CodeGen/CodeGenSYCL.cpp
@@ -69,8 +69,19 @@ void CodeGenModule::EmitSYCLKernelCaller(const FunctionDecl *KernelEntryPointFn,
   CanQualType KernelNameType =
       Ctx.getCanonicalType(KernelEntryPointAttr->getKernelName());
   const SYCLKernelInfo &KernelInfo = Ctx.getSYCLKernelInfo(KernelNameType);
-  auto *Fn = llvm::Function::Create(FnTy, llvm::Function::ExternalLinkage,
-                                    KernelInfo.GetKernelName(), &getModule());
+
+  // The entry point inherits the linkage of the free function it wraps. A
+  // template instantiation or inline function has ODR linkage and may be
+  // emitted in multiple translation units, so the entry point must be
+  // mergeable. Use weak_odr, not linkonce_odr: the entry point is referenced
+  // only externally (via the offload entry table) and must not be discarded.
+  GVALinkage GVAL = Ctx.GetGVALinkageForFunction(KernelEntryPointFn);
+  llvm::GlobalValue::LinkageTypes Linkage =
+      (GVAL == GVA_DiscardableODR || GVAL == GVA_StrongODR)
+          ? llvm::GlobalValue::WeakODRLinkage
+          : llvm::GlobalValue::ExternalLinkage;
+  auto *Fn = llvm::Function::Create(FnTy, Linkage, KernelInfo.GetKernelName(),
+                                    &getModule());
 
   // Emit the SYCL kernel caller function.
   CodeGenFunction CGF(*this);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5612,7 +5612,15 @@ void SemaSYCL::constructFreeFunctionKernel(FunctionDecl *FD,
 
   SyclKernelArgsSizeChecker argsSizeChecker(*this, FD->getLocation(),
                                             false /*IsSIMDKernel*/);
-  SyclKernelDeclCreator kernel_decl(*this, FD->getLocation(), FD->isInlined(),
+  // A free function that is a template instantiation (or is declared inline)
+  // has vague linkage and may be emitted in multiple translation units. The
+  // generated kernel must have vague linkage too so the copies merge at device
+  // link time instead of colliding. Mark it implicitly inline in that case so
+  // it inherits the linkage of the free function it wraps.
+  GVALinkage GVAL = getASTContext().GetGVALinkageForFunction(FD);
+  bool IsInline =
+      FD->isInlined() || GVAL == GVA_DiscardableODR || GVAL == GVA_StrongODR;
+  SyclKernelDeclCreator kernel_decl(*this, FD->getLocation(), IsInline,
                                     false /*IsSIMDKernel */, FD);
 
   FreeFunctionKernelBodyCreator kernel_body(*this, kernel_decl, FD);

--- a/clang/test/CodeGenSYCL/free-function-kernel-linkage.cpp
+++ b/clang/test/CodeGenSYCL/free-function-kernel-linkage.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -internal-isystem %S/Inputs -fsycl-is-device \
+// RUN:   -triple spir64-unknown-unknown -sycl-std=2020 -emit-llvm %s -o - \
+// RUN:   | FileCheck %s
+
+// A free function kernel that is a function template instantiation has vague
+// linkage and may be instantiated with the same arguments in more than one
+// translation unit. The generated __sycl_kernel_ entry point must therefore
+// have vague (weak_odr) linkage so the copies merge at device link time
+// instead of colliding with "symbol multiply defined". A non-template free
+// function kernel keeps strong external linkage.
+
+namespace ns {
+
+template <typename T>
+[[__sycl_detail__::add_ir_attributes_function("sycl-nd-range-kernel", 1)]]
+void templated_kernel(T *p) { *p = *p + 1; }
+
+template void templated_kernel<int>(int *);
+
+[[__sycl_detail__::add_ir_attributes_function("sycl-nd-range-kernel", 1)]]
+void plain_kernel(int *p) { *p = *p + 1; }
+
+} // namespace ns
+
+// Template instantiation -> vague linkage entry point.
+// CHECK: define weak_odr spir_kernel void @{{.*}}__sycl_kernel_ns{{.*}}templated_kernel
+
+// Non-template -> strong external entry point.
+// CHECK: define dso_local spir_kernel void @{{.*}}__sycl_kernel_ns{{.*}}plain_kernel

--- a/clang/test/CodeGenSYCL/free_function_kernel_params.cpp
+++ b/clang/test/CodeGenSYCL/free_function_kernel_params.cpp
@@ -58,9 +58,9 @@ template void ff_6(KArgWithPtrArray<TestArrSize> KArg);
 // GLOB-AS: %struct.__generated_KArgWithPtrArray = type { [3 x ptr addrspace(1)], [3 x i32], [3 x i32] }
 // GLOB-AS: %struct.KArgWithPtrArray = type { [3 x ptr addrspace(4)], [3 x i32], [3 x i32] }
 // GLOB-AS: define dso_local spir_kernel void @{{.*}}__sycl_kernel{{.*}}(ptr noundef byval(%struct.NoPointers) align 4 %__arg_S1, ptr noundef byval(%struct.__generated_Pointers) align 8 %__arg_S2, ptr noundef byval(%struct.__generated_Agg) align 8 %__arg_S3)
-// GLOB-AS: define dso_local spir_kernel void @{{.*}}__sycl_kernel_ff_6{{.*}}(ptr noundef byval(%struct.__generated_KArgWithPtrArray) align 8 %__arg_KArg)
+// GLOB-AS: define weak_odr spir_kernel void @{{.*}}__sycl_kernel_ff_6{{.*}}(ptr noundef byval(%struct.__generated_KArgWithPtrArray) align 8 %__arg_KArg)
 // GEN-AS: define dso_local spir_kernel void @{{.*}}__sycl_kernel{{.*}}(ptr noundef byval(%struct.NoPointers) align 4 %__arg_S1, ptr noundef byval(%struct.Pointers) align 8 %__arg_S2, ptr noundef byval(%struct.Agg) align 8 %__arg_S3)
-// GEN-AS: define dso_local spir_kernel void @{{.*}}__sycl_kernel_ff_6{{.*}}(ptr noundef byval(%struct.KArgWithPtrArray) align 8 %__arg_KArg)
+// GEN-AS: define weak_odr spir_kernel void @{{.*}}__sycl_kernel_ff_6{{.*}}(ptr noundef byval(%struct.KArgWithPtrArray) align 8 %__arg_KArg)
 
 __attribute__((sycl_device))
 [[__sycl_detail__::add_ir_attributes_function("sycl-nd-range-kernel", 0)]]
@@ -98,7 +98,7 @@ void ff_8(sycl::local_accessor<DataT, 1> lacc) {
 
 template void ff_8(sycl::local_accessor<float, 1> lacc);
 
-// CHECK: define dso_local spir_kernel void @{{.*}}__sycl_kernel_ff_8{{.*}}(ptr addrspace(3) noundef align 4 %__arg_Ptr, ptr noundef byval(%"struct.sycl::_V1::range") align 4 %__arg_AccessRange, ptr noundef byval(%"struct.sycl::_V1::range") align 4 %__arg_MemRange, ptr noundef byval(%"struct.sycl::_V1::id") align 4 %__arg_Offset)
+// CHECK: define weak_odr spir_kernel void @{{.*}}__sycl_kernel_ff_8{{.*}}(ptr addrspace(3) noundef align 4 %__arg_Ptr, ptr noundef byval(%"struct.sycl::_V1::range") align 4 %__arg_AccessRange, ptr noundef byval(%"struct.sycl::_V1::range") align 4 %__arg_MemRange, ptr noundef byval(%"struct.sycl::_V1::id") align 4 %__arg_Offset)
 // CHECK:  %__arg_Ptr.addr = alloca ptr addrspace(3), align 8
   // CHECK-NEXT: %lacc = alloca %"class.sycl::_V1::local_accessor", align 4
   // CHECK-NEXT: %agg.tmp = alloca %"struct.sycl::_V1::range", align 4

--- a/clang/test/CodeGenSYCL/kernel-entry-point-linkage.cpp
+++ b/clang/test/CodeGenSYCL/kernel-entry-point-linkage.cpp
@@ -1,0 +1,44 @@
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -emit-llvm \
+// RUN:   -std=c++17 %s -o - | FileCheck %s
+
+// Verify the linkage of SYCL kernel caller entry points (CMPLRLLVM-78181).
+// A kernel entry point synthesized from a function template instantiation (or
+// an inline free function) must be emitted with vague (weak_odr) linkage so
+// that the same instantiation in multiple translation units merges instead of
+// colliding at device link time. A non-template, non-inline kernel keeps
+// strong external linkage.
+
+template <typename KernelName, typename... Ts>
+void sycl_kernel_launch(const char *, Ts...) {}
+
+template <typename KernelName, typename KernelType>
+[[clang::sycl_kernel_entry_point(KernelName)]]
+void kernel_single_task(KernelType kernelFunc) {
+  kernelFunc();
+}
+
+struct TemplatedKernelName;
+struct ExplicitKernelName;
+struct NonTemplateKernelName;
+
+struct Functor {
+  void operator()() const {}
+};
+
+// Implicit instantiation of the entry-point template -> weak_odr.
+void trigger_implicit() {
+  kernel_single_task<TemplatedKernelName>(Functor{});
+}
+
+// Explicit instantiation of the entry-point template -> weak_odr.
+template void kernel_single_task<ExplicitKernelName, Functor>(Functor);
+
+// Non-template kernel entry point -> strong external.
+[[clang::sycl_kernel_entry_point(NonTemplateKernelName)]]
+void non_template_kernel(Functor kernelFunc) {
+  kernelFunc();
+}
+
+// CHECK-DAG: define weak_odr {{.*}}spir_kernel void @{{.*}}TemplatedKernelName
+// CHECK-DAG: define weak_odr {{.*}}spir_kernel void @{{.*}}ExplicitKernelName
+// CHECK-DAG: define {{(dso_local )?}}spir_kernel void @{{.*}}NonTemplateKernelName

--- a/clang/test/CodeGenSYCL/unnamed-types.cpp
+++ b/clang/test/CodeGenSYCL/unnamed-types.cpp
@@ -53,10 +53,10 @@ void g() {
 // DEVICE: define spir_kernel void @_ZTSN2QL3dg2MUlvE_E
 // DEVICE: call spir_func noundef i32 @_ZNK2QL3dg2MUlvE_clEv
 // DEVICE: define internal spir_func noundef i32 @_ZNK2QL3dg2MUlvE_clEv
-// DEVICE: define spir_kernel void @_ZTSN2QL10dg_inline1MUlvE_E
+// DEVICE: define weak_odr spir_kernel void @_ZTSN2QL10dg_inline1MUlvE_E
 // DEVICE: call spir_func noundef i32 @_ZNK2QL10dg_inline1MUlvE_clEv
 // DEVICE: define linkonce_odr spir_func noundef i32 @_ZNK2QL10dg_inline1MUlvE_clEv
-// DEVICE: define spir_kernel void @_ZTSN2QL11dg_templateILi3EEMUlvE_E
+// DEVICE: define weak_odr spir_kernel void @_ZTSN2QL11dg_templateILi3EEMUlvE_E
 // DEVICE: call spir_func noundef i32 @_ZNK2QL11dg_templateILi3EEMUlvE_clEv
 // DEVICE: define linkonce_odr spir_func noundef i32 @_ZNK2QL11dg_templateILi3EEMUlvE_clEv
 
@@ -76,9 +76,9 @@ void g() {
 // MSVC: define dso_local spir_kernel void @_ZTSN2QL3dg2MUlvE_E
 // MSVC: call spir_func noundef i32 @_ZNK2QL3dg2MUlvE_clEv
 // MSVC: define internal spir_func noundef i32 @_ZNK2QL3dg2MUlvE_clEv
-// MSVC: define dso_local spir_kernel void @_ZTSN2QL10dg_inline1MUlvE_E
+// MSVC: define weak_odr spir_kernel void @_ZTSN2QL10dg_inline1MUlvE_E
 // MSVC: call spir_func noundef i32 @_ZNK2QL10dg_inline1MUlvE_clEv
 // MSVC: define linkonce_odr spir_func noundef i32 @_ZNK2QL10dg_inline1MUlvE_clEv
-// MSVC: define dso_local spir_kernel void @_ZTSN2QL11dg_templateILi3EEMUlvE_E
+// MSVC: define weak_odr spir_kernel void @_ZTSN2QL11dg_templateILi3EEMUlvE_E
 // MSVC: call spir_func noundef i32 @_ZNK2QL11dg_templateILi3EEMUlvE_clEv
 // MSVC: define linkonce_odr spir_func noundef i32 @_ZNK2QL11dg_templateILi3EEMUlvE_clEv


### PR DESCRIPTION
A free function kernel that is a function template instantiation (or is declared inline) has vague linkage and may be instantiated with the same template arguments in more than one translation unit. The generated `__sycl_kernel_` entry point, however, was emitted with strong external linkage, so device linking failed with "symbol multiply defined". Users had to add `inline` to the kernel as a workaround.

Emit the entry point with vague linkage that mirrors the free function it wraps, in both code generation paths: