### PR TITLE
[UR][OpenCL] Release the program reference internally created by `makeWithNative`

### DIFF
--- a/unified-runtime/source/adapters/opencl/kernel.cpp
+++ b/unified-runtime/source/adapters/opencl/kernel.cpp
@@ -38,6 +38,11 @@ ur_result_t ur_kernel_handle_t_::makeWithNative(native_type NativeKernel,
     if (Context->CLContext != CLContext) {
       return UR_RESULT_ERROR_INVALID_CONTEXT;
     }
+    // Only set when this function creates the program wrapper itself, in
+    // which case it owns the reference returned by
+    // urProgramCreateWithNativeHandle. A program supplied by the caller stays
+    // owned by the caller.
+    ur_program_handle_t OwnedProgram = nullptr;
     if (Program) {
       if (Program->CLProgram != CLProgram) {
         return UR_RESULT_ERROR_INVALID_PROGRAM;
@@ -49,11 +54,18 @@ ur_result_t ur_kernel_handle_t_::makeWithNative(native_type NativeKernel,
       UR_RETURN_ON_FAILURE(ur::opencl::urProgramCreateWithNativeHandle(
           hNativeHandle, cast(Context), nullptr, &hProgram));
       Program = cast(hProgram);
+      OwnedProgram = hProgram;
     }
 
     auto URKernel =
         std::make_unique<ur_kernel_handle_t_>(NativeKernel, Program, Context);
     Kernel = URKernel.release();
+    // The kernel constructor took its own reference on the program, so drop
+    // the one created above; otherwise the program, and the context it keeps
+    // alive, outlive the kernel forever.
+    if (OwnedProgram) {
+      UR_RETURN_ON_FAILURE(ur::opencl::urProgramRelease(OwnedProgram));
+    }
   } catch (std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_RESOURCES;
   } catch (...) {


### PR DESCRIPTION
`urProgramCreateWithNativeHandle` returns an *owned* reference (a fresh
`ur_program_handle_t_` with a refcount of 1), and `ur_kernel_handle_t_`'s
constructor then takes a reference of its own via `urProgramRetain`. The
destructor only ever drops one of the two, so the program wrapper — and the
context reference it holds — is leaked for the lifetime of the process.

The fix releases the reference `makeWithNative` owns once the kernel has taken
its own, and only on the branch where `makeWithNative` created the program: a
program supplied by the caller is left untouched.

### Sanitizer report

LeakSanitizer on `opencl:cpu`, same executable run against the pre-fix library, via the existing E2E test `Adapters/interop-opencl-make-kernel.cpp`:

```
==583441==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 operator new(unsigned long)
    #1 ur::opencl::urProgramCreateWithNativeHandle(unsigned long, ur_context_handle_t_*, ...)
    #2 ur::opencl::urKernelCreateWithNativeHandle(unsigned long, ur_context_handle_t_*, ur_program_handle_t_*, ...)
    #3 urKernelCreateWithNativeHandle
    #4 sycl::_V1::detail::make_kernel(sycl::_V1::context const&, ...)
    #5 sycl::_V1::make_kernel<(sycl::_V1::backend)1>(...) sycl/backend.hpp:396:10
    #6 main a3-repro.cpp:30:22

Indirect leak of 56 byte(s) in 1 object(s) allocated from:
    #1 ur::opencl::urContextCreate(...)
...
SUMMARY: AddressSanitizer: 136 byte(s) leaked in 4 allocation(s).
```

Zero leaks with the fix.

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>