### PR TITLE
[SYCL][E2E] Use driver -emit-llvm flag in fp8/x2_alignment_codegen.cpp

### DIFF
--- a/sycl/test-e2e/Experimental/fp8/x2_alignment_codegen.cpp
+++ b/sycl/test-e2e/Experimental/fp8/x2_alignment_codegen.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-only -DNDEBUG -S -Xclang -emit-llvm %s -o - | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-device-only -DNDEBUG -S -emit-llvm %s -o - | FileCheck %s
 
 // UNSUPPORTED: target-nvidia, target-amd
 // UNSUPPORTED-INTENDED: relies on SPIR-V FP8 conversion builtins


### PR DESCRIPTION
`-Xclang -emit-llvm` is cc1 frontend flag and is ignored in this test. This issue is hidden downstream due to downstream SPIR-V customization.