### PR TITLE
[SYCL][E2E] Add missing REQUIRES: sg-* to FreeFunctionKernels/properties.cpp,enqueue_functions_sub_group_size.cpp

### DIFF
--- a/sycl/test-e2e/FreeFunctionKernels/enqueue_functions_sub_group_size.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/enqueue_functions_sub_group_size.cpp
@@ -71,6 +71,5 @@ int main() {
   sycl::queue q;
   int Ret = 0;
   Ret |= test<32>(q);
-  Ret |= test<32>(q);
   return Ret;
 }

--- a/sycl/test-e2e/FreeFunctionKernels/enqueue_functions_sub_group_size.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/enqueue_functions_sub_group_size.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: aspect-usm_shared_allocations
 // REQUIRES: sg-32
-// UNSUPPORTED: cuda, hip
+// UNSUPPORTED: hip
 // UNSUPPORTED-INTENDED: Device incompatible error
 
 // UNSUPPORTED: native_cpu

--- a/sycl/test-e2e/FreeFunctionKernels/enqueue_functions_sub_group_size.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/enqueue_functions_sub_group_size.cpp
@@ -69,7 +69,5 @@ template <int SIMD> int test(sycl::queue &q) {
 
 int main() {
   sycl::queue q;
-  int Ret = 0;
-  Ret |= test<32>(q);
-  return Ret;
+  return test<32>(q);
 }

--- a/sycl/test-e2e/FreeFunctionKernels/enqueue_functions_sub_group_size.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/enqueue_functions_sub_group_size.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
+// REQUIRES: sg-32
 // UNSUPPORTED: cuda, hip
 // UNSUPPORTED-INTENDED: Device incompatible error
 
@@ -69,7 +70,7 @@ template <int SIMD> int test(sycl::queue &q) {
 int main() {
   sycl::queue q;
   int Ret = 0;
-  Ret |= test<16>(q);
+  Ret |= test<32>(q);
   Ret |= test<32>(q);
   return Ret;
 }

--- a/sycl/test-e2e/FreeFunctionKernels/properties.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/properties.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
+// REQUIRES: sg-32
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -19,8 +20,8 @@ namespace syclext = sycl::ext::oneapi;
 namespace syclexp = sycl::ext::oneapi::experimental;
 
 static constexpr size_t NUM = 1024;
-static constexpr size_t WGSIZE = 32;
-static constexpr size_t SGSIZE = 16;
+static constexpr size_t WGSIZE = 64;
+static constexpr size_t SGSIZE = 32;
 
 inline void kernel_code(float start, float *ptr) {
   size_t id = syclext::this_work_item::get_nd_item<1>().get_global_linear_id();

--- a/sycl/test-e2e/FreeFunctionKernels/properties.cpp
+++ b/sycl/test-e2e/FreeFunctionKernels/properties.cpp
@@ -3,7 +3,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: cuda, hip
+// UNSUPPORTED: hip
 // UNSUPPORTED-INTENDED: Device incompatible error
 
 // XFAIL: target-native_cpu


### PR DESCRIPTION
`sub_group_size<SGSIZE>` is a compile-time kernel property that the
compiler lowers directly into a required-sub-group-size kernel attribute.
This means the tests require target device to support the `SGSIZE`.

Also change subgroup size to 32, which is minimum value for most GPUs.
Tests now pass on CUDA.