### PR TITLE
[file-table-tform] Don't explicitly close output stream

### DIFF
--- a/llvm/test/tools/file-table-tform/Inputs/stdout-gold.txt
+++ b/llvm/test/tools/file-table-tform/Inputs/stdout-gold.txt
@@ -1,0 +1,3 @@
+[A|C|D]
+aaa|100|XXX
+ccc|200|YYY

--- a/llvm/test/tools/file-table-tform/file-table-tform-stdout.test
+++ b/llvm/test/tools/file-table-tform/file-table-tform-stdout.test
@@ -1,0 +1,2 @@
+-- Test that Test that stdout (-o -) writing does not close the underlying fd.
+RUN: file-table-tform --extract=A,C,D %S/Inputs/a.txt -o - | diff - %S/Inputs/stdout-gold.txt

--- a/llvm/tools/file-table-tform/file-table-tform.cpp
+++ b/llvm/tools/file-table-tform/file-table-tform.cpp
@@ -356,7 +356,6 @@ struct TformCmd {
 
               if (Out.has_error())
                 return createFileError(Output, Out.error());
-              Out.close();
               return Error::success();
             });
     return F(this);
@@ -471,7 +470,6 @@ int main(int argc, char **argv) {
 
     if (Out.has_error())
       CHECK_AND_EXIT(createFileError(Output, Out.error()));
-    Out.close();
   }
   return 0;
 }


### PR DESCRIPTION
raw_fd_ostream never closes the underlying fd for stdout/stderr. file-table-tform called Out.close() unconditionally after writing, which asserts "ShouldClose" whenever the output is "-o -". Drop the explicit close() calls; the raw_fd_ostream destructor already flushes and closes real files via RAII.