### PR TITLE
[SYCL][ESIMD] Fix leak of the demangler output buffer in `ESIMDRemoveHostCode`

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDRemoveHostCode.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDRemoveHostCode.cpp
@@ -22,6 +22,8 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/TargetParser/Triple.h"
 
+#include <cstdlib>
+
 using namespace llvm;
 using namespace llvm::esimd;
 namespace id = itanium_demangle;
@@ -47,11 +49,16 @@ PreservedAnalyses ESIMDRemoveHostCodePass::run(Module &M,
     if (!NameNode)
       continue;
 
+    // OutputBuffer does not own its buffer - it must be freed by the caller.
+    // Name points into that buffer, so the checks must happen before the free.
     id::OutputBuffer NameBuf;
     NameNode->print(NameBuf);
     StringRef Name(NameBuf.getBuffer(), NameBuf.getCurrentPosition());
-    if (!Name.starts_with("sycl::_V1::ext::intel::esimd::") &&
-        !Name.starts_with("sycl::_V1::ext::intel::experimental::esimd::"))
+    bool IsESIMDFunction =
+        Name.starts_with("sycl::_V1::ext::intel::esimd::") ||
+        Name.starts_with("sycl::_V1::ext::intel::experimental::esimd::");
+    std::free(NameBuf.getBuffer());
+    if (!IsESIMDFunction)
       continue;
     SmallVector<BasicBlock *> BBV;
     for (BasicBlock &BB : F) {


### PR DESCRIPTION
i.e. one ~1 KB leak for each function whose name the pass demangled.

### Sanitizer report

```
==583075==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 3984 byte(s) in 4 object(s) allocated from:
    #0 realloc
    #1 llvm::itanium_demangle::OutputBuffer::grow(unsigned long)
         llvm/include/llvm/Demangle/Utility.h:50:36
    #2 llvm::itanium_demangle::OutputBuffer::operator+=(std::string_view)
         llvm/include/llvm/Demangle/Utility.h:138:7
    #3 llvm::itanium_demangle::NameType::printLeft(OutputBuffer&) const
         llvm/include/llvm/Demangle/ItaniumDemangle.h:522:56
    #4 llvm::itanium_demangle::OutputBuffer::printLeft(Node const&)
         llvm/include/llvm/Demangle/ItaniumDemangle.h:6273:56
    #5 llvm::itanium_demangle::Node::print(OutputBuffer&) const
         llvm/include/llvm/Demangle/ItaniumDemangle.h:287:8
    ... (NestedName::printLeft / OutputBuffer::printLeft / Node::print recursion) ...
   #24 llvm::itanium_demangle::NameWithTemplateArgs::printLeft(OutputBuffer&) const
         llvm/include/llvm/Demangle/ItaniumDemangle.h:1682:11
   #27 isESIMDFunctionUnfixed(char const*)      <- ESIMDRemoveHostCode.cpp:51 equivalent
   #28 main

SUMMARY: AddressSanitizer: 3984 byte(s) leaked in 4 allocation(s).
```

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>