### PR TITLE
[SYCL][Graph] Reset node visited marks when the allocation reuse search fails

### DIFF
--- a/sycl/source/detail/graph/memory_pool.cpp
+++ b/sycl/source/detail/graph/memory_pool.cpp
@@ -170,6 +170,13 @@ graph_mem_pool::tryReuseExistingAllocation(size_t Size, usm::alloc AllocType,
     NodesToCheck.pop();
   }
 
+  // No reusable allocation was found. The traversal above marked every node it
+  // visited, and sortTopological() requires MTotalVisitedEdges to be zero on
+  // all nodes, so the marks have to be cleared on this path as well as on the
+  // success path above. Leaving them set corrupts the next cycle check and the
+  // next reuse search.
+  MGraph.resetNodeVisitedEdges();
+
   return std::nullopt;
 }
 


### PR DESCRIPTION
`graph_mem_pool::tryReuseExistingAllocation()` walks the modifiable graph backwards
looking for the `async_free` node of an allocation it can recycle, and borrows
`node_impl::MTotalVisitedEdges` as its visited flag. It calls
`MGraph.resetNodeVisitedEdges()` only on the success path. On the failure path - no
reusable allocation reachable, which is the common case - every node the traversal
touched is left with `MTotalVisitedEdges` == 1.

Two user-visible symptoms:

- make_edge() on a plainly acyclic pair of nodes throws
  "Command graphs cannot contain cycles." make_edge is the one API that re-traverses
  the modifiable graph (makeEdge -> checkForCycles -> sortTopological), and it sees
  the stale marks.
- Allocation reuse silently stops working after one failed search

