### PR TITLE
[UR][L0] Free the active-barrier wait list when all barrier events have completed

### DIFF
--- a/unified-runtime/source/adapters/level_zero/queue.cpp
+++ b/unified-runtime/source/adapters/level_zero/queue.cpp
@@ -2440,6 +2440,14 @@ ur_result_t ur::level_zero::v1::ur_queue_handle_t_::insertActiveBarriers(
   UR_CALL(ActiveBarriers.clear());
 
   if (ActiveBarriersWaitList.Length == 0) {
+    // createAndRetainUrZeEventList allocates the event arrays up front and can
+    // still end up with a zero length if every barrier event had already
+    // completed. Nothing takes ownership of the list on this path, so free it
+    // here instead of leaking it; there are no retained events to collect.
+    std::list<ur_event_handle_t> EventsToBeReleased;
+    UR_CALL(
+        ActiveBarriersWaitList.collectEventsForReleaseAndDestroyUrZeEventList(
+            EventsToBeReleased));
     return UR_RESULT_SUCCESS;
   }
 


### PR DESCRIPTION
`ur_queue_handle_t_::insertActiveBarriers()` builds a `ur_ze_event_list_t` from the
queue's active barriers and then, if the resulting length is zero, returns early:
```
    if (ActiveBarriersWaitList.Length == 0) {
      return UR_RESULT_SUCCESS;
    }
```
`createAndRetainUrZeEventList()` allocates its `ZeEventList` and `UrEventList` arrays up
front, before filtering, so a zero length does not mean nothing was allocated - it
means every barrier event had already completed by the time the list was built.
`ur_ze_event_list_t` has no destructor, and the only thing that frees those arrays is
the ownership transfer further down the function, which this early return skips.
So both arrays leak, every time.

Found by LeakSanitizer on level_zero:gpu. 

### Reproduction

```cpp
#include <sycl/detail/core.hpp>
#include <vector>

int main() {
  sycl::queue Q;
  std::vector<int> Data(1024, 0);
  sycl::buffer<int> Buf(Data.data(), sycl::range<1>(1024));
  Q.submit([&](sycl::handler &CGH) {
    auto Acc = Buf.get_access<sycl::access_mode::write>(CGH);
    CGH.parallel_for(sycl::range<1>(1024), [=](sycl::id<1> I) { Acc[I] = 5; });
  });
  Q.ext_oneapi_submit_barrier().wait();
  auto HostAcc = Buf.get_host_access();
  return HostAcc[0] == 5 ? 0 : 1;
}
```

The `.wait()` is what makes it fire: the barrier event is complete by the time the host-accessor
read-back asks for a command list, so the wait list comes back with `Length == 0`.

---

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>