### PR TITLE
[SYCL] Don't offset a null parent allocation for a host sub-buffer

### DIFF
--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -417,8 +417,12 @@ void *MemoryManager::allocateMemSubBuffer(context_impl *TargetContext,
   waitForEvents(DepEvents);
   OutEvent = nullptr;
 
+  // A host allocation linked to a device one has no pointer of its own until
+  // it is mapped, so the parent can legitimately be null here and offsetting
+  // it would be UB. Null is a safe result: AllocaSubBufCommand recomputes the
+  // sub-buffer pointer from the parent on every getMemAllocation() query.
   if (!TargetContext)
-    return static_cast<void *>(static_cast<char *>(ParentMemObj) + Offset);
+    return ParentMemObj ? static_cast<char *>(ParentMemObj) + Offset : nullptr;
 
   size_t SizeInBytes = ElemSize;
   for (size_t I = 0; I < 3; ++I)


### PR DESCRIPTION
`MemoryManager::allocateMemSubBuffer()` short-circuits the host case with

```cpp
if (!TargetContext)
  return static_cast<void *>(static_cast<char *>(ParentMemObj) + Offset);
```

`ParentMemObj` is the host allocation of the parent buffer, and it can legitimately be **null** at
that point, which makes the pointer arithmetic undefined behavior.

#### Why the parent is null

When a buffer whose data currently lives on a device is accessed on the host, and the device context
reports host unified memory (or the buffer was created with
`ext::oneapi::property::buffer::use_pinned_host_memory`), the graph builder *links* the new host
alloca to the existing device alloca (`graph_builder.cpp`). A linked host alloca is not the leader
(`MIsLeaderAlloca(nullptr == LinkedAllocaCmd)`), so `AllocaCommand::enqueueImp()` deliberately
performs no allocation at all — and leaves `MMemAllocation` null.

#### How it was found

An ASan+UBSan (`-DLLVM_USE_SANITIZER="Address;Undefined"`) build of the SYCL runtime, running the
`sycl/test-e2e/Basic` suite:

```
memory_manager.cpp:421: runtime error: applying non-zero offset to null pointer
```
---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>